### PR TITLE
feat: add self-hosted LiveKit voice agent to replace Retell AI

### DIFF
--- a/app/api/retell/README.md
+++ b/app/api/retell/README.md
@@ -1,0 +1,20 @@
+# LEGACY — Retell AI Voice Agent Integration
+
+These files are the original Retell AI voice agent integration, preserved as a backup.
+The voice agent has been migrated to a self-hosted LiveKit agent (see `/livekit-agent/`).
+
+## Files in this directory
+
+- `webhook/route.ts` — Post-call event handler (activity logging, deal stage updates)
+- `tools/calendar/route.ts` — Calendar availability tool used during live calls
+
+## Related files outside this directory
+
+- `scripts/create-retell-agent.ts` — Script to create the Retell agent
+- `lib/retell-voice-agent.md` — Retell voice agent documentation
+
+## How to revert to Retell
+
+1. Re-enable the `RETELL_*` environment variables
+2. Point Twilio SIP trunk back to Retell instead of LiveKit
+3. Restore the Retell agent ID in workspace settings

--- a/livekit-agent/.env.example
+++ b/livekit-agent/.env.example
@@ -1,0 +1,13 @@
+# LiveKit Server
+LIVEKIT_URL=wss://your-livekit-server.example.com
+LIVEKIT_API_KEY=your_api_key
+LIVEKIT_API_SECRET=your_api_secret
+
+# Deepgram (Speech-to-Text)
+DEEPGRAM_API_KEY=your_deepgram_key
+
+# Groq (LLM — OpenAI-compatible)
+GROQ_API_KEY=your_groq_key
+
+# Cartesia (Text-to-Speech)
+CARTESIA_API_KEY=your_cartesia_key

--- a/livekit-agent/README.md
+++ b/livekit-agent/README.md
@@ -1,0 +1,60 @@
+# Earlymark LiveKit Voice Agent
+
+Self-hosted voice AI receptionist for the Earlymark CRM, powered by [LiveKit Agents](https://docs.livekit.io/agents/).
+
+This is a standalone Python microservice that runs alongside the main Next.js CRM app.
+
+## Stack
+
+| Component | Provider | Model |
+|-----------|----------|-------|
+| STT | Deepgram | nova-3 |
+| LLM | Groq | llama-4-maverick-17b-instruct |
+| TTS | Cartesia | sonic-english |
+| VAD | Silero | — |
+
+## Prerequisites
+
+- Python 3.11+
+- A running [LiveKit server](https://docs.livekit.io/home/self-hosting/local/) (self-hosted or LiveKit Cloud)
+- SIP trunk configured to route Twilio calls to LiveKit (see [LiveKit SIP docs](https://docs.livekit.io/sip/))
+- API keys for Deepgram, Groq, and Cartesia
+
+## Setup
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Configure environment
+cp .env.example .env.local
+# Edit .env.local with your API keys
+
+# 3. Run in development mode (auto-reload)
+python agent.py dev
+
+# 4. Run in production
+python agent.py start
+```
+
+## Architecture
+
+```
+Twilio → SIP Trunk → LiveKit Server → This Agent
+                                          ├── Deepgram (STT)
+                                          ├── Groq (LLM + tool calls)
+                                          └── Cartesia (TTS)
+```
+
+Inbound calls flow through Twilio's SIP trunk to a LiveKit room. This agent joins the room, transcribes speech, processes it through the LLM (with CRM tool access), and responds with synthesized speech.
+
+## CRM Integration (TODO)
+
+The `check_availability` and `update_lead` tools are currently mocked. To connect them to the real CRM:
+
+1. **Option A**: HTTP calls to the Next.js API routes
+2. **Option B**: Direct Supabase/PostgreSQL queries from Python
+
+## Reverting to Retell
+
+The original Retell AI integration is preserved in the main app at `app/api/retell/`. See the README there for revert instructions.

--- a/livekit-agent/agent.py
+++ b/livekit-agent/agent.py
@@ -1,0 +1,180 @@
+"""
+Earlymark LiveKit Voice Agent
+=============================
+Self-hosted voice AI receptionist for Earlymark CRM.
+
+Uses LiveKit Agents v1.0 with:
+- Deepgram (STT) — nova-3
+- Groq (LLM) — llama-4-maverick-17b-instruct via OpenAI-compatible API
+- Cartesia (TTS) — sonic-english
+- Silero (VAD)
+
+Run in development:  python agent.py dev
+Run in production:   python agent.py start
+"""
+
+import logging
+from enum import Enum
+from typing import Annotated
+
+from dotenv import load_dotenv
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    AutoSubscribe,
+    JobContext,
+    JobProcess,
+    WorkerOptions,
+    cli,
+    function_tool,
+)
+from livekit.plugins import cartesia, deepgram, openai, silero
+
+load_dotenv(dotenv_path=".env.local")
+logger = logging.getLogger("earlymark-agent")
+
+
+# ── Data: Simulated DB lookup ──────────────────────────────────────────────────
+
+
+async def get_user_context(phone_number: str) -> dict:
+    """
+    Simulates a database lookup based on the inbound Twilio number.
+
+    In production, replace this with an HTTP call to the Next.js API
+    or a direct Supabase/Prisma query to load per-workspace settings.
+    """
+    logger.info("Loading user context for phone_number=%s", phone_number)
+    return {
+        "business_name": "Michael's Plumbing",
+        "voice_id": "248be419-3632-4f38-9bed-47dc10c62d19",
+    }
+
+
+# ── Enums ──────────────────────────────────────────────────────────────────────
+
+
+class KanbanAction(str, Enum):
+    move_to_new = "move_to_new"
+    move_to_quote_sent = "move_to_quote_sent"
+    move_to_scheduled = "move_to_scheduled"
+
+
+# ── The Agent (with tools as methods) ──────────────────────────────────────────
+
+
+SYSTEM_PROMPT_TEMPLATE = """\
+You are the friendly and professional AI receptionist for {business_name}.
+Your goal is to answer questions, capture details from new leads, and help schedule jobs.
+
+TOOLS:
+- Use 'check_availability' when the user asks for dates.
+- CRITICAL: At the end of the call, you MUST use the 'update_lead' tool to save the \
+'contact_name' and the 'kanban_action'.
+
+KANBAN LOGIC:
+- If they just asked a question -> 'move_to_new'
+- If you sent a quote -> 'move_to_quote_sent'
+- If you booked a time -> 'move_to_scheduled'
+
+Be conversational but concise."""
+
+
+class EarlymarkReceptionist(Agent):
+    def __init__(self, business_name: str) -> None:
+        self._business_name = business_name
+        super().__init__(
+            instructions=SYSTEM_PROMPT_TEMPLATE.format(business_name=business_name),
+        )
+
+    @function_tool
+    async def check_availability(self, date: str) -> str:
+        """Check appointment availability for a given date."""
+        logger.info("check_availability called for date=%s", date)
+        # TODO: Replace with real calendar lookup via Next.js API or Supabase
+        return f"We have slots at 10am and 2pm on {date}."
+
+    @function_tool
+    async def update_lead(
+        self,
+        contact_name: str,
+        kanban_action: Annotated[
+            KanbanAction,
+            "The pipeline action: move_to_new, move_to_quote_sent, or move_to_scheduled",
+        ],
+    ) -> str:
+        """Updates the lead status in the CRM at the end of the call."""
+        logger.info(
+            "update_lead: contact=%s action=%s", contact_name, kanban_action.value
+        )
+        # TODO: Replace with real CRM update via Next.js API or Supabase
+        return f"Lead '{contact_name}' updated to '{kanban_action.value}'."
+
+    async def on_enter(self) -> None:
+        """Zero-latency greeting fired as soon as the agent joins the room."""
+        self.session.generate_reply(
+            instructions=f"Greet the caller: G'day, {self._business_name} speaking. How can I help?",
+            allow_interruptions=True,
+        )
+
+
+# ── Prewarm: load VAD model once per worker process ───────────────────────────
+
+
+def prewarm(proc: JobProcess) -> None:
+    proc.userdata["vad"] = silero.VAD.load()
+
+
+# ── Entrypoint ─────────────────────────────────────────────────────────────────
+
+
+async def entrypoint(ctx: JobContext) -> None:
+    await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
+    participant = await ctx.wait_for_participant()
+
+    # Extract SIP identity — the Twilio subaccount number that was dialed
+    sip_to_user = (participant.attributes or {}).get("sip.toUser", "")
+    inbound_number = sip_to_user or participant.identity
+    logger.info(
+        "Inbound number: %s, participant: %s",
+        inbound_number,
+        participant.identity,
+    )
+
+    # Load business-specific context (voice, prompt, etc.)
+    user_ctx = await get_user_context(inbound_number)
+    business_name = user_ctx["business_name"]
+    voice_id = user_ctx["voice_id"]
+
+    # ── The "God Stack" configuration ──────────────────────────────────────
+    session = AgentSession(
+        stt=deepgram.STT(model="nova-3", smart_format=True, endpointing=200),
+        llm=openai.LLM.with_groq(
+            model="llama-4-maverick-17b-instruct",
+            temperature=0.6,
+        ),
+        tts=cartesia.TTS(
+            model="sonic-english",
+            voice=voice_id,
+            speed=1.05,
+            emotion=["positivity:high", "curiosity:medium"],
+        ),
+        vad=ctx.proc.userdata["vad"],
+        allow_interruptions=True,
+    )
+
+    await session.start(
+        room=ctx.room,
+        agent=EarlymarkReceptionist(business_name=business_name),
+    )
+
+
+# ── CLI runner ─────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    cli.run_app(
+        WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            prewarm_fnc=prewarm,
+        ),
+    )

--- a/livekit-agent/requirements.txt
+++ b/livekit-agent/requirements.txt
@@ -1,0 +1,6 @@
+livekit-agents>=1.0,<2.0
+livekit-plugins-deepgram>=1.0,<2.0
+livekit-plugins-openai>=1.0,<2.0
+livekit-plugins-cartesia>=1.0,<2.0
+livekit-plugins-silero>=1.0,<2.0
+python-dotenv>=1.0


### PR DESCRIPTION
Adds a standalone Python microservice (livekit-agent/) using LiveKit Agents v1.0 with the "God Stack" — Deepgram STT, Groq LLM, Cartesia TTS, Silero VAD.

Includes CRM tool stubs (check_availability, update_lead) with kanban pipeline actions, SIP identity extraction for multi-tenant routing, and zero-latency greeting. Retell integration files are preserved and labeled as legacy.

https://claude.ai/code/session_01UXC593VmMunjdrpAMe7iio