### PR TITLE
feat: team roles/invites, automated booking reminders, and AI agent t…

### DIFF
--- a/actions/agent-tools.ts
+++ b/actions/agent-tools.ts
@@ -1,0 +1,381 @@
+"use server";
+
+import { db } from "@/lib/db";
+
+/**
+ * Tool: get_schedule
+ * Fetches scheduled jobs for a specific date range.
+ * Use when the user asks "What am I doing next week?" or "Do I have space on Tuesday?"
+ */
+export async function runGetSchedule(
+  workspaceId: string,
+  params: { startDate: string; endDate: string }
+): Promise<{
+  jobs: {
+    id: string;
+    title: string;
+    clientName: string;
+    address: string | null;
+    scheduledAt: string;
+    jobStatus: string | null;
+    value: number;
+  }[];
+  count: number;
+}> {
+  const start = new Date(params.startDate);
+  const end = new Date(params.endDate);
+
+  const jobs = await db.deal.findMany({
+    where: {
+      workspaceId,
+      scheduledAt: {
+        gte: start,
+        lte: end,
+      },
+    },
+    include: { contact: { select: { name: true } } },
+    orderBy: { scheduledAt: "asc" },
+  });
+
+  return {
+    jobs: jobs.map((j) => ({
+      id: j.id,
+      title: j.title,
+      clientName: j.contact?.name || "Unknown",
+      address: j.address,
+      scheduledAt: j.scheduledAt?.toISOString() || "",
+      jobStatus: j.jobStatus,
+      value: j.value ? Number(j.value) : 0,
+    })),
+    count: jobs.length,
+  };
+}
+
+/**
+ * Tool: search_job_history
+ * Searches for past jobs (completed/cancelled) based on keywords.
+ * Use for queries like "When was the last time I visited Mrs. Jones?" or "Jobs at 10 Henderson St".
+ */
+export async function runSearchJobHistory(
+  workspaceId: string,
+  params: { query: string; limit?: number }
+): Promise<{
+  jobs: {
+    id: string;
+    title: string;
+    clientName: string;
+    address: string | null;
+    scheduledAt: string | null;
+    stage: string;
+    jobStatus: string | null;
+    value: number;
+    createdAt: string;
+  }[];
+}> {
+  const take = params.limit || 5;
+  const q = params.query.trim();
+
+  const jobs = await db.deal.findMany({
+    where: {
+      workspaceId,
+      OR: [
+        { address: { contains: q, mode: "insensitive" } },
+        { title: { contains: q, mode: "insensitive" } },
+        { contact: { name: { contains: q, mode: "insensitive" } } },
+      ],
+    },
+    include: { contact: { select: { name: true } } },
+    orderBy: { createdAt: "desc" },
+    take,
+  });
+
+  return {
+    jobs: jobs.map((j) => ({
+      id: j.id,
+      title: j.title,
+      clientName: j.contact?.name || "Unknown",
+      address: j.address,
+      scheduledAt: j.scheduledAt?.toISOString() || null,
+      stage: j.stage,
+      jobStatus: j.jobStatus,
+      value: j.value ? Number(j.value) : 0,
+      createdAt: j.createdAt.toISOString(),
+    })),
+  };
+}
+
+/**
+ * Tool: get_financial_report
+ * Calculates revenue or job count for a date range.
+ */
+export async function runGetFinancialReport(
+  workspaceId: string,
+  params: { startDate: string; endDate: string }
+): Promise<{
+  totalRevenue: number;
+  jobCount: number;
+  averageJobValue: number;
+  invoicedTotal: number;
+  breakdown: { stage: string; count: number; value: number }[];
+}> {
+  const start = new Date(params.startDate);
+  const end = new Date(params.endDate);
+
+  const aggregate = await db.deal.aggregate({
+    where: {
+      workspaceId,
+      createdAt: { gte: start, lte: end },
+    },
+    _sum: { value: true, invoicedAmount: true },
+    _count: true,
+    _avg: { value: true },
+  });
+
+  // Get breakdown by stage
+  const byStage = await db.deal.groupBy({
+    by: ["stage"],
+    where: {
+      workspaceId,
+      createdAt: { gte: start, lte: end },
+    },
+    _count: true,
+    _sum: { value: true },
+  });
+
+  return {
+    totalRevenue: aggregate._sum.value ? Number(aggregate._sum.value) : 0,
+    jobCount: aggregate._count,
+    averageJobValue: aggregate._avg.value ? Number(aggregate._avg.value) : 0,
+    invoicedTotal: aggregate._sum.invoicedAmount
+      ? Number(aggregate._sum.invoicedAmount)
+      : 0,
+    breakdown: byStage.map((s) => ({
+      stage: s.stage,
+      count: s._count,
+      value: s._sum.value ? Number(s._sum.value) : 0,
+    })),
+  };
+}
+
+/**
+ * Tool: get_client_context
+ * Fetches recent notes, messages, and jobs for a specific client.
+ */
+export async function runGetClientContext(
+  workspaceId: string,
+  params: { clientName: string }
+): Promise<{
+  client: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    company: string | null;
+    address: string | null;
+  } | null;
+  recentNotes: { title: string; content: string | null; createdAt: string }[];
+  recentMessages: {
+    role: string;
+    content: string;
+    createdAt: string;
+  }[];
+  recentJobs: {
+    title: string;
+    stage: string;
+    scheduledAt: string | null;
+    value: number;
+  }[];
+}> {
+  // Fuzzy match: find best matching contact
+  const contacts = await db.contact.findMany({
+    where: {
+      workspaceId,
+      name: { contains: params.clientName, mode: "insensitive" },
+    },
+    take: 1,
+  });
+
+  if (!contacts.length) {
+    return {
+      client: null,
+      recentNotes: [],
+      recentMessages: [],
+      recentJobs: [],
+    };
+  }
+
+  const contact = contacts[0];
+
+  // Fetch last 5 notes (activities of type NOTE)
+  const notes = await db.activity.findMany({
+    where: { contactId: contact.id, type: "NOTE" },
+    orderBy: { createdAt: "desc" },
+    take: 5,
+    select: { title: true, content: true, createdAt: true },
+  });
+
+  // Fetch last 5 messages tied to this contact
+  const messages = await db.chatMessage.findMany({
+    where: {
+      workspaceId,
+      metadata: { path: ["contactId"], equals: contact.id },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 5,
+    select: { role: true, content: true, createdAt: true },
+  });
+
+  // Fetch last 3 jobs for this contact
+  const jobs = await db.deal.findMany({
+    where: { contactId: contact.id },
+    orderBy: { createdAt: "desc" },
+    take: 3,
+    select: {
+      title: true,
+      stage: true,
+      scheduledAt: true,
+      value: true,
+    },
+  });
+
+  return {
+    client: {
+      id: contact.id,
+      name: contact.name,
+      email: contact.email,
+      phone: contact.phone,
+      company: contact.company,
+      address: contact.address,
+    },
+    recentNotes: notes.map((n) => ({
+      title: n.title,
+      content: n.content,
+      createdAt: n.createdAt.toISOString(),
+    })),
+    recentMessages: messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+      createdAt: m.createdAt.toISOString(),
+    })),
+    recentJobs: jobs.map((j) => ({
+      title: j.title,
+      stage: j.stage,
+      scheduledAt: j.scheduledAt?.toISOString() || null,
+      value: j.value ? Number(j.value) : 0,
+    })),
+  };
+}
+
+/**
+ * Tool: get_today_summary
+ * Quick snapshot of today's scheduled jobs, overdue tasks, and unread messages.
+ */
+export async function runGetTodaySummary(
+  workspaceId: string
+): Promise<{
+  todayJobs: { title: string; clientName: string; scheduledAt: string; address: string | null }[];
+  overdueTasks: { title: string; dueAt: string }[];
+  recentMessages: number;
+}> {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayEnd = new Date();
+  todayEnd.setHours(23, 59, 59, 999);
+
+  const todayJobs = await db.deal.findMany({
+    where: {
+      workspaceId,
+      scheduledAt: { gte: todayStart, lte: todayEnd },
+    },
+    include: { contact: { select: { name: true } } },
+    orderBy: { scheduledAt: "asc" },
+  });
+
+  const overdueTasks = await db.task.findMany({
+    where: {
+      deal: { workspaceId },
+      completed: false,
+      dueAt: { lt: new Date() },
+    },
+    take: 5,
+    orderBy: { dueAt: "asc" },
+  });
+
+  const recentMsgCount = await db.chatMessage.count({
+    where: {
+      workspaceId,
+      createdAt: { gte: todayStart },
+    },
+  });
+
+  return {
+    todayJobs: todayJobs.map((j) => ({
+      title: j.title,
+      clientName: j.contact?.name || "Unknown",
+      scheduledAt: j.scheduledAt?.toISOString() || "",
+      address: j.address,
+    })),
+    overdueTasks: overdueTasks.map((t) => ({
+      title: t.title,
+      dueAt: t.dueAt?.toISOString() || "",
+    })),
+    recentMessages: recentMsgCount,
+  };
+}
+
+/**
+ * Tool: get_availability
+ * Checks available time slots for a given date, given existing scheduled jobs.
+ */
+export async function runGetAvailability(
+  workspaceId: string,
+  params: { date: string; workingHoursStart?: string; workingHoursEnd?: string }
+): Promise<{
+  date: string;
+  scheduledJobs: { title: string; startTime: string; clientName: string }[];
+  availableSlots: string[];
+}> {
+  const targetDate = new Date(params.date);
+  const dayStart = new Date(targetDate);
+  dayStart.setHours(0, 0, 0, 0);
+  const dayEnd = new Date(targetDate);
+  dayEnd.setHours(23, 59, 59, 999);
+
+  const jobs = await db.deal.findMany({
+    where: {
+      workspaceId,
+      scheduledAt: { gte: dayStart, lte: dayEnd },
+      jobStatus: { not: "CANCELLED" },
+    },
+    include: { contact: { select: { name: true } } },
+    orderBy: { scheduledAt: "asc" },
+  });
+
+  const whStart = params.workingHoursStart || "08:00";
+  const whEnd = params.workingHoursEnd || "17:00";
+  const [startH, startM] = whStart.split(":").map(Number);
+  const [endH, endM] = whEnd.split(":").map(Number);
+
+  // Generate 1-hour slots
+  const bookedHours = new Set(
+    jobs.map((j) => j.scheduledAt ? new Date(j.scheduledAt).getHours() : -1).filter((h) => h >= 0)
+  );
+
+  const availableSlots: string[] = [];
+  for (let h = startH; h < endH; h++) {
+    if (!bookedHours.has(h)) {
+      const slot = `${String(h).padStart(2, "0")}:${String(startM).padStart(2, "0")} - ${String(h + 1).padStart(2, "0")}:${String(startM).padStart(2, "0")}`;
+      availableSlots.push(slot);
+    }
+  }
+
+  return {
+    date: params.date,
+    scheduledJobs: jobs.map((j) => ({
+      title: j.title,
+      startTime: j.scheduledAt?.toISOString() || "",
+      clientName: j.contact?.name || "Unknown",
+    })),
+    availableSlots,
+  };
+}

--- a/actions/automated-message-actions.ts
+++ b/actions/automated-message-actions.ts
@@ -1,0 +1,268 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+
+export interface AutomatedMessageRuleView {
+  id: string;
+  name: string;
+  enabled: boolean;
+  triggerType: string;
+  channel: string;
+  messageTemplate: string;
+  hoursOffset: number;
+}
+
+const DEFAULT_RULES = [
+  {
+    name: "24h Booking Reminder",
+    triggerType: "booking_reminder_24h",
+    channel: "sms",
+    messageTemplate:
+      "Hi {{clientName}}, this is a reminder that your appointment for {{jobTitle}} is scheduled for {{scheduledTime}} tomorrow. Reply CONFIRM to confirm or call us to reschedule. - {{businessName}}",
+    hoursOffset: -24,
+  },
+  {
+    name: "Booking Confirmation",
+    triggerType: "booking_confirmation",
+    channel: "sms",
+    messageTemplate:
+      "Hi {{clientName}}, your booking for {{jobTitle}} has been confirmed for {{scheduledTime}}. We look forward to seeing you! - {{businessName}}",
+    hoursOffset: 0,
+  },
+  {
+    name: "Follow Up After Job",
+    triggerType: "follow_up_after_job",
+    channel: "sms",
+    messageTemplate:
+      "Hi {{clientName}}, thanks for choosing {{businessName}}! We hope the {{jobTitle}} went well. If you have any feedback, we'd love to hear it. - {{businessName}}",
+    hoursOffset: 24,
+  },
+];
+
+/**
+ * Get all automated message rules for the current workspace.
+ * Seeds defaults if none exist.
+ */
+export async function getAutomatedMessageRules(): Promise<AutomatedMessageRuleView[]> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return [];
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { workspaceId: true },
+  });
+  if (!user) return [];
+
+  let rules = await db.automatedMessageRule.findMany({
+    where: { workspaceId: user.workspaceId },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // Seed defaults if no rules exist
+  if (rules.length === 0) {
+    await db.automatedMessageRule.createMany({
+      data: DEFAULT_RULES.map((r) => ({
+        ...r,
+        workspaceId: user.workspaceId,
+      })),
+    });
+    rules = await db.automatedMessageRule.findMany({
+      where: { workspaceId: user.workspaceId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  return rules.map((r) => ({
+    id: r.id,
+    name: r.name,
+    enabled: r.enabled,
+    triggerType: r.triggerType,
+    channel: r.channel,
+    messageTemplate: r.messageTemplate,
+    hoursOffset: r.hoursOffset,
+  }));
+}
+
+/**
+ * Update an automated message rule.
+ */
+export async function updateAutomatedMessageRule(
+  ruleId: string,
+  data: Partial<{
+    name: string;
+    enabled: boolean;
+    channel: string;
+    messageTemplate: string;
+    hoursOffset: number;
+  }>
+): Promise<{ success: boolean; error?: string }> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return { success: false, error: "Unauthorized" };
+
+  await db.automatedMessageRule.update({
+    where: { id: ruleId },
+    data,
+  });
+
+  revalidatePath("/dashboard/settings/notifications");
+  return { success: true };
+}
+
+/**
+ * Create a new automated message rule.
+ */
+export async function createAutomatedMessageRule(data: {
+  name: string;
+  triggerType: string;
+  channel: string;
+  messageTemplate: string;
+  hoursOffset: number;
+}): Promise<{ success: boolean; error?: string }> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return { success: false, error: "Unauthorized" };
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { workspaceId: true },
+  });
+  if (!user) return { success: false, error: "User not found" };
+
+  await db.automatedMessageRule.create({
+    data: {
+      ...data,
+      workspaceId: user.workspaceId,
+    },
+  });
+
+  revalidatePath("/dashboard/settings/notifications");
+  return { success: true };
+}
+
+/**
+ * Delete an automated message rule.
+ */
+export async function deleteAutomatedMessageRule(
+  ruleId: string
+): Promise<{ success: boolean; error?: string }> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return { success: false, error: "Unauthorized" };
+
+  await db.automatedMessageRule.delete({ where: { id: ruleId } });
+  revalidatePath("/dashboard/settings/notifications");
+  return { success: true };
+}
+
+/**
+ * Process booking reminders for all workspaces.
+ * Called by the cron API endpoint. Sends SMS/email 24h before scheduled jobs.
+ */
+export async function processBookingReminders(): Promise<{
+  sent: number;
+  errors: number;
+}> {
+  let sent = 0;
+  let errors = 0;
+
+  // Find all enabled 24h reminder rules
+  const rules = await db.automatedMessageRule.findMany({
+    where: {
+      triggerType: "booking_reminder_24h",
+      enabled: true,
+    },
+  });
+
+  for (const rule of rules) {
+    // Find jobs scheduled 23-25 hours from now for this workspace
+    const now = new Date();
+    const windowStart = new Date(now.getTime() + 23 * 60 * 60 * 1000);
+    const windowEnd = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+
+    const upcomingJobs = await db.deal.findMany({
+      where: {
+        workspaceId: rule.workspaceId,
+        scheduledAt: {
+          gte: windowStart,
+          lte: windowEnd,
+        },
+        jobStatus: { not: "CANCELLED" },
+      },
+      include: {
+        contact: true,
+      },
+    });
+
+    const workspace = await db.workspace.findUnique({
+      where: { id: rule.workspaceId },
+      select: { name: true, twilioPhoneNumber: true, twilioSubaccountId: true },
+    });
+
+    for (const job of upcomingJobs) {
+      if (!job.contact?.phone) continue;
+
+      // Build message from template
+      const scheduledTime = job.scheduledAt
+        ? new Date(job.scheduledAt).toLocaleString("en-AU", {
+            weekday: "short",
+            day: "numeric",
+            month: "short",
+            hour: "numeric",
+            minute: "2-digit",
+          })
+        : "your scheduled time";
+
+      const message = rule.messageTemplate
+        .replace(/\{\{clientName\}\}/g, job.contact.name || "there")
+        .replace(/\{\{jobTitle\}\}/g, job.title || "your appointment")
+        .replace(/\{\{scheduledTime\}\}/g, scheduledTime)
+        .replace(/\{\{businessName\}\}/g, workspace?.name || "Our team");
+
+      // Send SMS if workspace has Twilio configured
+      if (
+        rule.channel !== "email" &&
+        workspace?.twilioPhoneNumber &&
+        workspace?.twilioSubaccountId
+      ) {
+        try {
+          const { getSubaccountClient } = await import("@/lib/twilio");
+          const client = getSubaccountClient(
+            workspace.twilioSubaccountId,
+            process.env.TWILIO_SUBACCOUNT_AUTH_TOKEN ||
+              process.env.TWILIO_AUTH_TOKEN ||
+              ""
+          );
+          await client.messages.create({
+            to: job.contact.phone,
+            from: workspace.twilioPhoneNumber,
+            body: message,
+          });
+          sent++;
+        } catch (err) {
+          console.error(
+            `[BookingReminder] SMS failed for job ${job.id}:`,
+            err
+          );
+          errors++;
+        }
+      }
+
+      // Log the reminder as an activity
+      try {
+        await db.activity.create({
+          data: {
+            type: "NOTE",
+            title: "Automated 24h Booking Reminder Sent",
+            content: message,
+            dealId: job.id,
+            contactId: job.contactId,
+          },
+        });
+      } catch {
+        // non-critical
+      }
+    }
+  }
+
+  return { sent, errors };
+}

--- a/actions/invite-actions.ts
+++ b/actions/invite-actions.ts
@@ -1,0 +1,179 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+import { UserRole } from "@prisma/client";
+
+/**
+ * Create an invite link for a workspace.
+ * Only OWNER and MANAGER roles can create invites.
+ * Managers can invite TEAM_MEMBER or MANAGER roles.
+ * Owners can invite any role.
+ */
+export async function createInvite(params: {
+  role: "MANAGER" | "TEAM_MEMBER";
+  email?: string;
+}): Promise<{ success: boolean; token?: string; error?: string }> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return { success: false, error: "Unauthorized" };
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { id: true, workspaceId: true, role: true },
+  });
+  if (!user) return { success: false, error: "User not found" };
+
+  // Permission check: only OWNER and MANAGER can invite
+  if (user.role !== "OWNER" && user.role !== "MANAGER") {
+    return { success: false, error: "Only managers and owners can create invites" };
+  }
+
+  // MANAGER cannot invite OWNER-level users
+  if (user.role === "MANAGER" && params.role !== "TEAM_MEMBER" && params.role !== "MANAGER") {
+    return { success: false, error: "Managers can only invite team members or other managers" };
+  }
+
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + 7); // 7 day expiry
+
+  const invite = await db.workspaceInvite.create({
+    data: {
+      workspaceId: user.workspaceId,
+      invitedById: user.id,
+      role: params.role as UserRole,
+      email: params.email || null,
+      expiresAt,
+    },
+  });
+
+  revalidatePath("/dashboard/team");
+  return { success: true, token: invite.token };
+}
+
+/**
+ * Get all pending invites for the current workspace.
+ */
+export async function getWorkspaceInvites() {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return [];
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { workspaceId: true, role: true },
+  });
+  if (!user) return [];
+
+  if (user.role !== "OWNER" && user.role !== "MANAGER") return [];
+
+  return db.workspaceInvite.findMany({
+    where: {
+      workspaceId: user.workspaceId,
+      acceptedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/**
+ * Validate an invite token and return the workspace info.
+ */
+export async function validateInviteToken(token: string) {
+  const invite = await db.workspaceInvite.findUnique({
+    where: { token },
+  });
+
+  if (!invite) return { valid: false, error: "Invalid invite link" };
+  if (invite.acceptedAt) return { valid: false, error: "This invite has already been used" };
+  if (invite.expiresAt < new Date()) return { valid: false, error: "This invite has expired" };
+
+  const workspace = await db.workspace.findUnique({
+    where: { id: invite.workspaceId },
+    select: { id: true, name: true },
+  });
+
+  return {
+    valid: true,
+    workspaceId: invite.workspaceId,
+    workspaceName: workspace?.name || "Workspace",
+    role: invite.role,
+  };
+}
+
+/**
+ * Accept an invite: link the newly signed-up user to the workspace.
+ */
+export async function acceptInvite(token: string, userId: string): Promise<{ success: boolean; error?: string }> {
+  const invite = await db.workspaceInvite.findUnique({
+    where: { token },
+  });
+
+  if (!invite) return { success: false, error: "Invalid invite" };
+  if (invite.acceptedAt) return { success: false, error: "Already accepted" };
+  if (invite.expiresAt < new Date()) return { success: false, error: "Invite expired" };
+
+  // Update the user's workspace and role
+  await db.user.update({
+    where: { id: userId },
+    data: {
+      workspaceId: invite.workspaceId,
+      role: invite.role,
+      hasOnboarded: true,
+    },
+  });
+
+  // Mark invite as accepted
+  await db.workspaceInvite.update({
+    where: { id: invite.id },
+    data: { acceptedAt: new Date() },
+  });
+
+  revalidatePath("/dashboard/team");
+  return { success: true };
+}
+
+/**
+ * Revoke (delete) a pending invite.
+ */
+export async function revokeInvite(inviteId: string): Promise<{ success: boolean; error?: string }> {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return { success: false, error: "Unauthorized" };
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { workspaceId: true, role: true },
+  });
+  if (!user || (user.role !== "OWNER" && user.role !== "MANAGER")) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  await db.workspaceInvite.delete({ where: { id: inviteId } });
+  revalidatePath("/dashboard/team");
+  return { success: true };
+}
+
+/**
+ * Get all team members for the current workspace (real data from DB).
+ */
+export async function getTeamMembers() {
+  const authUser = await getAuthUser();
+  if (!authUser?.email) return [];
+
+  const user = await db.user.findFirst({
+    where: { email: authUser.email },
+    select: { workspaceId: true },
+  });
+  if (!user) return [];
+
+  return db.user.findMany({
+    where: { workspaceId: user.workspaceId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+}

--- a/app/api/cron/booking-reminders/route.ts
+++ b/app/api/cron/booking-reminders/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { processBookingReminders } from "@/actions/automated-message-actions";
+
+/**
+ * Cron endpoint: Send automated 24h booking reminders.
+ * Should be called every hour via Vercel Cron or similar scheduler.
+ *
+ * Example cron config in vercel.json:
+ * { "crons": [{ "path": "/api/cron/booking-reminders", "schedule": "0 * * * *" }] }
+ */
+export async function GET(req: NextRequest) {
+  // Verify cron secret to prevent unauthorized access
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await processBookingReminders();
+    return NextResponse.json({
+      ok: true,
+      sent: result.sent,
+      errors: result.errors,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("[Cron] Booking reminders failed:", error);
+    return NextResponse.json(
+      { error: "Failed to process booking reminders" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/extension/import/route.ts
+++ b/app/api/extension/import/route.ts
@@ -40,10 +40,11 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   } catch (err) {
+    console.error("Extension import error:", err);
     return NextResponse.json(
       {
         success: false,
-        error: err instanceof Error ? err.message : "Internal error",
+        error: "Internal server error",
       },
       { status: 500 }
     );

--- a/app/api/webhooks/email/route.ts
+++ b/app/api/webhooks/email/route.ts
@@ -123,6 +123,6 @@ export async function POST(req: Request) {
 
     } catch (err: any) {
         console.error("Email Webhook Error:", err)
-        return NextResponse.json({ error: err.message }, { status: 500 })
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 })
     }
 }

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
         );
     } catch (error: any) {
         console.error("Stripe webhook verification failed:", error.message);
-        return new NextResponse(`Webhook Error: ${error.message}`, { status: 400 });
+        return new NextResponse("Webhook signature verification failed", { status: 400 });
     }
 
     try {
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
         }
     } catch (err: any) {
         console.error("Error handling Stripe event:", err);
-        return new NextResponse(`Webhook Error: ${err.message}`, { status: 500 });
+        return new NextResponse("Internal server error", { status: 500 });
     }
 
     return new NextResponse(null, { status: 200 });

--- a/app/dashboard/settings/notifications/page.tsx
+++ b/app/dashboard/settings/notifications/page.tsx
@@ -1,23 +1,209 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { Separator } from "@/components/ui/separator"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Mail, MessageSquare } from "lucide-react"
+import { Mail, MessageSquare, Loader2, Bot, Pencil } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
-
-export const dynamic = "force-dynamic"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import {
+    getNotificationPreferences,
+    saveNotificationPreferences,
+    type NotificationPreferences,
+} from "@/actions/notification-actions"
+import {
+    getAutomatedMessageRules,
+    updateAutomatedMessageRule,
+    type AutomatedMessageRuleView,
+} from "@/actions/automated-message-actions"
+import { toast } from "sonner"
 
 export default function NotificationsSettingsPage() {
+    const [prefs, setPrefs] = useState<NotificationPreferences | null>(null)
+    const [saving, setSaving] = useState(false)
+    const [rules, setRules] = useState<AutomatedMessageRuleView[]>([])
+    const [rulesLoading, setRulesLoading] = useState(true)
+    const [editingRule, setEditingRule] = useState<AutomatedMessageRuleView | null>(null)
+    const [editTemplate, setEditTemplate] = useState("")
+    const [editChannel, setEditChannel] = useState("sms")
+
+    useEffect(() => {
+        getNotificationPreferences().then(setPrefs).catch(() => {
+            setPrefs({
+                emailDealUpdates: true,
+                emailNewContacts: true,
+                emailWeeklySummary: true,
+                inAppTaskReminders: true,
+                inAppStaleDealAlerts: true,
+            })
+        })
+
+        getAutomatedMessageRules().then(setRules).finally(() => setRulesLoading(false))
+    }, [])
+
+    const updatePref = async (key: keyof NotificationPreferences, value: boolean) => {
+        if (!prefs) return
+        const updated = { ...prefs, [key]: value }
+        setPrefs(updated)
+        setSaving(true)
+        try {
+            await saveNotificationPreferences(updated)
+            toast.success("Notification preferences saved")
+        } catch {
+            toast.error("Failed to save preferences")
+            setPrefs(prefs)
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    const handleToggleRule = async (rule: AutomatedMessageRuleView) => {
+        const updated = !rule.enabled
+        setRules((prev) => prev.map((r) => r.id === rule.id ? { ...r, enabled: updated } : r))
+        try {
+            await updateAutomatedMessageRule(rule.id, { enabled: updated })
+            toast.success(updated ? "Rule enabled" : "Rule disabled")
+        } catch {
+            setRules((prev) => prev.map((r) => r.id === rule.id ? { ...r, enabled: rule.enabled } : r))
+            toast.error("Failed to update rule")
+        }
+    }
+
+    const handleSaveRuleEdit = async () => {
+        if (!editingRule) return
+        setSaving(true)
+        try {
+            await updateAutomatedMessageRule(editingRule.id, {
+                messageTemplate: editTemplate,
+                channel: editChannel,
+            })
+            setRules((prev) => prev.map((r) => r.id === editingRule.id ? { ...r, messageTemplate: editTemplate, channel: editChannel } : r))
+            toast.success("Message template saved")
+            setEditingRule(null)
+        } catch {
+            toast.error("Failed to save template")
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    const getTriggerLabel = (type: string) => {
+        switch (type) {
+            case "booking_reminder_24h": return "24h Before Booking"
+            case "booking_confirmation": return "On Booking Confirmed"
+            case "follow_up_after_job": return "24h After Job Complete"
+            default: return type
+        }
+    }
+
+    if (!prefs) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+        )
+    }
+
     return (
         <div className="space-y-6">
-            <div>
-                <h3 className="text-lg font-medium">Notifications</h3>
-                <p className="text-sm text-muted-foreground">
-                    Configure how you receive notifications.
-                </p>
+            <div className="flex items-center justify-between">
+                <div>
+                    <h3 className="text-lg font-medium">Notifications</h3>
+                    <p className="text-sm text-muted-foreground">
+                        Configure how you receive notifications.
+                    </p>
+                </div>
+                {saving && (
+                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                        <Loader2 className="h-3 w-3 animate-spin" /> Saving...
+                    </span>
+                )}
             </div>
             <Separator />
-            
+
             <div className="space-y-4">
+                {/* Automated Communication Rules */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                            <Bot className="h-5 w-5" />
+                            Automated Communication
+                        </CardTitle>
+                        <CardDescription>
+                            Set rules for automated text messages and emails sent by the AI agent. The agent will auto-send
+                            confirmations and reminders based on these rules.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        {rulesLoading ? (
+                            <div className="flex items-center justify-center py-8">
+                                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                            </div>
+                        ) : rules.length === 0 ? (
+                            <p className="text-sm text-muted-foreground text-center py-4">
+                                No automated rules configured yet.
+                            </p>
+                        ) : (
+                            rules.map((rule) => (
+                                <div key={rule.id} className="flex items-start justify-between p-4 rounded-xl border bg-slate-50/50">
+                                    <div className="space-y-1 flex-1 mr-4">
+                                        <div className="flex items-center gap-2">
+                                            <span className="font-medium text-sm">{rule.name}</span>
+                                            <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary font-medium">
+                                                {getTriggerLabel(rule.triggerType)}
+                                            </span>
+                                            <span className="text-xs px-2 py-0.5 rounded-full bg-slate-200 text-slate-600">
+                                                {rule.channel.toUpperCase()}
+                                            </span>
+                                        </div>
+                                        <p className="text-xs text-muted-foreground line-clamp-2 max-w-lg">
+                                            {rule.messageTemplate}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center gap-2 shrink-0">
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-8 w-8"
+                                            onClick={() => {
+                                                setEditingRule(rule)
+                                                setEditTemplate(rule.messageTemplate)
+                                                setEditChannel(rule.channel)
+                                            }}
+                                        >
+                                            <Pencil className="h-3.5 w-3.5" />
+                                        </Button>
+                                        <Switch
+                                            checked={rule.enabled}
+                                            onCheckedChange={() => handleToggleRule(rule)}
+                                        />
+                                    </div>
+                                </div>
+                            ))
+                        )}
+                        <p className="text-xs text-muted-foreground">
+                            Available template variables: {"{{clientName}}"}, {"{{jobTitle}}"}, {"{{scheduledTime}}"}, {"{{businessName}}"}
+                        </p>
+                    </CardContent>
+                </Card>
+
+                {/* Email Notifications */}
                 <Card>
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
@@ -34,25 +220,35 @@ export default function NotificationsSettingsPage() {
                                 <Label>Deal Updates</Label>
                                 <p className="text-sm text-muted-foreground">Get notified when deals are updated</p>
                             </div>
-                            <Switch defaultChecked />
+                            <Switch
+                                checked={prefs.emailDealUpdates}
+                                onCheckedChange={(v) => updatePref("emailDealUpdates", v)}
+                            />
                         </div>
                         <div className="flex items-center justify-between">
                             <div className="space-y-0.5">
                                 <Label>New Contacts</Label>
                                 <p className="text-sm text-muted-foreground">Get notified when new contacts are added</p>
                             </div>
-                            <Switch defaultChecked />
+                            <Switch
+                                checked={prefs.emailNewContacts}
+                                onCheckedChange={(v) => updatePref("emailNewContacts", v)}
+                            />
                         </div>
                         <div className="flex items-center justify-between">
                             <div className="space-y-0.5">
                                 <Label>Weekly Summary</Label>
                                 <p className="text-sm text-muted-foreground">Receive a weekly summary of your pipeline</p>
                             </div>
-                            <Switch defaultChecked />
+                            <Switch
+                                checked={prefs.emailWeeklySummary}
+                                onCheckedChange={(v) => updatePref("emailWeeklySummary", v)}
+                            />
                         </div>
                     </CardContent>
                 </Card>
 
+                {/* In-App Notifications */}
                 <Card>
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
@@ -69,18 +265,63 @@ export default function NotificationsSettingsPage() {
                                 <Label>Task Reminders</Label>
                                 <p className="text-sm text-muted-foreground">Show reminders for upcoming tasks</p>
                             </div>
-                            <Switch defaultChecked />
+                            <Switch
+                                checked={prefs.inAppTaskReminders}
+                                onCheckedChange={(v) => updatePref("inAppTaskReminders", v)}
+                            />
                         </div>
                         <div className="flex items-center justify-between">
                             <div className="space-y-0.5">
                                 <Label>Stale Deal Alerts</Label>
                                 <p className="text-sm text-muted-foreground">Alert when deals need attention</p>
                             </div>
-                            <Switch defaultChecked />
+                            <Switch
+                                checked={prefs.inAppStaleDealAlerts}
+                                onCheckedChange={(v) => updatePref("inAppStaleDealAlerts", v)}
+                            />
                         </div>
                     </CardContent>
                 </Card>
             </div>
+
+            {/* Edit Rule Dialog */}
+            <Dialog open={!!editingRule} onOpenChange={(open) => !open && setEditingRule(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Edit {editingRule?.name}</DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-4 py-2">
+                        <div className="space-y-2">
+                            <Label>Channel</Label>
+                            <Select value={editChannel} onValueChange={setEditChannel}>
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="sms">SMS</SelectItem>
+                                    <SelectItem value="email">Email</SelectItem>
+                                    <SelectItem value="both">Both</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-2">
+                            <Label>Message Template</Label>
+                            <Textarea
+                                value={editTemplate}
+                                onChange={(e) => setEditTemplate(e.target.value)}
+                                rows={5}
+                                className="font-mono text-sm"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Variables: {"{{clientName}}"}, {"{{jobTitle}}"}, {"{{scheduledTime}}"}, {"{{businessName}}"}
+                            </p>
+                        </div>
+                        <Button onClick={handleSaveRuleEdit} className="w-full" disabled={saving}>
+                            {saving ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Saving...</> : "Save Changes"}
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
         </div>
     )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -320,3 +320,12 @@
     border: none !important;
   }
 }
+
+/* Chat FAB gentle bounce animation */
+@keyframes bounce-gentle {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+.animate-bounce-gentle {
+  animation: bounce-gentle 2s ease-in-out 3;
+}

--- a/app/invite/join/page.tsx
+++ b/app/invite/join/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { Loader2, Users, Shield } from "lucide-react";
+import { validateInviteToken, acceptInvite } from "@/actions/invite-actions";
+import { toast } from "sonner";
+
+export default function JoinByInvitePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") || "";
+
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [inviteInfo, setInviteInfo] = useState<{
+    valid: boolean;
+    workspaceName?: string;
+    role?: string;
+  } | null>(null);
+
+  // Sign-up form state
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const supabase = createClient();
+
+  useEffect(() => {
+    if (!token) {
+      setError("No invite token provided.");
+      setLoading(false);
+      return;
+    }
+    validateInviteToken(token).then((result) => {
+      if (!result.valid) {
+        setError(result.error || "Invalid invite");
+      } else {
+        setInviteInfo(result);
+      }
+      setLoading(false);
+    });
+  }, [token]);
+
+  const handleJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setMessage("");
+
+    // Sign up with Supabase
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback?next=/dashboard`,
+        data: {
+          confirmed_at: new Date().toISOString(),
+          name: name || email.split("@")[0],
+        },
+      },
+    });
+
+    if (signUpError) {
+      setMessage(signUpError.message);
+      setSubmitting(false);
+      return;
+    }
+
+    // Auto sign-in
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (signInError) {
+      setMessage("Account created! Please sign in manually.");
+      setSubmitting(false);
+      return;
+    }
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      setMessage("Failed to get user after sign-up");
+      setSubmitting(false);
+      return;
+    }
+
+    // Accept the invite — this links the user to the workspace with the correct role
+    const result = await acceptInvite(token, user.id);
+    if (!result.success) {
+      setMessage(result.error || "Failed to accept invite");
+      setSubmitting(false);
+      return;
+    }
+
+    toast.success("Welcome to the team!");
+    router.push("/dashboard");
+    router.refresh();
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardContent className="p-8 text-center space-y-4">
+            <div className="h-12 w-12 mx-auto rounded-full bg-red-100 flex items-center justify-center">
+              <Shield className="h-6 w-6 text-red-600" />
+            </div>
+            <h2 className="text-xl font-bold text-midnight">Invalid Invite</h2>
+            <p className="text-muted-foreground">{error}</p>
+            <Button onClick={() => router.push("/auth")} variant="outline">
+              Go to Sign In
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const roleLabel =
+    inviteInfo?.role === "MANAGER" ? "Team Manager" : "Team Member";
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4 relative">
+      <div className="absolute inset-0 ott-glow -z-10" />
+
+      <div className="w-full max-w-md space-y-6">
+        {/* Header */}
+        <div className="text-center space-y-3">
+          <div className="h-12 w-12 mx-auto rounded-xl bg-primary flex items-center justify-center shadow-md shadow-primary/20">
+            <span className="text-white font-extrabold italic text-lg tracking-tighter">
+              Pj
+            </span>
+          </div>
+          <h1 className="text-2xl font-extrabold text-midnight tracking-tight">
+            Join {inviteInfo?.workspaceName}
+          </h1>
+          <div className="flex items-center justify-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">
+              You&apos;ve been invited as a <strong>{roleLabel}</strong>
+            </span>
+          </div>
+        </div>
+
+        <Card className="shadow-lg">
+          <CardContent className="p-6">
+            <form onSubmit={handleJoin} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="join-name" className="text-midnight font-semibold text-sm">
+                  Full Name
+                </Label>
+                <Input
+                  id="join-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="John Smith"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="join-email" className="text-midnight font-semibold text-sm">
+                  Email
+                </Label>
+                <Input
+                  id="join-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="join-password" className="text-midnight font-semibold text-sm">
+                  Password
+                </Label>
+                <Input
+                  id="join-password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Create a password"
+                  required
+                />
+              </div>
+              <Button
+                type="submit"
+                className="w-full"
+                size="lg"
+                disabled={submitting}
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Joining...
+                  </>
+                ) : (
+                  "Create Account & Join Team"
+                )}
+              </Button>
+            </form>
+
+            {message && (
+              <div className="mt-4 p-3 rounded-lg bg-red-50 text-red-600 text-sm text-center border border-red-100">
+                {message}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/chatbot/chat-interface.tsx
+++ b/components/chatbot/chat-interface.tsx
@@ -4,12 +4,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
-import { Send, Loader2, Sparkles, Clock, Calendar, FileText, Phone, Check, X, Mic } from 'lucide-react';
+import { Send, Loader2, Sparkles, Clock, Calendar, FileText, Phone, Check, X, Mic, Undo2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { getChatHistory, saveAssistantMessage, confirmJobDraft } from '@/actions/chat-actions';
+import { getChatHistory, saveAssistantMessage, confirmJobDraft, runUndoLastAction } from '@/actions/chat-actions';
 import { toast } from 'sonner';
 import { useSpeechRecognition } from '@/hooks/use-speech-recognition';
 
@@ -354,7 +354,20 @@ function ChatWithHistory({
                                 )}
                               >
                                 <Check className="w-4 h-4 shrink-0" />
-                                <span>{part.output.message}</span>
+                                <span className="flex-1">{part.output.message}</span>
+                                {isSuccess && workspaceId && (
+                                  <button
+                                    type="button"
+                                    onClick={async () => {
+                                      const result = await runUndoLastAction(workspaceId);
+                                      toast.info(result);
+                                    }}
+                                    className="ml-1 px-1.5 py-0.5 rounded text-[10px] bg-emerald-100 hover:bg-emerald-200 text-emerald-700 transition-colors flex items-center gap-0.5 shrink-0"
+                                    title="Undo this action"
+                                  >
+                                    <Undo2 className="w-3 h-3" /> Undo
+                                  </button>
+                                )}
                               </div>
                             );
                             return;

--- a/components/crm/contact-header.tsx
+++ b/components/crm/contact-header.tsx
@@ -1,15 +1,42 @@
 "use client"
 
+import { useState } from "react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
-import { Mail, Phone, MoreHorizontal, Edit } from "lucide-react"
+import { Mail, Phone, MoreHorizontal, Edit, MessageSquare, Bot } from "lucide-react"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator, DropdownMenuLabel } from "@/components/ui/dropdown-menu"
 import type { ContactView } from "@/actions/contact-actions"
+import { sendSMS } from "@/actions/messaging-actions"
+import { toast } from "sonner"
 
 interface ContactHeaderProps {
   contact: ContactView
 }
 
 export function ContactHeader({ contact }: ContactHeaderProps) {
+  const [smsOpen, setSmsOpen] = useState(false)
+  const [smsMessage, setSmsMessage] = useState("")
+  const [sending, setSending] = useState(false)
+
+  const handleSendSms = async () => {
+    if (!smsMessage.trim() || !contact.id) return
+    setSending(true)
+    try {
+      const result = await sendSMS(contact.id, smsMessage)
+      if (result.success) {
+        toast.success("SMS sent via Twilio")
+        setSmsMessage("")
+        setSmsOpen(false)
+      } else {
+        toast.error(result.error || "Failed to send SMS")
+      }
+    } catch {
+      toast.error("Failed to send SMS")
+    } finally {
+      setSending(false)
+    }
+  }
+
   return (
     <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 pb-6 border-b border-border/40">
       <div className="flex items-center gap-4">
@@ -26,14 +53,86 @@ export function ContactHeader({ contact }: ContactHeaderProps) {
       </div>
 
       <div className="flex items-center gap-2">
-        <Button variant="outline" size="sm" className="hover:bg-primary/5 hover:text-primary hover:border-primary/20 transition-all">
-          <Mail className="mr-2 h-4 w-4" />
-          Email
-        </Button>
-        <Button variant="outline" size="sm" className="hover:bg-primary/5 hover:text-primary hover:border-primary/20 transition-all">
-          <Phone className="mr-2 h-4 w-4" />
-          Call
-        </Button>
+        {/* Email - dropdown with native + agent options */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="hover:bg-primary/5 hover:text-primary hover:border-primary/20 transition-all">
+              <Mail className="mr-2 h-4 w-4" />
+              Email
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel className="text-xs">Email {contact.name}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {contact.email && (
+              <DropdownMenuItem asChild>
+                <a href={`mailto:${contact.email}`}>
+                  <Mail className="mr-2 h-4 w-4" />
+                  Open in email app
+                </a>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onClick={() => {
+              window.location.href = `/dashboard/inbox?contact=${contact.id}`
+            }}>
+              <Bot className="mr-2 h-4 w-4" />
+              Send via Agent (Resend)
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Call/Text - dropdown with native + agent options */}
+        <DropdownMenu open={smsOpen} onOpenChange={setSmsOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="hover:bg-primary/5 hover:text-primary hover:border-primary/20 transition-all">
+              <Phone className="mr-2 h-4 w-4" />
+              Call / Text
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-72">
+            <DropdownMenuLabel className="text-xs">Contact {contact.name}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {contact.phone && (
+              <>
+                <DropdownMenuItem asChild>
+                  <a href={`tel:${contact.phone}`}>
+                    <Phone className="mr-2 h-4 w-4" />
+                    Call from my phone
+                  </a>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <a href={`sms:${contact.phone}`}>
+                    <MessageSquare className="mr-2 h-4 w-4" />
+                    Text from my phone
+                  </a>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <div className="px-2 py-2">
+              <p className="text-xs font-medium text-muted-foreground mb-1.5 flex items-center gap-1">
+                <Bot className="h-3 w-3" /> Send SMS via Twilio
+              </p>
+              <textarea
+                className="w-full text-sm border border-input rounded-md px-2 py-1.5 bg-background resize-none focus:outline-none focus:ring-1 focus:ring-primary"
+                rows={2}
+                placeholder="Type your message..."
+                value={smsMessage}
+                onChange={(e) => setSmsMessage(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+              <Button
+                size="sm"
+                className="w-full mt-1.5 h-7 text-xs"
+                disabled={!smsMessage.trim() || sending}
+                onClick={handleSendSms}
+              >
+                {sending ? "Sending..." : "Send via Twilio"}
+              </Button>
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
         <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground">
           <Edit className="h-4 w-4" />
         </Button>

--- a/components/crm/contact-profile.tsx
+++ b/components/crm/contact-profile.tsx
@@ -3,8 +3,9 @@
 import { ContactView } from "@/actions/contact-actions"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
-import { Mail, Phone, Building2, Calendar, Edit, MapPin, Home } from "lucide-react"
+import { Mail, Phone, Building2, Calendar, Edit, MapPin, Home, MessageSquare, Bot } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 
 interface ContactProfileProps {
     contact: ContactView
@@ -58,14 +59,58 @@ export function ContactProfile({ contact }: ContactProfileProps) {
                                 <Edit className="w-4 h-4 mr-2" />
                                 Edit
                             </Button>
-                            <Button className="flex-1 md:flex-none">
-                                <Phone className="w-4 h-4 mr-2" />
-                                Call
-                            </Button>
-                            <Button className="flex-1 md:flex-none bg-primary hover:bg-primary/90 text-primary-foreground shadow-lg shadow-primary/20">
-                                <Mail className="w-4 h-4 mr-2" />
-                                Email
-                            </Button>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button className="flex-1 md:flex-none">
+                                        <Phone className="w-4 h-4 mr-2" />
+                                        Call / Text
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    {contact.phone && (
+                                        <>
+                                            <DropdownMenuItem asChild>
+                                                <a href={`tel:${contact.phone}`}>
+                                                    <Phone className="mr-2 h-4 w-4" /> Call from my phone
+                                                </a>
+                                            </DropdownMenuItem>
+                                            <DropdownMenuItem asChild>
+                                                <a href={`sms:${contact.phone}`}>
+                                                    <MessageSquare className="mr-2 h-4 w-4" /> Text from my phone
+                                                </a>
+                                            </DropdownMenuItem>
+                                            <DropdownMenuSeparator />
+                                        </>
+                                    )}
+                                    <DropdownMenuItem onClick={() => {
+                                        window.location.href = `/dashboard/inbox?contact=${contact.id}`
+                                    }}>
+                                        <Bot className="mr-2 h-4 w-4" /> Send SMS via Twilio
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button className="flex-1 md:flex-none bg-primary hover:bg-primary/90 text-primary-foreground shadow-lg shadow-primary/20">
+                                        <Mail className="w-4 h-4 mr-2" />
+                                        Email
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    {contact.email && (
+                                        <DropdownMenuItem asChild>
+                                            <a href={`mailto:${contact.email}`}>
+                                                <Mail className="mr-2 h-4 w-4" /> Open in email app
+                                            </a>
+                                        </DropdownMenuItem>
+                                    )}
+                                    <DropdownMenuItem onClick={() => {
+                                        window.location.href = `/dashboard/inbox?contact=${contact.id}`
+                                    }}>
+                                        <Bot className="mr-2 h-4 w-4" /> Send via Agent (Resend)
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
                         </div>
                     </div>
                 </div>

--- a/components/layout/Shell.tsx
+++ b/components/layout/Shell.tsx
@@ -190,7 +190,7 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
               <button
                 type="button"
                 onClick={() => setMobileChatOpen(true)}
-                className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 animate-bounce-gentle"
                 title="Open chat"
                 aria-label="Open chat"
               >
@@ -209,7 +209,7 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
                 chatbotPanelRef.current?.expand()
                 setChatbotExpanded(true)
               }}
-              className="hidden md:flex fixed bottom-5 right-5 z-[10000] h-11 w-11 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              className="hidden md:flex fixed bottom-5 right-5 z-[10000] h-11 w-11 items-center justify-center rounded-full border border-slate-200/80 bg-white shadow-lg hover:bg-slate-50 hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 animate-bounce-gentle"
               title="Open chat"
               aria-label="Open chat"
             >

--- a/components/layout/mobile-sidebar.tsx
+++ b/components/layout/mobile-sidebar.tsx
@@ -22,7 +22,7 @@ export function MobileSidebar() {
 
     return (
         <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-            <SheetContent side="left" className="p-0 w-[80px] border-r border-border bg-white">
+            <SheetContent side="left" className="p-0 w-[200px] border-r border-border bg-white">
                 <SheetHeader className="sr-only">
                     <SheetTitle>Navigation Menu</SheetTitle>
                 </SheetHeader>

--- a/components/modals/new-deal-modal.tsx
+++ b/components/modals/new-deal-modal.tsx
@@ -10,8 +10,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { createDeal } from "@/actions/deal-actions"
 import { getContacts, createContact, type ContactView } from "@/actions/contact-actions"
 import { toast } from "sonner"
-import { Plus, User, Mail, Phone, MapPin, AlertCircle } from "lucide-react"
+import { Plus, User, Mail, Phone, MapPin, AlertCircle, CalendarClock } from "lucide-react"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { AddressAutocomplete } from "@/components/ui/address-autocomplete"
 
 interface NewDealModalProps {
     isOpen: boolean
@@ -24,6 +25,7 @@ export function NewDealModal({ isOpen, onClose, workspaceId }: NewDealModalProps
     const [title, setTitle] = useState("")
     const [value, setValue] = useState("")
     const [address, setAddress] = useState("")
+    const [scheduledAt, setScheduledAt] = useState("")
     const [stage, setStage] = useState("new_request")
     const [contactId, setContactId] = useState("")
     const [contacts, setContacts] = useState<ContactView[]>([])
@@ -99,7 +101,8 @@ export function NewDealModal({ isOpen, onClose, workspaceId }: NewDealModalProps
                 contactId: finalContactId,
                 stage,
                 workspaceId,
-                address: address || undefined
+                address: address || undefined,
+                scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
             })
 
             if (result.success) {
@@ -107,6 +110,7 @@ export function NewDealModal({ isOpen, onClose, workspaceId }: NewDealModalProps
                 setTitle("")
                 setValue("")
                 setAddress("")
+                setScheduledAt("")
                 setStage("new_request")
                 setContactId("")
                 setNewContactName("")
@@ -176,13 +180,26 @@ export function NewDealModal({ isOpen, onClose, workspaceId }: NewDealModalProps
                             <Label htmlFor="address" className="text-right">
                                 Address
                             </Label>
-                            <div className="col-span-3 relative">
-                                <MapPin className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
-                                <Input
+                            <div className="col-span-3">
+                                <AddressAutocomplete
                                     id="address"
-                                    placeholder="123 Main St"
                                     value={address}
-                                    onChange={(e) => setAddress(e.target.value)}
+                                    onChange={setAddress}
+                                    placeholder="Start typing an address..."
+                                />
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-4 items-center gap-4">
+                            <Label htmlFor="scheduledAt" className="text-right">
+                                Schedule
+                            </Label>
+                            <div className="col-span-3 relative">
+                                <CalendarClock className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+                                <Input
+                                    id="scheduledAt"
+                                    type="datetime-local"
+                                    value={scheduledAt}
+                                    onChange={(e) => setScheduledAt(e.target.value)}
                                     className="pl-9"
                                 />
                             </div>

--- a/components/ui/address-autocomplete.tsx
+++ b/components/ui/address-autocomplete.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useRef, useEffect, useState, useCallback } from "react"
+import { useJsApiLoader } from "@react-google-maps/api"
+import { Input } from "@/components/ui/input"
+import { MapPin } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const LIBRARIES: ("places")[] = ["places"]
+
+interface AddressAutocompleteProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  className?: string
+  id?: string
+}
+
+export function AddressAutocomplete({
+  value,
+  onChange,
+  placeholder = "Start typing an address...",
+  className,
+  id,
+}: AddressAutocompleteProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null)
+  const [isFocused, setIsFocused] = useState(false)
+
+  const apiKey = typeof window !== "undefined"
+    ? (process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "")
+    : ""
+
+  const { isLoaded } = useJsApiLoader({
+    googleMapsApiKey: apiKey || "no-key",
+    libraries: LIBRARIES,
+  })
+
+  const handlePlaceChanged = useCallback(() => {
+    const place = autocompleteRef.current?.getPlace()
+    if (place?.formatted_address) {
+      onChange(place.formatted_address)
+    } else if (place?.name) {
+      onChange(place.name)
+    }
+  }, [onChange])
+
+  useEffect(() => {
+    if (!isLoaded || !inputRef.current || !apiKey || autocompleteRef.current) return
+
+    const autocomplete = new google.maps.places.Autocomplete(inputRef.current, {
+      types: ["address"],
+      componentRestrictions: { country: "au" },
+      fields: ["formatted_address", "name", "geometry"],
+    })
+
+    autocomplete.addListener("place_changed", handlePlaceChanged)
+    autocompleteRef.current = autocomplete
+
+    return () => {
+      google.maps.event.clearInstanceListeners(autocomplete)
+    }
+  }, [isLoaded, apiKey, handlePlaceChanged])
+
+  // Fallback to plain input if no API key
+  if (!apiKey) {
+    return (
+      <div className={cn("relative", className)}>
+        <MapPin className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+        <Input
+          id={id}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("relative", className)}>
+      <MapPin className={cn(
+        "absolute left-2.5 top-2.5 h-4 w-4 transition-colors",
+        isFocused ? "text-primary" : "text-slate-400"
+      )} />
+      <Input
+        ref={inputRef}
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        className="pl-9"
+      />
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,7 +122,8 @@ model User {
   bio         String?
   urls        Json?     // Stores array of { value: string }
   hasOnboarded Boolean  @default(false)
-  
+  role        UserRole  @default(OWNER)
+
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id])
   activities  Activity[]
@@ -463,6 +464,53 @@ enum TriggerEvent {
   JOB_COMPLETE
   ON_MY_WAY
   LATE
+  BOOKING_REMINDER_24H
+}
+
+// ─── Team Roles & Invites ───────────────────────────────────────────
+
+enum UserRole {
+  OWNER
+  MANAGER
+  TEAM_MEMBER
+}
+
+model WorkspaceInvite {
+  id          String    @id @default(cuid())
+  token       String    @unique @default(cuid())
+  email       String?
+  role        UserRole  @default(TEAM_MEMBER)
+
+  workspaceId String
+  invitedById String
+
+  acceptedAt  DateTime?
+  expiresAt   DateTime
+
+  createdAt   DateTime  @default(now())
+
+  @@index([token])
+  @@index([workspaceId])
+}
+
+// ─── Automated Communication Rules ─────────────────────────────────
+
+model AutomatedMessageRule {
+  id              String    @id @default(cuid())
+  name            String
+  enabled         Boolean   @default(true)
+  triggerType     String    // "booking_reminder_24h", "booking_confirmation", "follow_up_after_job", "no_show_alert"
+  channel         String    @default("sms") // "sms", "email", "both"
+  messageTemplate String    @db.Text
+
+  hoursOffset     Int       @default(-24) // negative = before event, positive = after event
+
+  workspaceId     String
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@index([workspaceId])
 }
 
 model SmsTemplate {


### PR DESCRIPTION
…ool-use refactor

- Add UserRole enum (OWNER/MANAGER/TEAM_MEMBER) and role field to User model
- Add WorkspaceInvite model for invite link-based team onboarding
- Add invite join page at /invite/join?token=xxx for team member sign-up
- Rebuild team management page with real DB data, invite creation dialog, and pending invite management
- Add AutomatedMessageRule model for configurable automated SMS/email rules
- Add automated communication settings UI in notifications settings page
- Add booking reminder cron endpoint at /api/cron/booking-reminders
- Seed default rules: 24h booking reminder, booking confirmation, post-job follow-up
- Refactor AI agent from context stuffing to tool-use (just-in-time retrieval)
- Remove getNext7DaysSchedule and getLast50Messages injection from system prompt
- Keep BusinessProfile and WorkspaceSettings as static context in system prompt
- Add 6 new agent tools: getSchedule, searchJobHistory, getFinancialReport, getClientContext, getTodaySummary, getAvailability
- Update system prompt to instruct model to use tools for data retrieval instead of guessing

https://claude.ai/code/session_01DDjerWHdA7vZ7x66DLdLnH