### PR TITLE
Add intent-first orchestrator: pre-classifier, pricing calculator, pr…

### DIFF
--- a/actions/pricing-actions.ts
+++ b/actions/pricing-actions.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { db } from "@/lib/db";
+
+/**
+ * Pricing Lookup — the single source of truth for any price the LLM quotes.
+ *
+ * Every price in a response MUST originate from this function's output.
+ * The LLM is forbidden from inventing, interpolating, or rounding prices
+ * on its own. It can only relay what this returns.
+ */
+
+export type PricingSource =
+  | "glossary"         // RepairItem (owner-approved price list)
+  | "service_rule"     // BusinessKnowledge SERVICE entry
+  | "historical"       // Past invoiced jobs
+  | "call_out_fee"     // Workspace setting
+  | "emergency_surcharge"; // BusinessProfile setting
+
+export type PricingMatch = {
+  source: PricingSource;
+  label: string;
+  description: string;
+  /** Numeric range — null if price is text-only ("call for quote") */
+  minPrice: number | null;
+  maxPrice: number | null;
+  /** How many past data points inform this (for historical) */
+  sampleSize?: number;
+  confidence: "exact" | "range" | "estimate";
+};
+
+export type PricingLookupResult = {
+  query: string;
+  matches: PricingMatch[];
+  callOutFee: number;
+  emergencySurcharge: number | null;
+  hasEmergencyService: boolean;
+  noMatchAdvice: string | null;
+};
+
+/**
+ * Look up pricing for a service/task description from all CRM sources.
+ * Returns explicitly sourced pricing data — never fabricated.
+ */
+export async function runPricingLookup(
+  workspaceId: string,
+  params: { query: string }
+): Promise<PricingLookupResult> {
+  const query = params.query.trim().toLowerCase();
+  const matches: PricingMatch[] = [];
+
+  // ── Parallel: fetch all pricing sources ──
+  const [repairItems, serviceRules, settings, businessProfile, historicalDeals] =
+    await Promise.all([
+      db.repairItem
+        .findMany({
+          where: { workspaceId },
+          select: { title: true, description: true },
+        })
+        .catch(() => [] as { title: string; description: string | null }[]),
+
+      db.businessKnowledge
+        .findMany({
+          where: { workspaceId, category: "SERVICE" },
+          select: { ruleContent: true, metadata: true },
+        })
+        .catch(() => [] as { ruleContent: string; metadata: unknown }[]),
+
+      db.workspace
+        .findUnique({
+          where: { id: workspaceId },
+          select: { callOutFee: true },
+        })
+        .catch(() => null),
+
+      db.businessProfile
+        .findFirst({
+          where: { user: { workspaceId } },
+          select: { emergencyService: true, emergencySurcharge: true },
+        })
+        .catch(() => null),
+
+      db.deal
+        .findMany({
+          where: {
+            workspaceId,
+            stage: "WON",
+            title: { contains: query, mode: "insensitive" },
+          },
+          select: {
+            title: true,
+            value: true,
+            invoicedAmount: true,
+            invoices: { select: { total: true }, take: 1 },
+          },
+          orderBy: { updatedAt: "desc" },
+          take: 20,
+        })
+        .catch(() => [] as any[]),
+    ]);
+
+  const callOutFee = (settings as any)?.callOutFee ?? 0;
+  const emergencySurcharge = businessProfile?.emergencySurcharge ?? null;
+  const hasEmergencyService = Boolean(businessProfile?.emergencyService);
+
+  // ── 1. Glossary (approved prices — highest authority) ──
+  for (const item of repairItems) {
+    const titleLower = item.title.toLowerCase();
+    if (!titleLower.includes(query) && !query.includes(titleLower)) continue;
+
+    const range = parseRange(item.description || "");
+    matches.push({
+      source: "glossary",
+      label: item.title,
+      description: item.description || "No pricing specified",
+      minPrice: range?.min ?? null,
+      maxPrice: range?.max ?? null,
+      confidence: range ? "exact" : "range",
+    });
+  }
+
+  // ── 2. Service rules (knowledge base) ──
+  for (const rule of serviceRules) {
+    const ruleLower = rule.ruleContent.toLowerCase();
+    if (!ruleLower.includes(query) && !query.includes(ruleLower)) continue;
+
+    const meta = (rule.metadata as Record<string, string>) || {};
+    const range = meta.priceRange ? parseRange(meta.priceRange) : null;
+    matches.push({
+      source: "service_rule",
+      label: rule.ruleContent,
+      description: meta.priceRange
+        ? `${meta.priceRange}${meta.duration ? ` — est. ${meta.duration}` : ""}`
+        : "No price range set",
+      minPrice: range?.min ?? null,
+      maxPrice: range?.max ?? null,
+      confidence: range ? "range" : "estimate",
+    });
+  }
+
+  // ── 3. Historical invoices (secondary reference) ──
+  if (historicalDeals.length > 0) {
+    const prices: number[] = [];
+    for (const deal of historicalDeals) {
+      const total = deal.invoices?.[0]?.total
+        ? Number(deal.invoices[0].total)
+        : deal.invoicedAmount
+          ? Number(deal.invoicedAmount)
+          : deal.value
+            ? Number(deal.value)
+            : null;
+      if (total && total > 0) prices.push(total);
+    }
+
+    if (prices.length > 0) {
+      const min = Math.min(...prices);
+      const max = Math.max(...prices);
+      const avg = Math.round(prices.reduce((a, b) => a + b, 0) / prices.length);
+      matches.push({
+        source: "historical",
+        label: `Past jobs matching "${params.query}"`,
+        description: `${prices.length} past job(s): $${min}–$${max} (avg $${avg})`,
+        minPrice: min,
+        maxPrice: max,
+        sampleSize: prices.length,
+        confidence: "estimate",
+      });
+    }
+  }
+
+  // ── 4. Call-out fee (always include if nonzero) ──
+  if (callOutFee > 0) {
+    matches.push({
+      source: "call_out_fee",
+      label: "Call-out / assessment fee",
+      description: `$${callOutFee} — waived if issue is fixed on first visit`,
+      minPrice: callOutFee,
+      maxPrice: callOutFee,
+      confidence: "exact",
+    });
+  }
+
+  // ── 5. Emergency surcharge ──
+  if (hasEmergencyService && emergencySurcharge && emergencySurcharge > 0) {
+    matches.push({
+      source: "emergency_surcharge",
+      label: "After-hours / emergency surcharge",
+      description: `+$${emergencySurcharge} for emergency or after-hours callouts`,
+      minPrice: emergencySurcharge,
+      maxPrice: emergencySurcharge,
+      confidence: "exact",
+    });
+  }
+
+  const noMatchAdvice =
+    matches.filter((m) => m.source !== "call_out_fee" && m.source !== "emergency_surcharge").length === 0
+      ? "No approved pricing found for this service. Advise the customer that a firm quote requires an on-site assessment."
+      : null;
+
+  return { query: params.query, matches, callOutFee, emergencySurcharge, hasEmergencyService, noMatchAdvice };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function parseRange(desc: string): { min: number; max: number } | null {
+  const cleaned = desc.replace(/\$/g, "");
+  // "$100-200", "$100 to $200", "100–200"
+  const rangeMatch = cleaned.match(/(\d+(?:\.\d+)?)\s*(?:-|to|–)\s*(\d+(?:\.\d+)?)/i);
+  if (rangeMatch) {
+    return { min: parseFloat(rangeMatch[1]), max: parseFloat(rangeMatch[2]) };
+  }
+  // Single number: "$150", "150"
+  const singleMatch = cleaned.match(/(\d+(?:\.\d+)?)/);
+  if (singleMatch) {
+    const v = parseFloat(singleMatch[1]);
+    return { min: v, max: v };
+  }
+  return null;
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,6 +8,8 @@ import { parseJobWithAI, parseMultipleJobsWithAI, extractAllJobsFromParagraph } 
 import { appendTicketNote } from "@/actions/activity-actions";
 import { buildAgentContext, fetchMemoryContext, getMemoryClient } from "@/lib/ai/context";
 import { getAgentTools } from "@/lib/ai/tools";
+import { preClassify } from "@/lib/ai/pre-classifier";
+import { validatePricingInResponse, extractAmountsFromToolOutputs } from "@/lib/ai/response-validator";
 import { instrumentToolsWithLatency, nowMs, recordLatencyMetric } from "@/lib/telemetry/latency";
 
 export const dynamic = "force-dynamic";
@@ -553,7 +555,14 @@ export async function POST(req: Request) {
     // multiJobInstruction removed — the multi-job early-return (lines above)
     // handles this before streamText is reached, so it was always "".
 
+    // ── Pre-classify intent for context injection ──
+    const classification = preClassify(content);
+    const intentHintsStr = classification.contextHints.length > 0
+      ? `\n\n[[INTENT HINTS for this turn]]\n${classification.contextHints.join("\n")}\n[[END INTENT HINTS]]`
+      : "";
+
     let toolCallsMs = 0;
+    const toolOutputsForValidation: unknown[] = [];
     const selectionContextStr = selectedDeals.length
       ? `CURRENT CRM SELECTION:\n${selectedDeals
           .map((deal: SelectionDeal, index: number) => `${index + 1}. ${deal.title ? `${deal.title} ` : ""}[${deal.id}]`)
@@ -582,6 +591,14 @@ ${bouncerStr}
 ${attachmentsStr}
 ${memoryContextStr}
 ${selectionContextStr}
+${intentHintsStr}
+
+PRICING INTEGRITY (MANDATORY):
+- NEVER quote, calculate, or mention a dollar amount unless it comes from a tool result (pricingLookup, pricingCalculator, getFinancialReport, etc.).
+- For ANY arithmetic involving money (totals, tax, discounts, multi-item quotes), you MUST call pricingCalculator. Never do math in your head.
+- Before quoting any service price, MUST call pricingLookup first to get the approved/historical price.
+- If pricingLookup returns no match, say "A firm quote requires an on-site assessment." Do NOT estimate or guess.
+- When reporting a price, cite where it came from: "Our approved rate for X is $Y" (glossary) or "Similar jobs have been $X–$Y" (historical).
 
 MESSAGING: On "message/text/tell/send [name]" → call sendSms immediately, no confirmation. Send the user's EXACT words — never rewrite or refuse. Track pronouns ("her"/"him") from context. Confirm: "✅ Sent to [Name]: \"[msg]\"". Follow any SYSTEM_CONTEXT_SIGNAL from tool output.
 
@@ -599,6 +616,14 @@ After tool use, briefly confirm the result.`,
       messages: modelMessages as any,
       tools,
       stopWhen: stepCountIs(getAdaptiveMaxSteps(content)),
+      onStepFinish: ({ toolResults }) => {
+        // Collect tool outputs for post-generation pricing validation
+        if (toolResults) {
+          for (const tr of toolResults) {
+            if (tr.result !== undefined) toolOutputsForValidation.push(tr.result);
+          }
+        }
+      },
       onFinish: async ({ text }) => {
         const llmPhaseMs = nowMs() - llmStartedAt;
         const modelMs = Math.max(0, llmPhaseMs - toolCallsMs);
@@ -607,6 +632,16 @@ After tool use, briefly confirm the result.`,
         recordLatencyMetric("chat.web.tool_calls_ms", toolCallsMs);
         recordLatencyMetric("chat.web.model_ms", modelMs);
         recordLatencyMetric("chat.web.total_ms", totalMs);
+
+        // === Pricing Response Validation ===
+        const validation = validatePricingInResponse(text, toolOutputsForValidation);
+        if (!validation.valid) {
+          console.warn(
+            `[PricingValidator] Unsourced amounts detected in response: ${validation.unsourcedAmounts.join(", ")}. ` +
+            `Sourced: ${validation.sourcedAmounts.join(", ")}. Mentioned: ${validation.mentionedAmounts.join(", ")}.`
+          );
+          recordLatencyMetric("chat.web.pricing_validation_fail", 1);
+        }
 
         // === STEP B: "The Learning" (Post-Generation Memory Storage) ===
         console.log(`[Mem0] Starting memory storage...`);

--- a/lib/ai/pre-classifier.ts
+++ b/lib/ai/pre-classifier.ts
@@ -1,0 +1,199 @@
+/**
+ * Pre-Classifier — Fast TypeScript-based intent detection.
+ *
+ * Runs BEFORE the LLM to catch obvious intents in <1ms. This is NOT a
+ * replacement for the LLM's tool selection — it's an accelerator that
+ * pre-injects the right context and hints so the LLM makes fewer
+ * round-trips.
+ *
+ * The classifier returns "hints" that get injected into the system prompt
+ * for the current turn only.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type IntentHint =
+  | "pricing"
+  | "scheduling"
+  | "communication"
+  | "flow_control"
+  | "reporting"
+  | "contact_lookup"
+  | "invoice"
+  | "support"
+  | "general";
+
+export type PreClassification = {
+  /** Primary detected intent */
+  intent: IntentHint;
+  /** Confidence: 1.0 = keyword match, 0.7 = heuristic */
+  confidence: number;
+  /** Extra context hints to inject into the LLM system prompt */
+  contextHints: string[];
+  /** Which tools the LLM should prefer for this intent */
+  suggestedTools: string[];
+  /** If true, pricing calculator is likely needed */
+  requiresCalculator: boolean;
+};
+
+// ─── Pattern Definitions ────────────────────────────────────────────
+
+const PRICING_PATTERNS = [
+  /\b(how much|price|pricing|quote|quoted|cost|rate|fee|charge|estimate)\b/i,
+  /\$\s*\d/,
+  /\b(call.?out|callout|assessment)\s*(fee)?\b/i,
+  /\b(invoice|invoiced|billing|bill)\b/i,
+  /\b(discount|gst|tax|surcharge|margin|markup)\b/i,
+  /\b(total|subtotal|per hour|hourly|flat rate)\b/i,
+];
+
+const SCHEDULING_PATTERNS = [
+  /\b(schedule|scheduled|booking|book|availability|available|slot|reschedule)\b/i,
+  /\b(today|tomorrow|tmrw|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
+  /\b(next week|this week|next month|this month)\b/i,
+  /\b\d{1,2}\s*(am|pm)\b/i,
+  /\b(what('s| is) my day|what am i doing|morning|afternoon)\b/i,
+];
+
+const COMMUNICATION_PATTERNS = [
+  /\b(text|sms|message|msg|send|email|call|ring|phone)\b/i,
+  /\b(tell|let .+ know|notify|remind|follow.?up)\b/i,
+  /\b(on my way|running late|otw|eta)\b/i,
+];
+
+const FLOW_CONTROL_PATTERNS = [
+  /^\s*(next|confirm|cancel|ok|okay|yes|no|done|undo|thanks|thank you|great|good|skip)\s*[.!]?\s*$/i,
+];
+
+const REPORTING_PATTERNS = [
+  /\b(revenue|earnings|income|profit|how much .*(earn|made|make))\b/i,
+  /\b(report|summary|stats|statistics|dashboard|pipeline|overview)\b/i,
+  /\b(this week|this month|last month|this quarter|year to date|ytd)\b/i,
+];
+
+const CONTACT_PATTERNS = [
+  /\b(find|search|look up|lookup|who is|contact info|details for)\b/i,
+  /\b(customer|client|their number|their email|their address)\b/i,
+];
+
+const INVOICE_PATTERNS = [
+  /\b(invoice|invoiced|create invoice|send invoice|draft invoice|mark.*paid|void)\b/i,
+  /\b(payment|paid|unpaid|outstanding|overdue)\b/i,
+];
+
+const SUPPORT_PATTERNS = [
+  /\b(help|support|bug|broken|not working|issue|problem|can't|cannot)\b/i,
+];
+
+// ─── Classifier ─────────────────────────────────────────────────────
+
+export function preClassify(text: string): PreClassification {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { intent: "general", confidence: 0, contextHints: [], suggestedTools: [], requiresCalculator: false };
+  }
+
+  // Flow control is the fastest path — exact match on short strings
+  if (FLOW_CONTROL_PATTERNS.some((p) => p.test(trimmed))) {
+    return {
+      intent: "flow_control",
+      confidence: 1.0,
+      contextHints: [],
+      suggestedTools: [],
+      requiresCalculator: false,
+    };
+  }
+
+  // Score each intent by pattern matches
+  const scores: { intent: IntentHint; score: number }[] = [
+    { intent: "pricing", score: countMatches(trimmed, PRICING_PATTERNS) },
+    { intent: "scheduling", score: countMatches(trimmed, SCHEDULING_PATTERNS) },
+    { intent: "communication", score: countMatches(trimmed, COMMUNICATION_PATTERNS) },
+    { intent: "reporting", score: countMatches(trimmed, REPORTING_PATTERNS) },
+    { intent: "contact_lookup", score: countMatches(trimmed, CONTACT_PATTERNS) },
+    { intent: "invoice", score: countMatches(trimmed, INVOICE_PATTERNS) },
+    { intent: "support", score: countMatches(trimmed, SUPPORT_PATTERNS) },
+  ];
+
+  scores.sort((a, b) => b.score - a.score);
+  const best = scores[0];
+
+  if (best.score === 0) {
+    return { intent: "general", confidence: 0.3, contextHints: [], suggestedTools: [], requiresCalculator: false };
+  }
+
+  const confidence = Math.min(1.0, 0.5 + best.score * 0.15);
+
+  return {
+    intent: best.intent,
+    confidence,
+    contextHints: getContextHints(best.intent),
+    suggestedTools: getSuggestedTools(best.intent),
+    requiresCalculator: best.intent === "pricing" || best.intent === "invoice",
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function countMatches(text: string, patterns: RegExp[]): number {
+  return patterns.filter((p) => p.test(text)).length;
+}
+
+function getContextHints(intent: IntentHint): string[] {
+  switch (intent) {
+    case "pricing":
+      return [
+        "PRICING QUERY DETECTED: You MUST use the pricingLookup tool to fetch approved prices before responding.",
+        "Use the pricingCalculator tool for ALL arithmetic (totals, tax, discounts). NEVER calculate in your head.",
+        "If no approved price exists, say a firm quote requires an on-site assessment. Do NOT estimate.",
+      ];
+    case "scheduling":
+      return [
+        "SCHEDULING QUERY: Use getSchedule or getAvailability before answering. Never guess availability.",
+      ];
+    case "communication":
+      return [
+        "COMMUNICATION REQUEST: Identify the contact and use sendSms/sendEmail/makeCall. Send the user's exact words.",
+      ];
+    case "reporting":
+      return [
+        "REPORT REQUEST: Use getFinancialReport or getTodaySummary to fetch real data. Never estimate revenue.",
+      ];
+    case "contact_lookup":
+      return [
+        "CONTACT QUERY: Use searchContacts or getClientContext to find the person first.",
+      ];
+    case "invoice":
+      return [
+        "INVOICE REQUEST: Use the invoice tools (createDraftInvoice, issueInvoice, etc.).",
+        "Use the pricingCalculator tool for any amount calculations. NEVER calculate in your head.",
+      ];
+    case "support":
+      return [
+        "SUPPORT REQUEST: Try to help first. If unable, use contactSupport to escalate.",
+      ];
+    default:
+      return [];
+  }
+}
+
+function getSuggestedTools(intent: IntentHint): string[] {
+  switch (intent) {
+    case "pricing":
+      return ["pricingLookup", "pricingCalculator"];
+    case "scheduling":
+      return ["getSchedule", "getAvailability"];
+    case "communication":
+      return ["sendSms", "sendEmail", "makeCall"];
+    case "reporting":
+      return ["getFinancialReport", "getTodaySummary"];
+    case "contact_lookup":
+      return ["searchContacts", "getClientContext"];
+    case "invoice":
+      return ["createDraftInvoice", "issueInvoice", "getInvoiceStatus", "pricingCalculator"];
+    case "support":
+      return ["contactSupport"];
+    default:
+      return [];
+  }
+}

--- a/lib/ai/pricing-calculator.ts
+++ b/lib/ai/pricing-calculator.ts
@@ -1,0 +1,194 @@
+/**
+ * Deterministic Pricing Calculator
+ *
+ * The LLM must NEVER perform pricing calculations itself. All arithmetic
+ * involving dollar amounts, quantities, taxes, discounts, or totals MUST
+ * be routed through this module. Results are the single source of truth
+ * that the LLM is allowed to quote back to the user.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type CalcOperation =
+  | "add"
+  | "subtract"
+  | "multiply"
+  | "divide"
+  | "percentage"
+  | "quote_total"
+  | "discount"
+  | "tax"
+  | "margin";
+
+export type LineItem = {
+  description: string;
+  unitPrice: number;
+  quantity: number;
+};
+
+export type CalcInput = {
+  operation: CalcOperation;
+  /** Primary operand (e.g. base price, subtotal) */
+  a: number;
+  /** Secondary operand (e.g. quantity, percentage rate) */
+  b?: number;
+  /** Line items for quote_total operation */
+  lineItems?: LineItem[];
+};
+
+export type CalcResult = {
+  result: number;
+  /** Human-readable breakdown the LLM can paste into its response */
+  explanation: string;
+  /** Formatted dollar string */
+  formatted: string;
+  /** Individual line totals when applicable */
+  lineBreakdown?: { description: string; total: number; formatted: string }[];
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  return `$${n.toLocaleString("en-AU", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ─── Calculator ─────────────────────────────────────────────────────
+
+export function calculate(input: CalcInput): CalcResult {
+  const { operation, a, b = 0, lineItems } = input;
+
+  switch (operation) {
+    case "add": {
+      const result = round2(a + b);
+      return {
+        result,
+        explanation: `${fmt(a)} + ${fmt(b)} = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "subtract": {
+      const result = round2(a - b);
+      return {
+        result,
+        explanation: `${fmt(a)} - ${fmt(b)} = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "multiply": {
+      const result = round2(a * b);
+      return {
+        result,
+        explanation: `${fmt(a)} × ${b} = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "divide": {
+      if (b === 0) {
+        return { result: 0, explanation: "Cannot divide by zero.", formatted: "$0.00" };
+      }
+      const result = round2(a / b);
+      return {
+        result,
+        explanation: `${fmt(a)} ÷ ${b} = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "percentage": {
+      // b% of a
+      const result = round2((a * b) / 100);
+      return {
+        result,
+        explanation: `${b}% of ${fmt(a)} = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "discount": {
+      // Apply b% discount to a
+      const discountAmount = round2((a * b) / 100);
+      const result = round2(a - discountAmount);
+      return {
+        result,
+        explanation: `${fmt(a)} less ${b}% discount (${fmt(discountAmount)}) = ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "tax": {
+      // Add b% tax to a (default 10% GST for Australia)
+      const rate = b || 10;
+      const taxAmount = round2((a * rate) / 100);
+      const result = round2(a + taxAmount);
+      return {
+        result,
+        explanation: `${fmt(a)} + ${rate}% tax (${fmt(taxAmount)}) = ${fmt(result)} inc. GST`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "margin": {
+      // Calculate sell price from cost (a) at margin% (b)
+      if (b >= 100) {
+        return { result: 0, explanation: "Margin cannot be 100% or more.", formatted: "$0.00" };
+      }
+      const result = round2(a / (1 - b / 100));
+      return {
+        result,
+        explanation: `Cost ${fmt(a)} at ${b}% margin = sell price ${fmt(result)}`,
+        formatted: fmt(result),
+      };
+    }
+
+    case "quote_total": {
+      const items = lineItems ?? [];
+      if (items.length === 0 && a > 0) {
+        // Shorthand: a = subtotal, b = tax rate
+        const rate = b || 10;
+        const taxAmount = round2((a * rate) / 100);
+        const total = round2(a + taxAmount);
+        return {
+          result: total,
+          explanation: `Subtotal ${fmt(a)} + ${rate}% GST (${fmt(taxAmount)}) = ${fmt(total)}`,
+          formatted: fmt(total),
+        };
+      }
+
+      const lineBreakdown = items.map((item) => {
+        const lineTotal = round2(item.unitPrice * item.quantity);
+        return {
+          description: item.description,
+          total: lineTotal,
+          formatted: fmt(lineTotal),
+        };
+      });
+
+      const subtotal = round2(lineBreakdown.reduce((sum, l) => sum + l.total, 0));
+      const callOutFee = round2(a); // a = call-out fee (0 if none)
+      const subtotalWithCallOut = round2(subtotal + callOutFee);
+      const taxRate = b || 10;
+      const tax = round2((subtotalWithCallOut * taxRate) / 100);
+      const total = round2(subtotalWithCallOut + tax);
+
+      const lines = lineBreakdown.map((l) => `  ${l.description}: ${l.formatted}`).join("\n");
+      let explanation = `Line items:\n${lines}\n  Subtotal: ${fmt(subtotal)}`;
+      if (callOutFee > 0) {
+        explanation += `\n  Call-out fee: ${fmt(callOutFee)}`;
+      }
+      explanation += `\n  GST (${taxRate}%): ${fmt(tax)}\n  Total: ${fmt(total)}`;
+
+      return { result: total, explanation, formatted: fmt(total), lineBreakdown };
+    }
+
+    default: {
+      return { result: 0, explanation: `Unknown operation: ${operation}`, formatted: "$0.00" };
+    }
+  }
+}

--- a/lib/ai/response-validator.ts
+++ b/lib/ai/response-validator.ts
@@ -1,0 +1,140 @@
+/**
+ * Response Validator — Post-generation check for pricing integrity.
+ *
+ * Scans the LLM's output text for dollar amounts and verifies each one
+ * was present in a tool call result from the same turn. Any unsourced
+ * dollar figure is flagged so the system can append a disclaimer.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type ValidationResult = {
+  /** True if all dollar amounts in the response are sourced */
+  valid: boolean;
+  /** Dollar amounts found in the response text */
+  mentionedAmounts: number[];
+  /** Dollar amounts present in tool outputs */
+  sourcedAmounts: number[];
+  /** Amounts in response that don't appear in any tool output */
+  unsourcedAmounts: number[];
+  /** Disclaimer to append if unsourced amounts found */
+  disclaimer: string | null;
+};
+
+// ─── Extraction ─────────────────────────────────────────────────────
+
+/**
+ * Extract all dollar amounts from a text string.
+ * Handles: $150, $1,200, $1,200.50, $150.00, $150k
+ */
+export function extractDollarAmounts(text: string): number[] {
+  if (!text) return [];
+  const amounts: number[] = [];
+  // Match $-prefixed numbers and standalone "X dollars" patterns
+  const dollarRegex = /\$\s*([\d,]+(?:\.\d{1,2})?)\s*(k)?/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = dollarRegex.exec(text)) !== null) {
+    const raw = match[1].replace(/,/g, "");
+    let value = parseFloat(raw);
+    if (match[2]?.toLowerCase() === "k") value *= 1000;
+    if (Number.isFinite(value) && value > 0) amounts.push(value);
+  }
+
+  return [...new Set(amounts)];
+}
+
+/**
+ * Extract all numeric amounts from tool outputs (recursively searches objects).
+ */
+export function extractAmountsFromToolOutputs(toolOutputs: unknown[]): number[] {
+  const amounts = new Set<number>();
+
+  function walk(obj: unknown) {
+    if (obj === null || obj === undefined) return;
+
+    if (typeof obj === "number" && Number.isFinite(obj) && obj > 0) {
+      amounts.add(obj);
+      return;
+    }
+
+    if (typeof obj === "string") {
+      // Extract dollar amounts from string values in tool outputs
+      for (const amount of extractDollarAmounts(obj)) {
+        amounts.add(amount);
+      }
+      // Also try bare numbers in strings like "150" in descriptions
+      const numMatch = obj.match(/\b(\d+(?:\.\d{1,2})?)\b/g);
+      if (numMatch) {
+        for (const n of numMatch) {
+          const val = parseFloat(n);
+          if (Number.isFinite(val) && val > 0) amounts.add(val);
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(obj)) {
+      for (const item of obj) walk(item);
+      return;
+    }
+
+    if (typeof obj === "object") {
+      for (const value of Object.values(obj as Record<string, unknown>)) {
+        walk(value);
+      }
+    }
+  }
+
+  for (const output of toolOutputs) walk(output);
+  return [...amounts];
+}
+
+// ─── Validator ──────────────────────────────────────────────────────
+
+/**
+ * Validate that dollar amounts in the LLM response are grounded in tool outputs.
+ *
+ * @param responseText - The LLM's generated text
+ * @param toolOutputs - Array of tool call result objects from the same turn
+ * @param tolerance - Acceptable rounding tolerance (default $1)
+ */
+export function validatePricingInResponse(
+  responseText: string,
+  toolOutputs: unknown[],
+  tolerance: number = 1
+): ValidationResult {
+  const mentionedAmounts = extractDollarAmounts(responseText);
+
+  // No dollar amounts in response → automatically valid
+  if (mentionedAmounts.length === 0) {
+    return {
+      valid: true,
+      mentionedAmounts: [],
+      sourcedAmounts: [],
+      unsourcedAmounts: [],
+      disclaimer: null,
+    };
+  }
+
+  const sourcedAmounts = extractAmountsFromToolOutputs(toolOutputs);
+
+  // Check each mentioned amount against sourced amounts
+  const unsourcedAmounts = mentionedAmounts.filter((mentioned) => {
+    return !sourcedAmounts.some(
+      (sourced) => Math.abs(sourced - mentioned) <= tolerance
+    );
+  });
+
+  const valid = unsourcedAmounts.length === 0;
+
+  return {
+    valid,
+    mentionedAmounts,
+    sourcedAmounts,
+    unsourcedAmounts,
+    disclaimer: valid
+      ? null
+      : "Note: Some pricing in this response could not be verified against our records. Please confirm with the business before proceeding.",
+  };
+}

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -52,6 +52,8 @@ import {
     runGetTodaySummary,
     runGetAvailability,
 } from "@/actions/agent-tools";
+import { runPricingLookup } from "@/actions/pricing-actions";
+import { calculate } from "@/lib/ai/pricing-calculator";
 import { buildJobDraftFromParams } from "@/lib/chat-utils";
 
 /**
@@ -535,6 +537,30 @@ export function getAgentTools(workspaceId: string, settings: AgentToolSettings |
                     workingHoursStart: settings?.workingHoursStart || "08:00",
                     workingHoursEnd: settings?.workingHoursEnd || "17:00",
                 }),
+        }),
+
+        // ─── Pricing Tools (Source of Truth) ─────────────────────
+        pricingLookup: tool({
+            description: "Look up approved pricing for a service or task. MUST be called before quoting ANY price. Returns explicitly sourced pricing from glossary, service rules, and historical jobs. Never quote a price without calling this first.",
+            inputSchema: z.object({
+                query: z.string().describe("Service or task to look up pricing for (e.g. 'sink repair', 'light install', 'blocked drain')"),
+            }),
+            execute: async ({ query }) => runPricingLookup(workspaceId, { query }),
+        }),
+        pricingCalculator: tool({
+            description: "Deterministic calculator for ALL pricing math. You MUST use this for any arithmetic involving dollar amounts — additions, totals, tax, discounts, margins, or multi-item quotes. NEVER perform pricing calculations yourself.",
+            inputSchema: z.object({
+                operation: z.enum(["add", "subtract", "multiply", "divide", "percentage", "quote_total", "discount", "tax", "margin"])
+                    .describe("The calculation to perform"),
+                a: z.number().describe("Primary value (e.g. base price, subtotal, cost)"),
+                b: z.number().optional().describe("Secondary value (e.g. quantity, tax rate %, discount %). For tax: defaults to 10% GST if omitted."),
+                lineItems: z.array(z.object({
+                    description: z.string().describe("Line item name"),
+                    unitPrice: z.number().describe("Price per unit"),
+                    quantity: z.number().describe("Quantity"),
+                })).optional().describe("For quote_total: list of line items. 'a' becomes call-out fee (0 if none), 'b' becomes tax rate."),
+            }),
+            execute: async (params) => calculate(params),
         }),
     };
 }


### PR DESCRIPTION
…icing lookup, response validator

- Pre-classifier (lib/ai/pre-classifier.ts): Fast TypeScript-based intent detection that runs before the LLM. Injects context hints for pricing, scheduling, communication, reporting, and invoice intents so the LLM makes fewer round-trips.

- Pricing calculator (lib/ai/pricing-calculator.ts): Deterministic calculator the LLM MUST use for all pricing arithmetic. Supports add, subtract, multiply, divide, percentage, discount, tax (GST), margin, and multi-line quote totals. The LLM is forbidden from doing pricing math itself.

- Pricing lookup (actions/pricing-actions.ts): Queries glossary, service rules, historical invoices, call-out fees, and emergency surcharges. Every dollar amount the LLM quotes must originate from this tool.

- Response validator (lib/ai/response-validator.ts): Post-generation check that extracts dollar amounts from the LLM's response and verifies each one was present in a tool call result. Logs unsourced amounts as warnings.

- Wired into chat route: pre-classifier hints injected into system prompt, tool outputs collected via onStepFinish for validation in onFinish. System prompt now enforces PRICING INTEGRITY rules — LLM must call pricingLookup before quoting and pricingCalculator before any math.

- Registered pricingLookup and pricingCalculator as agent tools in tools.ts.

https://claude.ai/code/session_018eqZsK28rxxMvgXZkFP4GM