### PR TITLE
fix: add missing BOOKING_REMINDER_24H to TriggerEvent maps

### DIFF
--- a/actions/sms-templates.ts
+++ b/actions/sms-templates.ts
@@ -12,6 +12,8 @@ const DEFAULT_TEMPLATES: Record<TriggerEvent, string> = {
     "Hi [Name], thanks for today! A review helps us heaps: [Link]",
   ON_MY_WAY: "Hi [Name], I'm 20 mins away.",
   LATE: "Hi [Name], stuck in traffic. 15 mins late.",
+  BOOKING_REMINDER_24H:
+    "Hi [Name], just a reminder you have a booking tomorrow.",
 };
 
 // ─── Get all templates for current user ─────────────────────────────
@@ -24,7 +26,7 @@ export async function getUserSmsTemplates() {
   });
 
   // Fill in defaults for any missing triggers
-  const events: TriggerEvent[] = ["JOB_COMPLETE", "ON_MY_WAY", "LATE"];
+  const events: TriggerEvent[] = ["JOB_COMPLETE", "ON_MY_WAY", "LATE", "BOOKING_REMINDER_24H"];
   return events.map((event) => {
     const existing = templates.find((t) => t.triggerEvent === event);
     return {

--- a/app/dashboard/settings/sms-templates/sms-templates-form.tsx
+++ b/app/dashboard/settings/sms-templates/sms-templates-form.tsx
@@ -7,7 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { upsertSmsTemplate } from "@/actions/sms-templates";
 import { toast } from "sonner";
-import { MessageSquare, Navigation, Clock, Loader2, Save } from "lucide-react";
+import { MessageSquare, Navigation, Clock, Bell, Loader2, Save } from "lucide-react";
 import type { TriggerEvent } from "@prisma/client";
 
 interface Template {
@@ -36,6 +36,11 @@ const TRIGGER_META: Record<TriggerEvent, { label: string; description: string; i
     label: "Running Late",
     description: "Quick heads-up when you're stuck in traffic.",
     icon: Clock,
+  },
+  BOOKING_REMINDER_24H: {
+    label: "Booking Reminder (24h)",
+    description: "Sent 24 hours before a scheduled booking.",
+    icon: Bell,
   },
 };
 


### PR DESCRIPTION
The Prisma enum TriggerEvent gained BOOKING_REMINDER_24H but the DEFAULT_TEMPLATES record, events array, and TRIGGER_META record were not updated, causing Record<TriggerEvent, ...> type errors at build.

https://claude.ai/code/session_01DDjerWHdA7vZ7x66DLdLnH