### PR TITLE
fix: remove invalid 'use server' from estimator page

### DIFF
--- a/app/dashboard/estimator/page.tsx
+++ b/app/dashboard/estimator/page.tsx
@@ -1,5 +1,3 @@
-"use server"
-
 import { getDeals } from "@/actions/deal-actions"
 import { EstimatorForm } from "@/components/tradie/estimator-form"
 


### PR DESCRIPTION
Page components can't have 'use server' — that directive only allows async function exports, which conflicts with export const dynamic. Pages are Server Components by default anyway.

https://claude.ai/code/session_01KWdS3djFRsEAwzekdUzEaB