### PR TITLE
Fix draft card layout: move cards outside chat bubble, widen container

### DIFF
--- a/components/chatbot/chat-interface.tsx
+++ b/components/chatbot/chat-interface.tsx
@@ -314,7 +314,7 @@ export function ChatInterface({ workspaceId }: ChatInterfaceProps) {
     )}>
 
       {/* Messages Area */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-6 scroll-smooth">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 pb-8 space-y-6 scroll-smooth">
         {Object.entries(groupedMessages).map(([dateKey, msgs]) => (
             <div key={dateKey} className="space-y-6">
                 <div className="flex items-center justify-center my-6">
@@ -327,8 +327,9 @@ export function ChatInterface({ workspaceId }: ChatInterfaceProps) {
                   <div
                     key={msg.id}
                     className={cn(
-                      "flex gap-4 max-w-[85%] group animate-in slide-in-from-bottom-2 duration-300",
-                      msg.role === 'user' ? "ml-auto flex-row-reverse" : ""
+                      "flex gap-4 group animate-in slide-in-from-bottom-2 duration-300",
+                      msg.role === 'user' ? "ml-auto flex-row-reverse max-w-[85%]" : "",
+                      msg.role !== 'user' && (msg.action === 'draft_job_natural' || msg.action === 'draft_deal') ? "max-w-[95%]" : msg.role !== 'user' ? "max-w-[85%]" : ""
                     )}
                   >
                     <div className={cn(
@@ -342,7 +343,7 @@ export function ChatInterface({ workspaceId }: ChatInterfaceProps) {
                       )}
                     </div>
 
-                    <div className="space-y-2">
+                    <div className="space-y-2 min-w-0">
                         <div className={cn(
                           "p-4 text-sm leading-relaxed shadow-sm",
                           msg.role === 'user'
@@ -350,64 +351,64 @@ export function ChatInterface({ workspaceId }: ChatInterfaceProps) {
                             : "bg-white border border-slate-100 text-slate-800 rounded-2xl rounded-tl-none"
                         )}>
                           <div className="whitespace-pre-wrap">{msg.text}</div>
-
-                          {/* Generative UI: Draft Deal Card */}
-                          {msg.action === 'draft_deal' && msg.data && (
-                            <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-slate-50/50">
-                                <div className="bg-slate-100 px-4 py-2 border-b border-slate-200 flex justify-between items-center">
-                                    <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Draft Deal</span>
-                                    <span className="text-[10px] bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full border border-amber-200">Needs Confirmation</span>
-                                </div>
-                                <div className="p-4 space-y-3">
-                                    <div>
-                                        <div className="text-xs text-slate-500 mb-0.5">Title</div>
-                                        <div className="font-medium text-slate-900">{msg.data.title}</div>
-                                    </div>
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div>
-                                            <div className="text-xs text-slate-500 mb-0.5">Value</div>
-                                            <div className="font-medium text-emerald-600">${Number(msg.data.value).toLocaleString()}</div>
-                                        </div>
-                                        <div>
-                                            <div className="text-xs text-slate-500 mb-0.5">Company</div>
-                                            <div className="font-medium text-slate-900">{msg.data.company || "N/A"}</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="p-2 bg-white border-t border-slate-200 flex gap-2">
-                                    <button
-                                        onClick={() => handleConfirmDeal(msg.data)}
-                                        className="flex-1 bg-slate-900 text-white text-xs py-2 rounded-lg font-medium hover:bg-slate-800 transition-colors flex items-center justify-center gap-1.5"
-                                    >
-                                        <Check className="w-3.5 h-3.5" />
-                                        Create Deal
-                                    </button>
-                                    <button
-                                        onClick={() => handleSend("Cancel that deal.")}
-                                        className="px-3 bg-white border border-slate-200 text-slate-600 text-xs py-2 rounded-lg font-medium hover:bg-slate-50 transition-colors"
-                                    >
-                                        <X className="w-4 h-4" />
-                                    </button>
-                                </div>
-                            </div>
-                          )}
-
-                          {/* Generative UI: Editable Job Draft Card */}
-                          {msg.action === 'draft_job_natural' && msg.data && (
-                            <JobDraftCard
-                              data={msg.data}
-                              onConfirm={(edited) => handleConfirmJobNatural(edited)}
-                              onCancel={() => {
-                                setMessages(prev => [...prev, {
-                                  id: Date.now().toString(),
-                                  role: 'bot',
-                                  text: 'Job entry cancelled.',
-                                  createdAt: new Date().toISOString(),
-                                }]);
-                              }}
-                            />
-                          )}
                         </div>
+
+                        {/* Generative UI: Draft Deal Card — rendered outside the bubble */}
+                        {msg.action === 'draft_deal' && msg.data && (
+                          <div className="overflow-hidden rounded-xl border border-slate-200 bg-slate-50/50">
+                              <div className="bg-slate-100 px-4 py-2 border-b border-slate-200 flex justify-between items-center">
+                                  <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Draft Deal</span>
+                                  <span className="text-[10px] bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full border border-amber-200">Needs Confirmation</span>
+                              </div>
+                              <div className="p-4 space-y-3">
+                                  <div>
+                                      <div className="text-xs text-slate-500 mb-0.5">Title</div>
+                                      <div className="font-medium text-slate-900">{msg.data.title}</div>
+                                  </div>
+                                  <div className="grid grid-cols-2 gap-4">
+                                      <div>
+                                          <div className="text-xs text-slate-500 mb-0.5">Value</div>
+                                          <div className="font-medium text-emerald-600">${Number(msg.data.value).toLocaleString()}</div>
+                                      </div>
+                                      <div>
+                                          <div className="text-xs text-slate-500 mb-0.5">Company</div>
+                                          <div className="font-medium text-slate-900">{msg.data.company || "N/A"}</div>
+                                      </div>
+                                  </div>
+                              </div>
+                              <div className="p-2 bg-white border-t border-slate-200 flex gap-2">
+                                  <button
+                                      onClick={() => handleConfirmDeal(msg.data)}
+                                      className="flex-1 bg-slate-900 text-white text-xs py-2 rounded-lg font-medium hover:bg-slate-800 transition-colors flex items-center justify-center gap-1.5"
+                                  >
+                                      <Check className="w-3.5 h-3.5" />
+                                      Create Deal
+                                  </button>
+                                  <button
+                                      onClick={() => handleSend("Cancel that deal.")}
+                                      className="px-3 bg-white border border-slate-200 text-slate-600 text-xs py-2 rounded-lg font-medium hover:bg-slate-50 transition-colors"
+                                  >
+                                      <X className="w-4 h-4" />
+                                  </button>
+                              </div>
+                          </div>
+                        )}
+
+                        {/* Generative UI: Editable Job Draft Card — rendered outside the bubble */}
+                        {msg.action === 'draft_job_natural' && msg.data && (
+                          <JobDraftCard
+                            data={msg.data}
+                            onConfirm={(edited) => handleConfirmJobNatural(edited)}
+                            onCancel={() => {
+                              setMessages(prev => [...prev, {
+                                id: Date.now().toString(),
+                                role: 'bot',
+                                text: 'Job entry cancelled.',
+                                createdAt: new Date().toISOString(),
+                              }]);
+                            }}
+                          />
+                        )}
 
                         {/* Time Stamp */}
                         <div className={cn(


### PR DESCRIPTION
The draft cards (JobDraftCard and Draft Deal) were rendered inside the chat bubble div, causing them to be constrained by the bubble's padding, rounded corners, and max-w-[85%]. This made the card's inputs and confirm/cancel buttons invisible or unscrollable.

Changes:
- Moved draft cards outside the message bubble but still within the message container (space-y-2), so they render as siblings below the text bubble instead of being crammed inside it
- Added min-w-0 to the content wrapper to prevent flex overflow
- Widened bot messages with draft cards to max-w-[95%] so inputs have room to breathe
- Added pb-8 to scroll area so the last card isn't hidden behind the input bar

https://claude.ai/code/session_01XbyiyY2mgWtXaTsZQo1Z9W