### PR TITLE
Convert next.config.ts to next.config.mjs for Vercel compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
- Replace next.config.ts with next.config.mjs
- Fixes Turbopack parse error on Vercel deployment
- Build tested and passes locally

https://claude.ai/code/session_014UPNidKgK7pPTBqscce1Mj