### PR TITLE
fix: graceful DB error handling on all server-rendered pages

### DIFF
--- a/app/dashboard/estimator/page.tsx
+++ b/app/dashboard/estimator/page.tsx
@@ -3,26 +3,31 @@ import { EstimatorForm } from "@/components/tradie/estimator-form"
 
 export const dynamic = 'force-dynamic'
 
-// Mock Workspace ID for now - in production this comes from auth context
 const WORKSPACE_ID = "demo-workspace"
 
 export default async function EstimatorPage() {
-    // Fetch deals to populate the selector
-    // We only want active deals ideally, but getDeals returns all
-    const deals = await getDeals(WORKSPACE_ID)
+    try {
+        const deals = await getDeals(WORKSPACE_ID)
 
-    return (
-        <div className="flex-1 space-y-4 p-4 md:p-8 pt-6 max-w-2xl mx-auto">
-            <div className="flex items-center justify-between space-y-2">
-                <h2 className="text-3xl font-bold tracking-tight text-slate-900">
-                    Estimator
-                </h2>
+        return (
+            <div className="flex-1 space-y-4 p-4 md:p-8 pt-6 max-w-2xl mx-auto">
+                <div className="flex items-center justify-between space-y-2">
+                    <h2 className="text-3xl font-bold tracking-tight text-slate-900">
+                        Estimator
+                    </h2>
+                </div>
+                <p className="text-slate-500">
+                    Generate quick quotes on the go. Select a deal, add line items, and create a PDF-ready invoice.
+                </p>
+
+                <EstimatorForm deals={deals} />
             </div>
-            <p className="text-slate-500">
-                Generate quick quotes on the go. Select a deal, add line items, and create a PDF-ready invoice.
-            </p>
-
-            <EstimatorForm deals={deals} />
-        </div>
-    )
+        )
+    } catch {
+        return (
+            <div className="flex-1 flex items-center justify-center p-8">
+                <p className="text-slate-500">Database not initialized. Please push the schema first.</p>
+            </div>
+        )
+    }
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,40 +9,61 @@ import { Plus } from "lucide-react"
 export const dynamic = 'force-dynamic'
 
 export default async function DashboardPage() {
-    // In a real app, we'd get the user ID from the session
-    const workspace = await getOrCreateWorkspace("demo-user")
-    const deals = await getDeals(workspace.id)
+    try {
+        const workspace = await getOrCreateWorkspace("demo-user")
+        const deals = await getDeals(workspace.id)
 
-    return (
-        <div className="h-full flex flex-col space-y-4">
-            {/* Header */}
-            <div className="flex items-center justify-between shrink-0">
-                <div>
-                    <h1 className="text-2xl font-bold text-slate-900">Pipeline</h1>
-                    <p className="text-sm text-slate-500">Manage your deals and activity</p>
+        return (
+            <div className="h-full flex flex-col space-y-4">
+                {/* Header */}
+                <div className="flex items-center justify-between shrink-0">
+                    <div>
+                        <h1 className="text-2xl font-bold text-slate-900">Pipeline</h1>
+                        <p className="text-sm text-slate-500">Manage your deals and activity</p>
+                    </div>
+                    <Button>
+                        <Plus className="mr-2 h-4 w-4" />
+                        New Deal
+                    </Button>
                 </div>
-                <Button>
-                    <Plus className="mr-2 h-4 w-4" />
-                    New Deal
-                </Button>
+
+                {/* Health Widget */}
+                <DealHealthWidget deals={deals} />
+
+                {/* Main Content Area */}
+                <div className="flex-1 w-full flex gap-6 overflow-hidden min-h-0">
+                    {/* Left: Kanban Board */}
+                    <div className="flex-1 min-w-[300px] h-full overflow-hidden">
+                        <KanbanBoard deals={deals} />
+                    </div>
+
+                    {/* Right: Activity Feed / Widgets */}
+                    <div className="hidden xl:block w-[350px] shrink-0 h-full overflow-hidden">
+                        <ActivityFeed />
+                    </div>
+                </div>
             </div>
+        )
+    } catch {
+        return (
+            <div className="h-full flex items-center justify-center">
+                <div className="text-center max-w-md space-y-4">
+                    <h2 className="text-2xl font-bold text-slate-900">Database Not Initialized</h2>
+                    <p className="text-slate-500">
+                        The database tables have not been created yet. Run these commands with your Supabase DIRECT_URL:
+                    </p>
+                    <pre className="bg-slate-100 text-slate-800 p-4 rounded-lg text-left text-sm overflow-x-auto">
+{`DATABASE_URL="your-direct-url" \\
+  npx prisma@6 db push
 
-            {/* Health Widget */}
-            <DealHealthWidget deals={deals} />
-
-            {/* Main Content Area */}
-            <div className="flex-1 w-full flex gap-6 overflow-hidden min-h-0">
-                {/* Left: Kanban Board */}
-                <div className="flex-1 min-w-[300px] h-full overflow-hidden">
-                    <KanbanBoard deals={deals} />
-                </div>
-
-                {/* Right: Activity Feed / Widgets */}
-                <div className="hidden xl:block w-[350px] shrink-0 h-full overflow-hidden">
-                    {/* Pass workspaceId to feed so it can fetch its own data */}
-                    <ActivityFeed />
+DATABASE_URL="your-direct-url" \\
+  npx prisma@6 db seed`}
+                    </pre>
+                    <p className="text-xs text-slate-400">
+                        Use the DIRECT_URL (port 5432), not the pooler URL.
+                    </p>
                 </div>
             </div>
-        </div>
-    )
+        )
+    }
 }

--- a/app/dashboard/tradie/map/page.tsx
+++ b/app/dashboard/tradie/map/page.tsx
@@ -3,42 +3,43 @@ import { Button } from "@/components/ui/button"
 import { List, Map as MapIcon } from "lucide-react"
 import Link from "next/link"
 
-// Dynamically import Leaflet map to avoid window is not defined during build/SSR
-// const JobMap = nextDynamic(() => import("@/components/tradie/job-map"), {
-//     ssr: false,
-//     loading: () => <div className="w-full h-full bg-slate-100 flex items-center justify-center text-slate-400">Loading Map...</div>
-// })
-
 export const dynamic = 'force-dynamic'
 
 export default async function TradieMapPage() {
-    const _deals = await getDeals("demo-workspace")
+    try {
+        const _deals = await getDeals("demo-workspace")
 
-    return (
-        <div className="h-full flex flex-col p-6 gap-6">
-            <header className="flex items-center justify-between shrink-0">
-                <div>
-                    <h1 className="text-2xl font-semibold text-slate-900">Job Map</h1>
-                    <p className="text-sm text-slate-500">Visualize active jobs and plan your route.</p>
-                </div>
-                <div className="flex gap-2 bg-white p-1 rounded-lg border border-slate-200 shadow-sm">
-                    <Link href="/dashboard/tradie">
-                        <Button variant="ghost" size="sm" className="h-8 px-2 text-slate-500">
-                            <List className="w-4 h-4 mr-2" />
-                            List
+        return (
+            <div className="h-full flex flex-col p-6 gap-6">
+                <header className="flex items-center justify-between shrink-0">
+                    <div>
+                        <h1 className="text-2xl font-semibold text-slate-900">Job Map</h1>
+                        <p className="text-sm text-slate-500">Visualize active jobs and plan your route.</p>
+                    </div>
+                    <div className="flex gap-2 bg-white p-1 rounded-lg border border-slate-200 shadow-sm">
+                        <Link href="/dashboard/tradie">
+                            <Button variant="ghost" size="sm" className="h-8 px-2 text-slate-500">
+                                <List className="w-4 h-4 mr-2" />
+                                List
+                            </Button>
+                        </Link>
+                        <Button variant="secondary" size="sm" className="h-8 px-2 font-medium bg-slate-100 text-slate-900 cursor-default">
+                            <MapIcon className="w-4 h-4 mr-2" />
+                            Map
                         </Button>
-                    </Link>
-                    <Button variant="secondary" size="sm" className="h-8 px-2 font-medium bg-slate-100 text-slate-900 cursor-default">
-                        <MapIcon className="w-4 h-4 mr-2" />
-                        Map
-                    </Button>
-                </div>
-            </header>
+                    </div>
+                </header>
 
-            <div className="flex-1 min-h-0 bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden flex items-center justify-center">
-                {/* <JobMap deals={deals} /> */}
-                <p className="text-slate-400">Map unavailable during build maintenance.</p>
+                <div className="flex-1 min-h-0 bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden flex items-center justify-center">
+                    <p className="text-slate-400">Map unavailable during build maintenance.</p>
+                </div>
             </div>
-        </div>
-    )
+        )
+    } catch {
+        return (
+            <div className="h-full flex items-center justify-center">
+                <p className="text-slate-500">Database not initialized. Please push the schema first.</p>
+            </div>
+        )
+    }
 }

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -7,26 +7,32 @@ import Link from "next/link";
 export const dynamic = 'force-dynamic';
 
 export default async function InboxPage() {
-  const workspace = await getOrCreateWorkspace("demo-user");
-  const threads = await getInboxThreads(workspace.id);
+  try {
+    const workspace = await getOrCreateWorkspace("demo-user");
+    const threads = await getInboxThreads(workspace.id);
 
-  return (
-    <div className="h-screen flex flex-col bg-white">
-      {/* Header */}
-      <div className="h-16 border-b border-slate-200 flex items-center px-4 shrink-0">
-        <Link 
-          href="/dashboard" 
-          className="mr-4 p-2 rounded-full hover:bg-slate-100 text-slate-500 transition-colors"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </Link>
-        <h1 className="text-lg font-semibold text-slate-900">Inbox</h1>
-      </div>
+    return (
+      <div className="h-screen flex flex-col bg-white">
+        <div className="h-16 border-b border-slate-200 flex items-center px-4 shrink-0">
+          <Link
+            href="/dashboard"
+            className="mr-4 p-2 rounded-full hover:bg-slate-100 text-slate-500 transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-lg font-semibold text-slate-900">Inbox</h1>
+        </div>
 
-      {/* Main Content */}
-      <div className="flex-1 overflow-hidden">
-        <InboxView initialThreads={threads} />
+        <div className="flex-1 overflow-hidden">
+          <InboxView initialThreads={threads} />
+        </div>
       </div>
-    </div>
-  );
+    );
+  } catch {
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <p className="text-slate-500">Database not initialized. Please push the schema first.</p>
+      </div>
+    );
+  }
 }

--- a/app/kiosk/open-house/page.tsx
+++ b/app/kiosk/open-house/page.tsx
@@ -3,9 +3,6 @@ import { getDeals } from "@/actions/deal-actions"
 
 export const dynamic = 'force-dynamic'
 
-// In a real app, this ID would come from a query param ?dealId=...
-// or the agent would select the "Active Open House" deal from a dashboard.
-// For now, we'll try to find a relevant deal or mock it.
 const WORKSPACE_ID = "demo-workspace"
 
 interface PageProps {
@@ -13,63 +10,69 @@ interface PageProps {
 }
 
 export default async function OpenHouseKioskPage({ searchParams }: PageProps) {
-    const params = await searchParams
-    let dealId = params.dealId
-    let dealTitle = "123 Main Street"
+    try {
+        const params = await searchParams
+        let dealId = params.dealId
+        let dealTitle = "123 Main Street"
 
-    // Fallback: Grab the first available deal if none specified (for demo purposes)
-    if (!dealId) {
-        const deals = await getDeals(WORKSPACE_ID)
-        const firstDeal = deals[0]
-        if (firstDeal) {
-            dealId = firstDeal.id
-            dealTitle = firstDeal.title
+        if (!dealId) {
+            const deals = await getDeals(WORKSPACE_ID)
+            const firstDeal = deals[0]
+            if (firstDeal) {
+                dealId = firstDeal.id
+                dealTitle = firstDeal.title
+            }
         }
-    }
 
-    if (!dealId) {
+        if (!dealId) {
+            return (
+                <div className="flex items-center justify-center min-h-screen bg-slate-50">
+                    <p className="text-slate-500">No active open house found.</p>
+                </div>
+            )
+        }
+
+        return (
+            <div className="min-h-screen bg-slate-100 flex flex-col justify-center p-4 md:p-8 bg-[url('https://images.unsplash.com/photo-1560518883-ce09059eeffa?ixlib=rb-4.0.3&auto=format&fit=crop&w=2073&q=80')] bg-cover bg-center relative">
+                <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm z-0"></div>
+
+                <div className="relative z-10 w-full max-w-5xl mx-auto grid lg:grid-cols-2 gap-8 items-center">
+                    <div className="hidden lg:block text-white space-y-6">
+                        <div className="inline-flex items-center px-3 py-1 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-sm font-medium">
+                            Open House Now
+                        </div>
+                        <h1 className="text-5xl font-bold tracking-tight leading-tight">
+                            Find your<br />dream home.
+                        </h1>
+                        <p className="text-lg text-white/80 max-w-md">
+                            Sign in to get instant access to property details, floor plans, and upcoming inspection times.
+                        </p>
+
+                        <div className="pt-8 flex items-center gap-4">
+                            <div className="flex -space-x-3">
+                                {[1, 2, 3].map(i => (
+                                    <div key={i} className="w-10 h-10 rounded-full border-2 border-slate-900 bg-slate-200"></div>
+                                ))}
+                            </div>
+                            <p className="text-sm font-medium">Join 24 others interested today</p>
+                        </div>
+                    </div>
+
+                    <div className="w-full">
+                        <KioskForm dealId={dealId} dealTitle={dealTitle} />
+                    </div>
+                </div>
+
+                <div className="absolute bottom-6 left-6 text-white/40 text-xs z-10">
+                    Powered by Pj Buddy
+                </div>
+            </div>
+        )
+    } catch {
         return (
             <div className="flex items-center justify-center min-h-screen bg-slate-50">
-                <p className="text-slate-500">No active open house found.</p>
+                <p className="text-slate-500">Database not initialized. Please push the schema first.</p>
             </div>
         )
     }
-
-    return (
-        <div className="min-h-screen bg-slate-100 flex flex-col justify-center p-4 md:p-8 bg-[url('https://images.unsplash.com/photo-1560518883-ce09059eeffa?ixlib=rb-4.0.3&auto=format&fit=crop&w=2073&q=80')] bg-cover bg-center relative">
-            {/* Overlay */}
-            <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm z-0"></div>
-
-            <div className="relative z-10 w-full max-w-5xl mx-auto grid lg:grid-cols-2 gap-8 items-center">
-                <div className="hidden lg:block text-white space-y-6">
-                    <div className="inline-flex items-center px-3 py-1 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-sm font-medium">
-                        Open House Now
-                    </div>
-                    <h1 className="text-5xl font-bold tracking-tight leading-tight">
-                        Find your<br />dream home.
-                    </h1>
-                    <p className="text-lg text-white/80 max-w-md">
-                        Sign in to get instant access to property details, floor plans, and upcoming inspection times.
-                    </p>
-
-                    <div className="pt-8 flex items-center gap-4">
-                        <div className="flex -space-x-3">
-                            {[1, 2, 3].map(i => (
-                                <div key={i} className="w-10 h-10 rounded-full border-2 border-slate-900 bg-slate-200"></div>
-                            ))}
-                        </div>
-                        <p className="text-sm font-medium">Join 24 others interested today</p>
-                    </div>
-                </div>
-
-                <div className="w-full">
-                    <KioskForm dealId={dealId} dealTitle={dealTitle} />
-                </div>
-            </div>
-
-            <div className="absolute bottom-6 left-6 text-white/40 text-xs z-10">
-                Powered by Pj Buddy
-            </div>
-        </div>
-    )
 }

--- a/project_status_log.md
+++ b/project_status_log.md
@@ -76,6 +76,17 @@ The Frontend (Antigravity) has built the **Visual Shell** for the Core CRM. We a
 
 ## Change Log
 
+### 2026-02-06 [Backend - Claude Code] - Vercel Deployment
+**Fix**: Production deployment to Vercel
+*   **URL**: https://assistantbot-zeta.vercel.app
+*   **Schema**: Switched Prisma from SQLite to PostgreSQL for Vercel/Supabase compatibility.
+*   **Build**: Added `prisma generate` to build script and `postinstall` hook so Prisma client regenerates on each Vercel deploy.
+*   **Dynamic pages**: Marked all DB-dependent pages (`dashboard`, `estimator`, `inbox`, `kiosk`, `tradie/map`) as `force-dynamic` to prevent build-time DB queries.
+*   **Error handling**: Wrapped all server-rendered pages in try/catch so they show a helpful "Database Not Initialized" message instead of crashing when Supabase tables don't exist.
+*   **Fix**: Removed invalid `"use server"` directive from estimator page (pages are Server Components by default, `"use server"` only allows async function exports).
+*   **Extension**: Removed hardcoded `localhost:3000` — users must configure their deployment URL.
+*   **Status**: App deploys and builds on Vercel. DB tables need `prisma db push` + `prisma db seed` against Supabase.
+
 ### 2026-02-06 [Backend - Claude Code] - Code Quality & Build Cleanup
 **Fix**: Full codebase audit and quality pass
 *   **Security**: Removed hardcoded Supabase credentials from `lib/db.ts`. DB connection now requires `.env` to be configured.


### PR DESCRIPTION
Wrap all DB-dependent pages in try/catch so they show a helpful 'Database Not Initialized' message instead of a server-side crash when Supabase tables haven't been created yet. Update status log with Vercel deployment URL and changes.

https://claude.ai/code/session_01KWdS3djFRsEAwzekdUzEaB