### PR TITLE
Fix Next.js dynamic import in Server Component

### DIFF
--- a/app/(dashboard)/tradie/map/page.tsx
+++ b/app/(dashboard)/tradie/map/page.tsx
@@ -1,19 +1,9 @@
 import { getTradieJobs } from "@/actions/tradie-actions"
 import { getOrCreateWorkspace } from "@/actions/workspace-actions"
 import { getAuthUserId } from "@/lib/auth"
-import dynamicImport from "next/dynamic"
+import MapView from "@/components/map/map-view-client"
 
 export const dynamic = "force-dynamic"
-
-// Dynamically import to avoid SSR issues with Leaflet
-const MapView = dynamicImport(() => import("@/components/map/map-view"), {
-    ssr: false,
-    loading: () => (
-        <div className="h-full w-full bg-slate-900 flex items-center justify-center text-slate-500">
-            Loading Map...
-        </div>
-    ),
-})
 
 export default async function TradieMapPage() {
     const userId = await getAuthUserId()

--- a/components/map/map-view-client.tsx
+++ b/components/map/map-view-client.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+// Dynamically import to avoid SSR issues with Leaflet
+const MapView = dynamic(() => import("@/components/map/map-view"), {
+    ssr: false,
+    loading: () => (
+        <div className="h-full w-full bg-slate-900 flex items-center justify-center text-slate-500">
+            Loading Map...
+        </div>
+    ),
+})
+
+export default MapView


### PR DESCRIPTION
- Create client component wrapper (map-view-client.tsx) for dynamic Leaflet import
- Move ssr: false dynamic import from Server Component to Client Component
- Resolves build error: "ssr: false not allowed with next/dynamic in Server Components"

https://claude.ai/code/session_014UPNidKgK7pPTBqscce1Mj