### PR TITLE
UI: home page & multi-page improvements per issue tracker

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -2,21 +2,16 @@
 
 import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { 
-  TrendingUp, 
-  TrendingDown, 
-  DollarSign, 
-  Users, 
-  Calendar, 
+import {
+  TrendingUp,
+  TrendingDown,
+  DollarSign,
+  Users,
   Star,
-  BarChart3,
-  PieChart,
-  Activity,
-  Target,
-  Clock,
-  CheckCircle
+  CheckCircle,
+  Calendar,
+  LayoutList,
 } from "lucide-react"
 import { useShellStore } from "@/lib/store"
 import { getReportsData, type ReportsData } from "@/actions/analytics-actions"
@@ -25,6 +20,7 @@ export default function AnalyticsPage() {
   const [timeRange, setTimeRange] = useState("30d")
   const [data, setData] = useState<ReportsData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [revenueExpanded, setRevenueExpanded] = useState(false)
   const workspaceId = useShellStore((s) => s.workspaceId)
 
   useEffect(() => {
@@ -45,9 +41,9 @@ export default function AnalyticsPage() {
       <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-6">
         <div className="animate-pulse space-y-4">
           <div className="h-8 bg-secondary rounded-xl w-1/3"></div>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="h-24 bg-secondary rounded-[24px]"></div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="h-28 bg-secondary rounded-[24px]"></div>
             ))}
           </div>
         </div>
@@ -63,6 +59,16 @@ export default function AnalyticsPage() {
     )
   }
   if (!data) return null
+
+  // Pipeline count: new requests + quote sent (not yet scheduled)
+  const pipelineCount = data.deals.byStage
+    .filter(s => ["New request", "Quote sent"].includes(s.stage))
+    .reduce((sum, s) => sum + s.count, 0)
+
+  const scheduledCount = data.deals.byStage
+    .find(s => s.stage === "Scheduled")?.count ?? 0
+
+  const hasRating = data.customers.satisfaction > 0
 
   return (
     <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-6">
@@ -85,228 +91,182 @@ export default function AnalyticsPage() {
         </Select>
       </div>
 
-      {/* Key Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      {/* 3 Key Cards: Status | Revenue | Customer */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+
+        {/* Card 1: Status */}
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Total Revenue</p>
-                <p className="text-2xl font-bold text-midnight">${data.revenue.total.toLocaleString()}</p>
-                <div className="flex items-center gap-1 mt-1">
-                  {data.revenue.growth > 0 ? (
-                    <TrendingUp className="h-3 w-3 text-primary" />
-                  ) : (
-                    <TrendingDown className="h-3 w-3 text-destructive" />
-                  )}
-                  <span className={`text-xs ${data.revenue.growth > 0 ? 'text-primary' : 'text-destructive'}`}>
-                    {Math.abs(data.revenue.growth)}%
-                  </span>
-                </div>
-              </div>
-              <DollarSign className="h-8 w-8 text-muted-foreground/40" />
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Status</p>
+              <LayoutList className="h-5 w-5 text-muted-foreground/40" />
             </div>
+            <div className="grid grid-cols-3 gap-3 text-center">
+              <div>
+                <p className="text-2xl font-bold text-midnight">{data.jobs.completed}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">Completed</p>
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-amber-600">{scheduledCount}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">Scheduled</p>
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-blue-600">{pipelineCount}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">Pipeline</p>
+              </div>
+            </div>
+            <p className="text-[10px] text-muted-foreground/60 mt-3 text-center">Pipeline = new requests + quotes sent</p>
           </CardContent>
         </Card>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Total Deals</p>
-                <p className="text-2xl font-bold text-midnight">{data.deals.total}</p>
-                <div className="flex items-center gap-1 mt-1">
-                  <Target className="h-3 w-3 text-blue-600" />
-                  <span className="text-xs text-blue-600">{data.deals.conversion}% conversion</span>
-                </div>
-              </div>
-              <BarChart3 className="h-8 w-8 text-muted-foreground/40" />
+        {/* Card 2: Revenue — click to expand trend */}
+        <Card
+          className="cursor-pointer hover:shadow-md transition-shadow"
+          onClick={() => setRevenueExpanded(!revenueExpanded)}
+        >
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Revenue</p>
+              <DollarSign className="h-5 w-5 text-muted-foreground/40" />
             </div>
+            <p className="text-3xl font-bold text-midnight">${data.revenue.total.toLocaleString()}</p>
+            <div className="flex items-center gap-1 mt-2">
+              {data.revenue.growth > 0 ? (
+                <TrendingUp className="h-3.5 w-3.5 text-primary" />
+              ) : (
+                <TrendingDown className="h-3.5 w-3.5 text-destructive" />
+              )}
+              <span className={`text-xs font-medium ${data.revenue.growth > 0 ? 'text-primary' : 'text-destructive'}`}>
+                {Math.abs(Math.round(data.revenue.growth))}% vs last month
+              </span>
+            </div>
+            <p className="text-[10px] text-muted-foreground/60 mt-2">{revenueExpanded ? "Click to collapse" : "Click to see trend"}</p>
           </CardContent>
         </Card>
 
+        {/* Card 3: Customer */}
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Customers</p>
-                <p className="text-2xl font-bold text-midnight">{data.customers.total}</p>
-                <div className="flex items-center gap-1 mt-1">
-                  <Users className="h-3 w-3 text-purple-600" />
-                  <span className="text-xs text-purple-600">{data.customers.new} new this month</span>
-                </div>
-              </div>
-              <Users className="h-8 w-8 text-muted-foreground/40" />
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Customers</p>
+              <Users className="h-5 w-5 text-muted-foreground/40" />
             </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between">
+            <div className="grid grid-cols-2 gap-3">
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Satisfaction</p>
-                <p className="text-2xl font-bold text-midnight">{data.customers.satisfaction}</p>
-                <div className="flex items-center gap-1 mt-1">
-                  <Star className="h-3 w-3 text-amber-500" />
-                  <span className="text-xs text-amber-600">Average rating</span>
-                </div>
+                <p className="text-2xl font-bold text-midnight">{data.customers.new}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">New this month</p>
               </div>
-              <Star className="h-8 w-8 text-muted-foreground/40" />
+              <div>
+                {hasRating ? (
+                  <>
+                    <div className="flex items-baseline gap-1">
+                      <p className="text-2xl font-bold text-midnight">{data.customers.satisfaction}</p>
+                      <Star className="h-4 w-4 text-amber-500 mb-0.5" />
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-0.5">Avg rating</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm font-medium text-muted-foreground mt-1">No ratings yet</p>
+                    <p className="text-xs text-muted-foreground/60 mt-0.5">Ratings will appear here</p>
+                  </>
+                )}
+              </div>
             </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Charts Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Revenue Chart */}
+      {/* Revenue trend (expandable) */}
+      {revenueExpanded && (
         <Card>
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="h-5 w-5" />
+            <CardTitle className="flex items-center gap-2 text-base">
+              <TrendingUp className="h-4 w-4" />
               Revenue Trend
             </CardTitle>
             <CardDescription>Monthly revenue over time</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              {data.revenue.monthly.map((month, index) => (
-                <div key={index} className="flex items-center gap-3">
-                  <span className="text-sm text-slate-600 w-12">{month.month}</span>
-                  <div className="flex-1 bg-secondary rounded-full h-6 relative overflow-hidden">
-                    <div 
-                      className="absolute left-0 top-0 h-full bg-primary rounded-full"
-                      style={{ width: `${(Math.max(...data.revenue.monthly.map(m => m.revenue)) > 0 ? (month.revenue / Math.max(...data.revenue.monthly.map(m => m.revenue))) * 100 : 0)}%` }}
-                    />
-                  </div>
-                  <span className="text-sm font-medium text-slate-900 w-20 text-right">
-                    ${month.revenue.toLocaleString()}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Deal Pipeline */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <PieChart className="h-5 w-5" />
-              Deal Pipeline
-            </CardTitle>
-            <CardDescription>Deals by stage</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {data.deals.byStage.map((stage, index) => (
-                <div key={index} className="flex items-center gap-3">
-                  <span className="text-sm text-slate-600 w-24">{stage.stage}</span>
-                  <div className="flex-1 bg-secondary rounded-full h-6 relative overflow-hidden">
-                    <div 
-                      className="absolute left-0 top-0 h-full rounded-full bg-primary/80"
-                      style={{ width: `${(data.deals.byStage.length && Math.max(...data.deals.byStage.map(s => s.count)) > 0 ? (stage.count / Math.max(...data.deals.byStage.map(s => s.count))) * 100 : 0)}%` }}
-                    />
-                  </div>
-                  <span className="text-sm font-medium text-slate-900 w-12 text-right">
-                    {stage.count}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Job Performance */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Activity className="h-5 w-5" />
-              Job Performance
-            </CardTitle>
-            <CardDescription>Job completion metrics</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="flex items-center justify-center w-12 h-12 bg-mint-50 rounded-full mx-auto mb-2">
-                  <CheckCircle className="h-6 w-6 text-primary" />
-                </div>
-                <p className="text-2xl font-bold text-midnight">{data.jobs.completed}</p>
-                <p className="text-xs text-slate-600">Completed</p>
-              </div>
-              <div className="text-center">
-                <div className="flex items-center justify-center w-12 h-12 bg-blue-50 rounded-full mx-auto mb-2">
-                  <Clock className="h-6 w-6 text-blue-500" />
-                </div>
-                <p className="text-2xl font-bold text-midnight">{data.jobs.inProgress}</p>
-                <p className="text-xs text-slate-600">In Progress</p>
-              </div>
-              <div className="text-center">
-                <div className="flex items-center justify-center w-12 h-12 bg-secondary rounded-full mx-auto mb-2">
-                  <Calendar className="h-6 w-6 text-midnight" />
-                </div>
-                <p className="text-2xl font-bold text-midnight">{data.jobs.avgCompletionTime}</p>
-                <p className="text-xs text-slate-600">Avg Days</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Team Performance - shown when we have team data */}
-        {data.team.performance.length > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Users className="h-5 w-5" />
-                Team Performance
-              </CardTitle>
-              <CardDescription>Individual team member metrics</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                {data.team.performance.map((member, index) => (
-                  <div key={index} className="flex items-center justify-between p-3 bg-secondary/50 rounded-2xl">
-                    <div>
-                      <p className="font-medium text-midnight">{member.name}</p>
-                      <p className="text-sm text-muted-foreground">{member.jobs} jobs completed</p>
+              {data.revenue.monthly.map((month, index) => {
+                const maxRev = Math.max(...data.revenue.monthly.map(m => m.revenue))
+                const pct = maxRev > 0 ? (month.revenue / maxRev) * 100 : 0
+                return (
+                  <div key={index} className="flex items-center gap-3">
+                    <span className="text-sm text-slate-600 w-10 shrink-0">{month.month}</span>
+                    <div className="flex-1 bg-secondary rounded-full h-5 relative overflow-hidden">
+                      <div
+                        className="absolute left-0 top-0 h-full bg-primary rounded-full transition-all duration-500"
+                        style={{ width: `${pct}%` }}
+                      />
                     </div>
-                    <div className="text-right">
-                      <p className="font-medium text-primary">${member.revenue.toLocaleString()}</p>
-                      <p className="text-xs text-muted-foreground">revenue</p>
-                    </div>
+                    <span className="text-sm font-medium text-slate-900 w-20 text-right shrink-0">
+                      ${month.revenue.toLocaleString()}
+                    </span>
                   </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-      {/* Export Options */}
+      {/* Job performance detail */}
       <Card>
         <CardHeader>
-          <CardTitle>Export Reports</CardTitle>
-          <CardDescription>Download detailed reports for offline analysis</CardDescription>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CheckCircle className="h-4 w-4" />
+            Job Performance
+          </CardTitle>
+          <CardDescription>Completion metrics for the selected period</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex gap-3">
-            <Button variant="outline">
-              <BarChart3 className="h-4 w-4 mr-2" />
-              Export as CSV
-            </Button>
-            <Button variant="outline">
-              <PieChart className="h-4 w-4 mr-2" />
-              Export as PDF
-            </Button>
-            <Button variant="outline">
-              <Calendar className="h-4 w-4 mr-2" />
-              Schedule Report
-            </Button>
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <div>
+              <p className="text-2xl font-bold text-midnight">{data.jobs.completed}</p>
+              <p className="text-xs text-slate-600 mt-1">Completed</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-midnight">{data.jobs.inProgress}</p>
+              <p className="text-xs text-slate-600 mt-1">In progress</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-midnight">{data.jobs.avgCompletionTime}</p>
+              <p className="text-xs text-slate-600 mt-1">Avg days to complete</p>
+            </div>
           </div>
         </CardContent>
       </Card>
+
+      {/* Team Performance - only when data exists */}
+      {data.team.performance.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Users className="h-4 w-4" />
+              Team Performance
+            </CardTitle>
+            <CardDescription>Individual team member metrics</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {data.team.performance.map((member, index) => (
+                <div key={index} className="flex items-center justify-between p-3 bg-secondary/50 rounded-2xl">
+                  <div>
+                    <p className="font-medium text-midnight">{member.name}</p>
+                    <p className="text-sm text-muted-foreground">{member.jobs} jobs completed</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium text-primary">${member.revenue.toLocaleString()}</p>
+                    <p className="text-xs text-muted-foreground">revenue</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/app/dashboard/settings/layout.tsx
+++ b/app/dashboard/settings/layout.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { cn } from "@/lib/utils"
+import { AlertTriangle } from "lucide-react"
 
 interface SettingsLayoutProps {
     children: React.ReactNode
@@ -95,6 +96,13 @@ function SidebarNav({ className, items, ...props }: SidebarNavProps) {
 export default function SettingsLayout({ children }: SettingsLayoutProps) {
     return (
         <div className="space-y-6 p-4 pl-6 pb-16 md:p-8 md:pl-10 lg:p-10 lg:pl-14 max-w-6xl mx-auto w-full">
+            {/* WIP Banner */}
+            <div className="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800">
+                <AlertTriangle className="h-5 w-5 shrink-0 text-red-500" />
+                <p className="text-sm font-medium">
+                    Settings is a work in progress (WIP). Some options may not be fully functional yet.
+                </p>
+            </div>
             <div className="space-y-1.5">
                 <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-white">Settings</h2>
                 <p className="text-slate-500 text-sm">

--- a/app/dashboard/team/page.tsx
+++ b/app/dashboard/team/page.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { MoreHorizontal, Plus, Shield, Users } from "lucide-react"
+import { MoreHorizontal, Plus, Shield, Users, AlertTriangle } from "lucide-react"
 
 export default async function TeamPage() {
     const authUser = await getAuthUser()
@@ -48,6 +48,13 @@ export default async function TeamPage() {
 
     return (
         <div className="p-6 max-w-7xl mx-auto space-y-6">
+            {/* WIP Banner */}
+            <div className="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800">
+                <AlertTriangle className="h-5 w-5 shrink-0 text-red-500" />
+                <p className="text-sm font-medium">
+                    Team Management is a work in progress and needs further development. Features shown are placeholders only.
+                </p>
+            </div>
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-midnight">Team Management</h1>

--- a/components/layout/Shell.tsx
+++ b/components/layout/Shell.tsx
@@ -9,9 +9,10 @@ import { TutorialOverlay } from "@/components/tutorial/tutorial-overlay"
 import { Sidebar } from "@/components/core/sidebar"
 import { MobileSidebar } from "@/components/layout/mobile-sidebar"
 import { Switch } from "@/components/ui/switch"
-import { Layers, MessageSquare } from "lucide-react"
+import { Layers, MessageSquare, Menu, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import type { ImperativePanelHandle } from "react-resizable-panels"
 
 export function Shell({ children, chatbot }: { children: React.ReactNode; chatbot?: React.ReactNode }) {
@@ -24,6 +25,7 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
   const [mounted, setMounted] = useState(false)
   const chatbotPanelRef = useRef<ImperativePanelHandle>(null)
   const [chatbotExpanded, setChatbotExpanded] = useState(false)
+  const [mobileChatOpen, setMobileChatOpen] = useState(false)
   const didDragRef = useRef(false)
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null)
 
@@ -173,7 +175,23 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
             </ResizablePanel>
           </ResizablePanelGroup>
 
-          {/* Icon-only chat trigger: bottom RHS when panel collapsed (e.g. when card modal open and side panel not available). */}
+          {/* Mobile: floating nav + chat buttons */}
+          <div className="md:hidden fixed bottom-5 right-5 z-[10000] flex flex-col gap-2 items-end">
+            {/* Chat FAB - opens a sheet on mobile */}
+            {chatbot && (
+              <button
+                type="button"
+                onClick={() => setMobileChatOpen(true)}
+                className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                title="Open chat"
+                aria-label="Open chat"
+              >
+                <MessageSquare className="h-5 w-5 text-primary" />
+              </button>
+            )}
+          </div>
+
+          {/* Desktop: chat FAB when panel is collapsed */}
           {chatbot && !chatbotExpanded && (
             <button
               type="button"
@@ -183,13 +201,47 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
                 chatbotPanelRef.current?.expand()
                 setChatbotExpanded(true)
               }}
-              className="fixed bottom-5 right-5 z-[10000] flex h-11 w-11 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              className="hidden md:flex fixed bottom-5 right-5 z-[10000] h-11 w-11 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               title="Open chat"
               aria-label="Open chat"
             >
               <MessageSquare className="h-5 w-5 text-primary" />
             </button>
           )}
+
+          {/* Mobile: hamburger menu - fixed bottom-left for navigation on non-dashboard pages */}
+          <button
+            type="button"
+            onClick={() => useShellStore.getState().setMobileMenuOpen(true)}
+            className="md:hidden fixed bottom-5 left-5 z-[10000] flex h-12 w-12 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+            title="Open navigation"
+            aria-label="Open navigation menu"
+          >
+            <Menu className="h-5 w-5 text-slate-700" />
+          </button>
+
+          {/* Mobile Chat Sheet */}
+          <Sheet open={mobileChatOpen} onOpenChange={setMobileChatOpen}>
+            <SheetContent side="bottom" className="h-[85dvh] p-0 flex flex-col">
+              <SheetHeader className="shrink-0 flex flex-row items-center justify-between px-4 py-3 border-b border-border/50">
+                <SheetTitle className="flex items-center gap-2 text-sm font-semibold">
+                  <MessageSquare className="h-4 w-4 text-primary" />
+                  AI Assistant
+                </SheetTitle>
+                <button
+                  type="button"
+                  onClick={() => setMobileChatOpen(false)}
+                  className="rounded-full p-1.5 text-muted-foreground hover:bg-muted transition-colors"
+                  aria-label="Close chat"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </SheetHeader>
+              <div id="mobile-assistant-pane" className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                {chatbot}
+              </div>
+            </SheetContent>
+          </Sheet>
         </div>
       )}
     </div>


### PR DESCRIPTION
Home page / Kanban:
- Rename 'Scheduled jobs' KPI card to 'Upcoming jobs' (next 7 days window)
- Remove 'Pipeline' kanban column — legacy pipeline deals now map to 'Quote sent'
- Rename 'Ready to be invoiced' column to 'Awaiting payment'
- Increase kanban drag activation delay to 250ms so mobile users can scroll without accidentally grabbing cards

New job modal:
- Rename 'Title' to 'Job description' for clarity
- Require first name + at least email or phone before a card can be created
- Remove deprecated 'Pipeline' stage option; rename 'Ready to be invoiced' to 'Awaiting payment'

Contacts tab:
- Add sort toggle (A–Z alphabetical / recent first by last-interacted date)
- Clickable column headers for Name (A–Z) and Last interacted (recent first)
- Map legacy PIPELINE prisma stage to 'quote_sent' column
- Update stage filter labels to match renamed columns

Analytics & Reporting:
- Reorder summary cards: Status (completed / scheduled / pipeline) → Revenue → Customer
- Revenue card is now clickable to expand/collapse the monthly trend chart
- Satisfaction rating shows 'No ratings yet' instead of zero when no ratings exist
- Remove duplicate/overlapping cards; keep Job Performance detail below

Team Management:
- Add red WIP banner at the top noting this page needs further development

Settings:
- Add red WIP banner at the top of the settings layout

Mobile (Shell):
- Add floating hamburger button (bottom-left) visible on all pages so users can open the sidebar from any tab
- Chat FAB (bottom-right) on mobile now opens a bottom Sheet/drawer instead of trying to expand the hidden desktop panel

https://claude.ai/code/session_011CKC4zXiraq6hGM3BpnSDr