### PR TITLE
fix: cast settings JSON to satisfy Prisma InputJsonValue type

### DIFF
--- a/actions/notification-actions.ts
+++ b/actions/notification-actions.ts
@@ -137,7 +137,7 @@ export async function saveNotificationPreferences(prefs: NotificationPreferences
   await db.workspace.update({
     where: { id: user.workspaceId },
     data: {
-      settings: { ...currentSettings, notificationPreferences: prefs },
+      settings: { ...currentSettings, notificationPreferences: { ...prefs } } as Record<string, unknown>,
     },
   })
 


### PR DESCRIPTION
Prisma's Json field rejects typed interfaces directly because they lack an index signature. Spread prefs into a plain object and cast the whole settings value as Record<string, unknown>.

https://claude.ai/code/session_01DDjerWHdA7vZ7x66DLdLnH