### PR TITLE
feat: wire end-to-end onboarding flow (signup → setup → tutorial → da…

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -12,9 +12,9 @@ export default function LoginPage() {
     const router = useRouter()
 
     const handleSocialLogin = (provider: string) => {
-        // For demo purposes, bypass auth and go straight to dashboard
+        // For demo purposes, bypass auth and go to setup (redirects to dashboard if already onboarded)
         console.log(`Logging in with ${provider}`)
-        router.push("/dashboard")
+        router.push("/setup")
     }
 
     return (
@@ -59,7 +59,7 @@ export default function LoginPage() {
                 </div>
             </CardContent>
             <CardFooter className="flex flex-col gap-4">
-                <Link href="/dashboard" className="w-full">
+                <Link href="/setup" className="w-full">
                     <Button className="w-full">Sign In</Button>
                 </Link>
                 <p className="text-center text-sm text-slate-500">

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -12,8 +12,8 @@ export default function SignupPage() {
     const router = useRouter()
 
     const handleSignup = () => {
-        // For demo purposes, bypass auth and go straight to dashboard
-        router.push("/dashboard")
+        // For demo purposes, bypass auth and go to onboarding setup
+        router.push("/setup")
     }
 
     return (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation"
 import { getDeals } from "@/actions/deal-actions"
 import { getOrCreateWorkspace } from "@/actions/workspace-actions"
 import { KanbanBoard } from "@/components/crm/kanban-board"
@@ -12,6 +13,9 @@ export default async function DashboardPage() {
     let workspace, deals;
     try {
         workspace = await getOrCreateWorkspace("demo-user")
+        if (!workspace.onboardingComplete) {
+            redirect("/setup")
+        }
         deals = await getDeals(workspace.id)
     } catch {
         return (

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,6 +1,20 @@
+import { redirect } from "next/navigation"
+import { getOrCreateWorkspace } from "@/actions/workspace-actions"
 import { SetupChat } from "@/components/onboarding/setup-chat"
 
-export default function SetupPage() {
+export const dynamic = 'force-dynamic'
+
+export default async function SetupPage() {
+    // Check if the user has already completed onboarding
+    try {
+        const workspace = await getOrCreateWorkspace("demo-user")
+        if (workspace.onboardingComplete) {
+            redirect("/dashboard")
+        }
+    } catch {
+        // DB not ready — show setup anyway, it will save when DB is available
+    }
+
     return (
         <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-4">
             <div className="text-center mb-8 space-y-2">

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,10 +45,11 @@ model Workspace {
   id            String         @id @default(cuid())
   name          String
   type          WorkspaceType
-  industryType  IndustryType?
-  ownerId       String?
-  location      String?
-  brandingColor String         @default("#6366f1")
+  industryType        IndustryType?
+  ownerId             String?
+  location            String?
+  onboardingComplete  Boolean        @default(false)
+  brandingColor       String         @default("#6366f1")
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 


### PR DESCRIPTION
…shboard)

- Add onboardingComplete field to Workspace schema
- Add completeOnboarding server action that persists business name, industry type, and location to the workspace
- Wire setup-chat to call completeOnboarding at final step (was only saving industry to localStorage, now saves everything to DB)
- Route signup and login to /setup instead of /dashboard
- /setup checks onboardingComplete — redirects to /dashboard if done
- /dashboard checks onboardingComplete — redirects to /setup if not done
- Flow: signup → /setup (3-step chat) → /tutorial → /dashboard

https://claude.ai/code/session_01KWdS3djFRsEAwzekdUzEaB