### PR TITLE
fix: use JSON roundtrip for Prisma Json field compatibility

### DIFF
--- a/actions/notification-actions.ts
+++ b/actions/notification-actions.ts
@@ -137,7 +137,7 @@ export async function saveNotificationPreferences(prefs: NotificationPreferences
   await db.workspace.update({
     where: { id: user.workspaceId },
     data: {
-      settings: { ...currentSettings, notificationPreferences: { ...prefs } } as Record<string, unknown>,
+      settings: JSON.parse(JSON.stringify({ ...currentSettings, notificationPreferences: prefs })),
     },
   })
 


### PR DESCRIPTION
Record<string, unknown> isn't assignable to Prisma's InputJsonValue. Use JSON.parse(JSON.stringify(...)) to produce a clean plain object that satisfies the Json field type constraint.

https://claude.ai/code/session_01DDjerWHdA7vZ7x66DLdLnH