### PR TITLE
Reduce Travis chatbox latency by cutting ~40% input tokens

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -506,7 +506,7 @@ export async function POST(req: Request) {
 
     // Context pruning: keep only the last MAX_HISTORY_MESSAGES to avoid unbounded
     // token growth and rising latency/cost. System messages always pass through.
-    const MAX_HISTORY_MESSAGES = 20;
+    const MAX_HISTORY_MESSAGES = 12;
     if (modelMessages.length > MAX_HISTORY_MESSAGES) {
       const systemMsgs = modelMessages.filter((m: any) => m.role === "system");
       const nonSystemMsgs = modelMessages.filter((m: any) => m.role !== "system");
@@ -532,9 +532,8 @@ export async function POST(req: Request) {
       return createUIMessageStreamResponse({ stream });
     }
 
-    const multiJobInstruction = useMultiJobFlow
-      ? `\n\nMULTIPLE JOBS — CRITICAL: The user has pasted multiple jobs in one message. You MUST process them ONE AT A TIME. First call showJobDraftForConfirmation with ONLY the first job's details (clientName, workDescription, price, address, schedule, phone, email). Then say clearly: "This is the first one. Confirm and I'll create it, then we'll do the next." Do NOT call createJobNatural until the user has confirmed. After the user confirms (e.g. "confirm", "ok", "yes", "done"), call createJobNatural for that job, then call showJobDraftForConfirmation for the NEXT job. Repeat until all jobs are done.`
-      : "";
+    // multiJobInstruction removed — the multi-job early-return (lines above)
+    // handles this before streamText is reached, so it was always "".
 
     let toolCallsMs = 0;
     const tools = instrumentToolsWithLatency(
@@ -547,8 +546,8 @@ export async function POST(req: Request) {
     const llmStartedAt = nowMs();
     const result = streamText({
       model: google(CHAT_MODEL_ID as "gemini-2.0-flash-lite"),
-      system: `You are Travis, a concise CRM assistant for tradies. Keep responses SHORT and punchy — tradies are busy. No essays. Use "jobs" not "meetings".
-${multiJobInstruction}
+      maxTokens: 1024,
+      system: `You are Travis, a concise CRM assistant for tradies. Be SHORT and punchy — no essays. Say "jobs" not "meetings".
 ${knowledgeBaseStr}
 ${agentModeStr}
 ${workingHoursStr}
@@ -559,64 +558,17 @@ ${pricingRulesStr}
 ${bouncerStr}
 ${memoryContextStr}
 
-MESSAGING RULES — CRITICAL:
-1. When the user says "message X", "text X", "tell X", "send X a message" — IMMEDIATELY call the sendSms tool. Do NOT ask for confirmation. Just send it.
-2. Send EXACTLY what the user says. Never refuse to send a message because it's "not professional" or informal. If the user says "tell Jody JK NVM", send "JK NVM".
-3. Keep conversation context. If the user mentions a person's name, and later says "message her" or "text him", use the most recently discussed person.
-4. After sending, briefly confirm: "✅ Sent to [Name]: \"[message]\"" — format the message in quotes so it stands out.
-5. Never rewrite or "improve" the user's message content unless explicitly asked to.
-6. Always check the output of the previous tool. If it contains a SYSTEM_CONTEXT_SIGNAL, follow that instruction for the immediate next turn.
+MESSAGING: On "message/text/tell/send [name]" → call sendSms immediately, no confirmation. Send the user's EXACT words — never rewrite or refuse. Track pronouns ("her"/"him") from context. Confirm: "✅ Sent to [Name]: \"[msg]\"". Follow any SYSTEM_CONTEXT_SIGNAL from tool output.
 
-IMPORTANT: You have access to tools for checking the schedule, job history, finances, and client details. If a user asks a question you don't have the answer to in your immediate context, USE THE TOOLS. Do not guess. Always call the appropriate tool to retrieve real data before answering.
+USE TOOLS for real data — never guess. Call the appropriate tool before answering data questions.
 
-UNCERTAINTY & ERROR HANDLING — CRITICAL:
-When you don't understand, aren't sure, or encounter problems, follow these rules:
+WHEN UNCERTAIN: Never return blank. Ask to clarify if unclear. List options if ambiguous. Request missing info. If tool fails, explain and suggest retry. If no data, say what you checked. For getTodaySummary, LEAD with preparation alerts before the schedule.
 
-1. UNCLEAR INTENT: If you don't understand what the user wants, say: "I'm not sure what you'd like me to do. Could you clarify? For example, you could say 'Schedule a job for John tomorrow' or 'Show me this week's jobs'."
+USER_ROLE: ${userRole}. Data changes: OWNER/MANAGER confirm via showConfirmationCard → recordManualRevenue after user says "confirm"/"ok"/"yes". TEAM_MEMBER cannot change data — tell them to ask their manager.
 
-2. AMBIGUOUS COMMAND: If a request could mean multiple things, ask for clarification: "I can interpret this a few ways:
-• Option 1: [interpretation]
-• Option 2: [interpretation]  
-Which did you mean?"
+MULTI-JOB "NEXT": Always use showJobDraftForConfirmation tool (never plain text). One job at a time. Don't call createJobNatural until user confirms.
 
-3. MISSING INFORMATION: If you need more details to complete a task: "To [do action], I need a bit more info:
-• [missing info 1]
-• [missing info 2]
-Could you provide these?"
-
-4. CONTACT NAME MISMATCH: If you can't find a contact, the tools will suggest similar names. Never return blank responses.
-
-5. OUT OF SCOPE: If the user asks for something you can't do: "I can't [do specific thing], but I can help you with [related things I can do]. Would any of those work?"
-
-6. TECHNICAL ERRORS: If a tool fails: "I ran into an issue [brief description]. This might be because [possible reason]. Want to try again, or should I log this for support?"
-
-7. VAGUE REQUESTS: If the request is too vague: "I want to help, but I need more specifics. Could you tell me [what you need to know]?"
-
-8. ALWAYS RESPOND: Never return empty/blank responses. Always provide helpful guidance even when uncertain.
-9. DATA RETRIEVAL FAILURE: If tools return no data: "I checked [what you checked] but didn't find [what you expected]. This could mean [possible explanations]. What would you like to do?"
-
-10. USER_ROLE: ${userRole}. DATA CORRECTIONS (manager-only): Only OWNER and MANAGER can confirm changes to data (revenue, job/customer details). If USER_ROLE is TEAM_MEMBER: when the user says something is wrong (e.g. "I made $200 in February"), do NOT offer to update it. Say: "Only your team manager or owner can update that. Ask them to make the change or to confirm it." If USER_ROLE is OWNER or MANAGER: when the user says data is wrong, offer to update it and say they can confirm by typing **confirm** (or "ok", "agree", "yes", or any positive reply) or by clicking the Confirm button. Then call the showConfirmationCard tool with a short summary (e.g. "Update February revenue to $200") so the user sees a Confirm button. When the user replies with "confirm", "ok", "agree", "yes", or any clear positive affirmation, call recordManualRevenue. Only call recordManualRevenue after the user has confirmed.
-
-TOOLS — DATA RETRIEVAL (use these to look up information on demand):
-- getSchedule: Fetches jobs for a date range. ALWAYS call this when the user asks about their schedule, availability, or upcoming/past appointments. Also use before scheduling new jobs to check for conflicts and nearby jobs for smart routing.
-- searchJobHistory: Search past jobs by keyword (client name, address, description). Use for "When did I last visit X?", "Jobs at Y address", or any historical question.
-- getFinancialReport: Revenue, job counts, and completion rates for a date range. Use for "How much did I earn?", "Monthly revenue?", "How many jobs this quarter?"
-- showConfirmationCard: Show a Confirm/Cancel button for a data change. Call when you offer to update data so the user can click Confirm or type ok/agree/yes/confirm.
-- recordManualRevenue: Record revenue for a period. Call ONLY after the user has confirmed (typed confirm, ok, agree, yes, or clicked Confirm).
-- getClientContext: Full client profile — contact info, recent jobs, notes, messages. Use for "Tell me about X", "What's the history with Y?", or before contacting a client.
-- getTodaySummary: PREPARATION-FOCUSED daily briefing. Returns today's jobs with readiness checks (missing address, no phone, unassigned, unconfirmed, deposit not paid, materials needed). Use for "What's on today?", "Morning brief", "Am I ready?". CRITICAL: When presenting results, LEAD with preparation alerts (e.g. "Heads up: 2 jobs need attention before you head out") and list specific issues so the tradie can fix them. Then show the schedule.
-- getAvailability: Check available time slots on a specific day. Use for "Am I free on Tuesday?", "What slots are open next Monday?", "When can I fit in a job?"
-- getConversationHistory: Retrieve text/call/email history with a specific contact.
-- createNotification: Create a scheduled notification or reminder alert.
-- updateAiPreferences: Save a permanent behavioral rule. Use when the user gives a lasting instruction like "From now on, always add a 1 hour buffer" or "Remember I don't work past 3pm on Fridays". Also use when the user says "Stop taking jobs for X" — prefix with [HARD_CONSTRAINT] to strictly decline or [FLAG_ONLY] to just flag.
-- addAgentFlag: Add a private triage warning to a deal. Use when you have concerns about a lead (far distance, tire-kicker, risky) but it does NOT match a hard No-Go rule. The flag appears on the owner's dashboard.
-- undoLastAction: Undo the most recent action. Use when the user says "Undo that" or "Revert the last change".
-- assignTeamMember: Assign a team member to a job. Use when the user says "Assign Dave to the Henderson job" or "Put Sarah on the plumbing repair".
-- contactSupport: Create a support ticket when the user asks for help, reports issues, or needs assistance.
-
-MULTI-JOB FOLLOW-UP — CRITICAL: When the user replies with "Next" or "next job please" in a thread where a job draft was shown ("first one" or "one at a time"), you MUST call the showJobDraftForConfirmation tool with the NEXT job's details (clientName, workDescription, price, address, schedule, phone, email from the user's original message). Do NOT output the job as plain text or bullet points (e.g. "* Client: Bob * Work: ..."). The user must see a draft CARD with Confirm/Cancel buttons. Call the tool, then you may add one short line like "Here's the next one — confirm or cancel." Do NOT call createJobNatural for the job they just confirmed or cancelled; only call showJobDraftForConfirmation for the next job. Repeat until all jobs are shown as draft cards.
-
-After any tool, briefly confirm in a friendly way. If a tool fails, say so and suggest what to try. Never return empty responses.`,
+After tool use, briefly confirm the result.`,
       messages: modelMessages as any,
       tools,
       stopWhen: stepCountIs(getAdaptiveMaxSteps(content)),

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -44,14 +44,12 @@ import { buildJobDraftFromParams } from "@/lib/chat-utils";
 export function getAgentTools(workspaceId: string, settings: any, userId?: string) {
     return {
         listDeals: tool({
-            description:
-                "List all deals/jobs in the pipeline. Use when the user asks to see deals, pipeline, jobs, or what they have. Returns id, title, stage, value for each deal.",
+            description: "List all jobs in the pipeline (id, title, stage, value).",
             inputSchema: z.object({}),
             execute: async () => runListDeals(workspaceId),
         }),
         moveDeal: tool({
-            description:
-                "Move a deal to a different stage. Use deal title (from listDeals if unsure) and target stage: completed, quoted, scheduled, in progress, new request, pipeline, ready to invoice, deleted.",
+            description: "Move a job to a different stage (completed, quoted, scheduled, in progress, new request, pipeline, ready to invoice, deleted).",
             inputSchema: z.object({
                 dealTitle: z.string().describe("Name/title of the deal or job to move"),
                 newStage: z.string().describe("Target stage name"),
@@ -60,8 +58,7 @@ export function getAgentTools(workspaceId: string, settings: any, userId?: strin
                 runMoveDeal(workspaceId, dealTitle.trim(), newStage.trim()),
         }),
         createDeal: tool({
-            description:
-                "Create a new deal. Requires title; optional company/client name and value (number).",
+            description: "Create a new deal/job.",
             inputSchema: z.object({
                 title: z.string().describe("Deal or job title"),
                 company: z.string().optional().describe("Client or company name"),
@@ -71,30 +68,28 @@ export function getAgentTools(workspaceId: string, settings: any, userId?: strin
                 runCreateDeal(workspaceId, { title, company, value }),
         }),
         createJobNatural: tool({
-            description:
-                "Create a job from a one-liner: extract clientName, workDescription, price; optional address, schedule, phone, email. REQUIRED when the user pastes a single message describing a job (person + work + optional address/time/price/phone). Always extract the client's phone number if included. Always pass schedule when a date or time is mentioned so the job goes to the Scheduled column.",
+            description: "Create a job from natural language. Always extract phone if included. Pass schedule when date/time is mentioned.",
             inputSchema: z.object({
-                clientName: z.string().describe("Client full name (first and last)"),
+                clientName: z.string().describe("Client full name"),
                 workDescription: z.string().describe("What work is needed"),
                 price: z.number().describe("Price in dollars"),
-                address: z.string().optional().describe("Street address for the job"),
-                schedule: z.string().optional().describe("When e.g. tomorrow 2pm"),
-                phone: z.string().optional().describe("Client phone number if provided (e.g. 0434955958 or +61434955958)"),
-                email: z.string().optional().describe("Client email if provided"),
+                address: z.string().optional().describe("Street address"),
+                schedule: z.string().optional().describe("When, e.g. tomorrow 2pm"),
+                phone: z.string().optional().describe("Client phone number"),
+                email: z.string().optional().describe("Client email"),
             }),
             execute: async (params) => runCreateJobNatural(workspaceId, params),
         }),
         showJobDraftForConfirmation: tool({
-            description:
-                "REQUIRED when showing any job in a multi-job flow. Shows a draft CARD with Confirm/Cancel buttons — the user must see this card, not a text description. When the user says 'Next' or you are showing the 2nd, 3rd, etc. job from their list: call this tool with that job's clientName, workDescription, price, address, schedule, phone, email (extract from the user's original message). Do NOT reply with bullet points like '* Client: X * Work: Y' — that is wrong. Always call this tool so the UI displays the draft card. After the user confirms the card, they will send 'Next' and you call this tool again for the next job.",
+            description: "Show a draft CARD with Confirm/Cancel buttons. REQUIRED for multi-job flows — never use plain text for job details.",
             inputSchema: z.object({
-                clientName: z.string().describe("Client full name (first and last)"),
+                clientName: z.string().describe("Client full name"),
                 workDescription: z.string().describe("What work is needed"),
                 price: z.number().describe("Price in dollars"),
-                address: z.string().optional().describe("Street address for the job"),
-                schedule: z.string().optional().describe("When e.g. tomorrow 2pm"),
-                phone: z.string().optional().describe("Client phone number if provided"),
-                email: z.string().optional().describe("Client email if provided"),
+                address: z.string().optional().describe("Street address"),
+                schedule: z.string().optional().describe("When, e.g. tomorrow 2pm"),
+                phone: z.string().optional().describe("Client phone number"),
+                email: z.string().optional().describe("Client email"),
             }),
             execute: async (params) => {
                 const draft = buildJobDraftFromParams({
@@ -110,134 +105,131 @@ export function getAgentTools(workspaceId: string, settings: any, userId?: strin
             },
         }),
         proposeReschedule: tool({
-            description:
-                "Propose a new time for an existing job. Use when the user says to propose a different time (e.g. after a clash warning, or 'let's schedule at 3pm instead'). Logs the proposed time, adds a note, and creates a task to contact the customer to confirm.",
+            description: "Propose a new time for an existing job. Logs the time, adds a note, creates a follow-up task.",
             inputSchema: z.object({
-                dealTitle: z.string().describe("Job/deal title (e.g. Plumbing Replacement, or the client/job name)"),
-                proposedSchedule: z.string().describe("The new proposed time, e.g. tomorrow 3pm, Tuesday 10am"),
+                dealTitle: z.string().describe("Job/deal title"),
+                proposedSchedule: z.string().describe("New proposed time, e.g. tomorrow 3pm"),
             }),
             execute: async ({ dealTitle, proposedSchedule }) =>
                 runProposeReschedule(workspaceId, { dealTitle, proposedSchedule }),
         }),
         updateInvoiceAmount: tool({
-            description: "Update the final invoiced amount for a job. Use this when the user mentions invoicing a job or changing the invoice amount.",
+            description: "Update the final invoiced amount for a job.",
             inputSchema: z.object({
                 dealTitle: z.string().describe("Job/deal title to invoice"),
-                amount: z.number().describe("The final invoiced amount as a number"),
+                amount: z.number().describe("Final invoiced amount"),
             }),
             execute: async ({ dealTitle, amount }) =>
                 runUpdateInvoiceAmount(workspaceId, { dealTitle, amount }),
         }),
         updateAiPreferences: tool({
-            description: "Use this when the user gives you a permanent instruction about how you should behave, quote, or schedule in the future (e.g., 'From now on, always add a 1 hour buffer', 'Remember I dont work past 3pm on Fridays'). Also use when the user says 'Stop taking jobs for X' — prefix the rule with [HARD_CONSTRAINT] to strictly decline, or [FLAG_ONLY] to just flag for review.",
+            description: "Save a permanent behavioral rule. Prefix [HARD_CONSTRAINT] to strictly decline or [FLAG_ONLY] to just flag.",
             inputSchema: z.object({
-                rule: z.string().describe("The specific behavioral rule to save permanently. Prefix with [HARD_CONSTRAINT] for strict decline rules or [FLAG_ONLY] for flag-only preferences."),
+                rule: z.string().describe("The rule to save. Prefix with [HARD_CONSTRAINT] or [FLAG_ONLY]."),
             }),
             execute: async ({ rule }) => runUpdateAiPreferences(workspaceId, rule),
         }),
         logActivity: tool({
-            description: "Record a call, meeting, note, or email explicitly. Use when the user says 'Log a call with John' or 'Note down that the pipe was broken'.",
+            description: "Record a call, meeting, note, or email.",
             inputSchema: z.object({
-                type: z.enum(["CALL", "EMAIL", "NOTE", "MEETING", "TASK"]).describe("The type of activity to record"),
-                content: z.string().describe("What happened or what the note is about"),
+                type: z.enum(["CALL", "EMAIL", "NOTE", "MEETING", "TASK"]).describe("Activity type"),
+                content: z.string().describe("What happened"),
             }),
             execute: async ({ type, content }) => runLogActivity({ type, content }),
         }),
         createTask: tool({
-            description: "Create a reminder or to-do task. Use when the user says 'Remind me tomorrow to order pipes' or 'Task: check up on Mary'.",
+            description: "Create a reminder or to-do task.",
             inputSchema: z.object({
-                title: z.string().describe("The name or title of the task"),
-                dueAtISO: z.string().optional().describe("ISO date string for when the task is due. Default is tomorrow 9am if omitted."),
-                description: z.string().optional().describe("Optional extra details about the task"),
+                title: z.string().describe("Task title"),
+                dueAtISO: z.string().optional().describe("ISO due date. Default: tomorrow 9am."),
+                description: z.string().optional().describe("Extra details"),
             }),
             execute: async (params) => runCreateTask(params),
         }),
         searchContacts: tool({
-            description: "Look up people or companies in the database CRM. Use when the user asks 'Find John Doe' or 'Search my contacts for Acme Corp'.",
+            description: "Look up contacts by name or keyword in the CRM.",
             inputSchema: z.object({
-                query: z.string().describe("The name or keyword to search for"),
+                query: z.string().describe("Name or keyword to search"),
             }),
             execute: async ({ query }) => runSearchContacts(workspaceId, query),
         }),
         createContact: tool({
-            description: "Add a new person or company to the database CRM explicitly.",
+            description: "Add a new contact to the CRM.",
             inputSchema: z.object({
-                name: z.string().describe("The contact's full name or company name"),
-                email: z.string().optional().describe("The contact's email address"),
-                phone: z.string().optional().describe("The contact's phone number"),
+                name: z.string().describe("Full name or company name"),
+                email: z.string().optional().describe("Email address"),
+                phone: z.string().optional().describe("Phone number"),
             }),
             execute: async (params) => runCreateContact(workspaceId, params),
         }),
         sendSms: tool({
-            description: "Send an SMS text message to a contact. Use when the user says 'Text Steven I'm on my way' or 'Send a message to Mary saying we'll be there at 3pm'. Finds the contact by name and sends via their phone number.",
+            description: "Send an SMS to a contact by name. Finds the contact and sends via their phone.",
             inputSchema: z.object({
-                contactName: z.string().describe("Name of the contact to text"),
-                message: z.string().describe("The SMS message to send"),
+                contactName: z.string().describe("Contact name"),
+                message: z.string().describe("SMS message to send"),
             }),
             execute: async ({ contactName, message }) =>
                 runSendSms(workspaceId, { contactName, message }),
         }),
         sendEmail: tool({
-            description: "Send an email to a contact. Use when the user says 'Email Mary the quote' or 'Send John an email confirming his appointment'. Finds the contact by name and uses their email address.",
+            description: "Send an email to a contact by name.",
             inputSchema: z.object({
-                contactName: z.string().describe("Name of the contact to email"),
-                subject: z.string().describe("Email subject line"),
-                body: z.string().describe("Email body content"),
+                contactName: z.string().describe("Contact name"),
+                subject: z.string().describe("Email subject"),
+                body: z.string().describe("Email body"),
             }),
             execute: async ({ contactName, subject, body }) =>
                 runSendEmail(workspaceId, { contactName, subject, body }),
         }),
         makeCall: tool({
-            description: "Initiate an outbound phone call to a contact via the AI voice agent (Retell AI). Use when the user says 'Call John', 'Ring Mary about the quote', or 'Phone Steven to confirm'. The AI voice agent will handle the conversation.",
+            description: "Initiate an outbound phone call via the AI voice agent.",
             inputSchema: z.object({
-                contactName: z.string().describe("Name of the contact to call"),
-                purpose: z.string().optional().describe("Brief purpose of the call, e.g. 'confirm appointment for Thursday' or 'follow up on quote'"),
+                contactName: z.string().describe("Contact name"),
+                purpose: z.string().optional().describe("Brief call purpose"),
             }),
             execute: async ({ contactName, purpose }) =>
                 runMakeCall(workspaceId, { contactName, purpose }),
         }),
         getConversationHistory: tool({
-            description: "Retrieve text/call/email history with a specific contact. Use when the user asks 'Show me my texts with Steven' or 'What's my history with Mary?' or 'Show me my conversation with John'.",
+            description: "Get text/call/email history with a specific contact.",
             inputSchema: z.object({
-                contactName: z.string().describe("Name of the contact to look up history for"),
-                limit: z.number().optional().describe("How many recent items to return (default 20)"),
+                contactName: z.string().describe("Contact name"),
+                limit: z.number().optional().describe("Max items to return (default 20)"),
             }),
             execute: async ({ contactName, limit }) =>
                 runGetConversationHistory(workspaceId, { contactName, limit }),
         }),
         createNotification: tool({
-            description: "Create a scheduled notification or reminder alert. Use when the user says 'Notify me 2 days before Wendy's job' or 'Alert me Friday if John hasn't responded' or 'Remind me to follow up with the plumber'.",
+            description: "Create a scheduled notification or reminder alert.",
             inputSchema: z.object({
-                title: z.string().describe("Short notification title"),
-                message: z.string().describe("Notification details/body"),
-                scheduledAtISO: z.string().optional().describe("ISO date for when to trigger (e.g. 2026-02-25T09:00:00). Omit for immediate."),
-                link: z.string().optional().describe("Optional URL to navigate to when clicked"),
+                title: z.string().describe("Notification title"),
+                message: z.string().describe("Notification details"),
+                scheduledAtISO: z.string().optional().describe("ISO date to trigger. Omit for immediate."),
+                link: z.string().optional().describe("URL to open when clicked"),
             }),
             execute: async (params) =>
                 runCreateScheduledNotification(workspaceId, params),
         }),
         undoLastAction: tool({
-            description: "Undo the most recent action. Use when the user says 'Undo that', 'Revert', 'Take that back', or 'Oops undo'. Reverses the last deal creation, stage move, or other reversible action.",
+            description: "Undo the most recent action (deal creation, stage move, etc.).",
             inputSchema: z.object({}),
             execute: async () => runUndoLastAction(workspaceId),
         }),
         assignTeamMember: tool({
-            description: "Assign a team member to a job/deal. Use when the user says 'Assign Dave to the Henderson job', 'Put Sarah on the plumbing repair', or 'Give the roof job to Mike'. Fuzzy-matches both the job title and team member name.",
+            description: "Assign a team member to a job. Fuzzy-matches job title and member name.",
             inputSchema: z.object({
-                dealTitle: z.string().describe("The job/deal title or description to assign"),
-                teamMemberName: z.string().describe("The team member's name (or email) to assign the job to"),
+                dealTitle: z.string().describe("Job/deal title"),
+                teamMemberName: z.string().describe("Team member name or email"),
             }),
             execute: async ({ dealTitle, teamMemberName }) =>
                 runAssignTeamMember(workspaceId, { dealTitle, teamMemberName }),
         }),
         contactSupport: tool({
-            description: "Create a support ticket when the user asks for help, reports issues, or needs assistance. Use for phrases like 'I need help', 'support', 'contact support', 'something is broken', 'phone number not working', 'billing issue', etc. Automatically categorizes and prioritizes the request.",
+            description: "Create a support ticket for user issues or help requests.",
             inputSchema: z.object({
-                message: z.string().describe("The user's support request or issue description"),
+                message: z.string().describe("Support request description"),
             }),
             execute: async ({ message }) => {
-                // Note: Since auth may run in a webhook context, passing userId is safer than
-                // relying purely on Next.js headers/cookies when not available.
                 let activeUserId = userId;
                 if (!activeUserId) {
                     const { getAuthUserId } = await import("@/lib/auth");
@@ -248,87 +240,87 @@ export function getAgentTools(workspaceId: string, settings: any, userId?: strin
             },
         }),
         appendTicketNote: tool({
-            description: "Appends details to an existing ticket. Use this ONLY when the user adds information immediately after a ticket creation event.",
+            description: "Append details to an existing support ticket.",
             inputSchema: z.object({
-                ticketId: z.string().describe("Existing support ticket ID"),
-                noteContent: z.string().describe("Additional details to append to the ticket"),
+                ticketId: z.string().describe("Support ticket ID"),
+                noteContent: z.string().describe("Details to append"),
             }),
             execute: async ({ ticketId, noteContent }) =>
                 runAppendTicketNote({ ticketId, noteContent }),
         }),
 
         addAgentFlag: tool({
-            description: "Add a triage flag/warning to a deal. Use this when you have concerns about a lead (e.g. far distance, potential tire-kicker, high-risk location) but the job does NOT match a hard No-Go rule. The flag will appear on the owner's dashboard for review.",
+            description: "Add a private triage flag to a deal for owner review. Use for concerns that don't match No-Go rules.",
             inputSchema: z.object({
-                dealTitle: z.string().describe("Title of the deal to flag"),
-                flag: z.string().describe("Short warning note (e.g. 'Far away — 45km', 'Potential tire-kicker', 'High-risk location')"),
+                dealTitle: z.string().describe("Deal title to flag"),
+                flag: z.string().describe("Short warning note"),
             }),
             execute: async ({ dealTitle, flag }) =>
                 runAddAgentFlag(workspaceId, { dealTitle, flag }),
         }),
 
-        // ─── Phase 2: Just-in-Time Retrieval Tools ──────────────────────
+        // ─── Just-in-Time Retrieval Tools ──────────────────────
         getSchedule: tool({
-            description: "Fetches scheduled jobs for a specific date range. Use this when the user asks 'What am I doing next week?', 'Do I have space on Tuesday?', 'What's my schedule for March?', or any question about upcoming or past appointments. Also use before scheduling new jobs to check for conflicts and nearby jobs for smart geolocation routing.",
+            description: "Fetch jobs for a date range. Use for schedule questions and to check conflicts before new jobs.",
             inputSchema: z.object({
-                startDate: z.string().describe("Start of date range as ISO string (e.g. 2026-02-21T00:00:00)"),
-                endDate: z.string().describe("End of date range as ISO string (e.g. 2026-02-28T23:59:59)"),
+                startDate: z.string().describe("Range start (ISO string)"),
+                endDate: z.string().describe("Range end (ISO string)"),
             }),
             execute: async ({ startDate, endDate }) =>
                 runGetSchedule(workspaceId, { startDate, endDate }),
         }),
         searchJobHistory: tool({
-            description: "Searches for past jobs (completed, cancelled, or any status) based on keywords. Use for queries like 'When was the last time I visited Mrs. Jones?', 'Jobs at 10 Henderson St', 'Have I done work for Acme Corp before?', or any question about past job history.",
+            description: "Search past jobs by keyword (client name, address, description).",
             inputSchema: z.object({
-                query: z.string().describe("Search keywords — client name, address, or job description"),
-                limit: z.number().optional().describe("Max results to return (default 5)"),
+                query: z.string().describe("Search keywords"),
+                limit: z.number().optional().describe("Max results (default 5)"),
             }),
             execute: async ({ query, limit }) =>
                 runSearchJobHistory(workspaceId, { query, limit }),
         }),
         getFinancialReport: tool({
-            description: "Calculates revenue, job count, and completion rates for a date range. Use when the user asks 'How much did I earn this month?', 'What's my revenue for February?', 'How many jobs did I complete last quarter?', or any financial/performance question.",
+            description: "Revenue, job counts, and completion rates for a date range.",
             inputSchema: z.object({
-                startDate: z.string().describe("Start of date range as ISO string"),
-                endDate: z.string().describe("End of date range as ISO string"),
+                startDate: z.string().describe("Range start (ISO string)"),
+                endDate: z.string().describe("Range end (ISO string)"),
             }),
             execute: async ({ startDate, endDate }) =>
                 runGetFinancialReport(workspaceId, { startDate, endDate }),
         }),
         showConfirmationCard: tool({
-            description: "Show a Confirm button so the user can approve a data change (e.g. update revenue). Call this when you offer to update data and want the user to confirm. Pass a short summary of what will change.",
+            description: "Show Confirm/Cancel button for a data change. Pass a short summary.",
             inputSchema: z.object({
-                summary: z.string().describe("Short summary of the change, e.g. 'Update February revenue to $200'"),
+                summary: z.string().describe("Short change summary"),
             }),
             execute: async ({ summary }) => ({ showConfirmButton: true, summary }),
         }),
         recordManualRevenue: tool({
-            description: "Record manual revenue for a period. Call ONLY after the user has confirmed (typed 'confirm', 'ok', 'agree', 'yes', or clicked Confirm). Use the amount and date range the user originally gave.",
+            description: "Record revenue for a period. Call ONLY after user confirms.",
             inputSchema: z.object({
                 amount: z.number().describe("Revenue amount in dollars"),
-                startDate: z.string().describe("Start of period as ISO string (e.g. 2026-02-01T00:00:00)"),
-                endDate: z.string().describe("End of period as ISO string (e.g. 2026-02-28T23:59:59)"),
+                startDate: z.string().describe("Period start (ISO string)"),
+                endDate: z.string().describe("Period end (ISO string)"),
             }),
             execute: async ({ amount, startDate, endDate }) =>
                 recordManualRevenue(workspaceId, { amount, startDate, endDate }),
         }),
         getClientContext: tool({
-            description: "Fetches a complete profile for a specific client: their contact info, recent jobs, notes, and message history. Use when the user asks 'Tell me about Mrs. Jones', 'What's the history with John Smith?', 'Pull up Steven's details', or needs context about a client before a call/visit.",
+            description: "Full client profile: contact info, recent jobs, notes, messages.",
             inputSchema: z.object({
-                clientName: z.string().describe("The client name to look up (fuzzy matched)"),
+                clientName: z.string().describe("Client name (fuzzy matched)"),
             }),
             execute: async ({ clientName }) =>
                 runGetClientContext(workspaceId, { clientName }),
         }),
         getTodaySummary: tool({
-            description: "Daily briefing with preparation checks. Returns today's jobs with readiness flags (missing address, no phone, unassigned, unconfirmed, deposit not paid, materials needed). Use for 'What's on today?', 'Morning brief', 'Am I ready for today?', or when the user opens the chat. IMPORTANT: When presenting the briefing, lead with any preparation alerts so the tradie can fix issues BEFORE heading out.",
+            description: "Today's jobs with readiness checks (missing address/phone, unassigned, etc.). Lead with alerts.",
             inputSchema: z.object({}),
             execute: async () => runGetTodaySummary(workspaceId),
         }),
         getAvailability: tool({
-            description: "Check available time slots on a specific date given existing scheduled jobs and working hours. Use for 'Am I free on Tuesday?', 'What slots are open next Monday?', 'When can I fit in a job this week?'.",
+            description: "Check available time slots on a specific date.",
             inputSchema: z.object({
-                date: z.string().describe("The target date as ISO string (e.g. 2026-02-25)"),
+                date: z.string().describe("Target date (ISO string)"),
             }),
             execute: async ({ date }) =>
                 runGetAvailability(workspaceId, {

--- a/lib/services/ai-agent.ts
+++ b/lib/services/ai-agent.ts
@@ -87,7 +87,7 @@ export async function processAgentCommand(userId: string, message: string): Prom
         } = agentContext;
         const preprocessingMs = nowMs() - preprocessingStartedAt;
 
-        const systemPrompt = `You are Travis, a concise CRM assistant for tradies. Keep responses SHORT and punchy — tradies are busy. No essays. Use "jobs" not "meetings".
+        const systemPrompt = `You are Travis, a concise CRM assistant for tradies. Be SHORT and punchy — no essays. Say "jobs" not "meetings".
 ${knowledgeBaseStr}
 ${agentModeStr}
 ${workingHoursStr}
@@ -97,18 +97,9 @@ ${preferencesStr}
 ${pricingRulesStr}
 ${memoryContextStr}
 
-MESSAGING RULES — CRITICAL:
-1. When the user says "message X", "text X", "tell X", "send X a message" — IMMEDIATELY call the sendSms tool. Do NOT ask for confirmation. Just send it.
-2. After sending, briefly confirm: "✅ Sent to [Name]: \"[message]\"" — format the message in quotes so it stands out.
-3. Keep conversation context. If the user mentions a person's name, and later says "message her" or "text him", use the most recently discussed person.
+MESSAGING: On "message/text/tell/send [name]" → call sendSms immediately, no confirmation. Send EXACT words. Confirm: "✅ Sent to [Name]: \"[msg]\"". Track pronouns from context.
 
-IMPORTANT: You have access to tools for checking the schedule, job history, finances, and client details. If a user asks a question you don't have the answer to in your immediate context, USE THE TOOLS. Do not guess.
-
-UNCERTAINTY & ERROR HANDLING — CRITICAL:
-When you don't understand, aren't sure, or encounter problems, follow these rules:
-1. NEVER guess or make up a command.
-2. Tell the user clearly what went wrong (e.g. "I can't find a job with that name" or "I'm not sure what you mean by 'flibbertigibbet'").
-3. Suggest a corrective action (e.g. "Did you mean the plumbing job?" or "Try saying 'Create job for [Name]'").`;
+USE TOOLS for real data — never guess. If uncertain, say what went wrong and suggest a correction.`;
 
         const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
         if (!apiKey) {


### PR DESCRIPTION
- Compress system prompt: remove redundant TOOLS—DATA RETRIEVAL section (duplicated tool definitions), condense UNCERTAINTY handling from 10 verbose points to 3 lines, tighten MESSAGING rules
- Remove dead multiJobInstruction code (always "" due to early-return)
- Compress all 27 tool descriptions (~45% shorter, same semantics)
- Compress context strings: bouncer rules, agent script, pricing rules
- Reduce MAX_HISTORY_MESSAGES 20→12 (cuts conversation token load)
- Add maxTokens: 1024 to bound output generation time
- Apply same prompt compression to headless agent (ai-agent.ts)

https://claude.ai/code/session_014XCsEaSQWc9nRpLEYp3zx5