### PR TITLE
PR1: Fix pipeline mappings, rewrite marketing copy, archive estimator

### DIFF
--- a/actions/deal-actions.ts
+++ b/actions/deal-actions.ts
@@ -29,12 +29,13 @@ import {
 // ─── Types ──────────────────────────────────────────────────────────
 
 // Maps Prisma DealStage enum to frontend column ids (6-column CRM)
+// NEGOTIATION and PIPELINE are legacy enum values — both map to their clean equivalents.
 const STAGE_MAP: Record<string, string> = {
   NEW: "new_request",
   CONTACTED: "quote_sent",
-  NEGOTIATION: "scheduled",
+  NEGOTIATION: "scheduled",   // legacy alias → scheduled
   SCHEDULED: "scheduled",
-  PIPELINE: "pipeline",
+  PIPELINE: "quote_sent",     // legacy alias → quote_sent (was silently remapped via kanban-columns anyway)
   INVOICED: "ready_to_invoice",
   PENDING_COMPLETION: "pending_approval",
   WON: "completed",
@@ -47,7 +48,7 @@ const STAGE_REVERSE: Record<string, string> = {
   new_request: "NEW",
   quote_sent: "CONTACTED",
   scheduled: "SCHEDULED",
-  pipeline: "PIPELINE",
+  // "pipeline" removed — no longer a valid frontend column; falls back to CONTACTED via quote_sent
   ready_to_invoice: "INVOICED",
   pending_approval: "PENDING_COMPLETION",
   completed: "WON",
@@ -61,7 +62,6 @@ const STAGE_ACTIVITY_LABELS: Record<string, string> = {
   new_request: "New request",
   quote_sent: "Quote sent",
   scheduled: "Scheduled",
-  pipeline: "Pipeline",
   ready_to_invoice: "Ready to invoice",
   pending_approval: "Pending approval",
   completed: "Completed",

--- a/app/(dashboard)/tradie/estimator/page.tsx
+++ b/app/(dashboard)/tradie/estimator/page.tsx
@@ -1,53 +1,5 @@
-
-import { EstimatorForm } from "@/components/tradie/estimator-form";
-import { getAuthUserId } from "@/lib/auth";
-import { getOrCreateWorkspace } from "@/actions/workspace-actions";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
-export default async function EstimatorPage() {
-    const userId = await getAuthUserId();
-
-    if (!userId) {
-        redirect("/auth");
-    }
-
-    let workspaceId: string | null = null;
-    let errorMessage: string | null = null;
-
-    try {
-        const workspace = await getOrCreateWorkspace(userId);
-        workspaceId = workspace.id;
-    } catch (error) {
-        console.error("Estimator page error:", error);
-        errorMessage = error instanceof Error ? error.message : "Unknown error";
-    }
-
-    if (errorMessage || !workspaceId) {
-        return (
-            <div className="min-h-screen bg-slate-950 text-slate-50 p-4 flex items-center justify-center">
-                <div className="text-center">
-                    <h2 className="text-xl font-semibold text-red-500 mb-2">Error Loading Estimator</h2>
-                    <p className="text-slate-400">{errorMessage || "Unknown error"}</p>
-                </div>
-            </div>
-        );
-    }
-
-    return (
-        <div className="min-h-screen bg-slate-950 text-slate-50 p-4 pb-24">
-            <header className="flex items-center gap-4 mb-6 sticky top-0 bg-slate-950 z-10 py-2">
-                <Link href="/crm/tradie">
-                    <Button variant="ghost" size="icon" className="text-slate-400 hover:text-white hover:bg-slate-800">
-                        <ArrowLeft className="h-6 w-6" />
-                    </Button>
-                </Link>
-                <h1 className="text-xl font-bold">Quick Estimator</h1>
-            </header>
-
-            <EstimatorForm workspaceId={workspaceId} />
-        </div>
-    );
+export default function EstimatorPage() {
+  redirect("/crm/dashboard");
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,17 +50,17 @@ const OLD_WAY = [
 
 const TRACEY_WAY = [
     { icon: "📞", label: "Customer calls" },
-    { icon: "🤖", label: "Tracey picks up 24/7, secures and logs the job" },
+    { icon: "🤖", label: "Tracey picks up 24/7, qualifies the lead, and books the job" },
     { icon: "🔧", label: "Get on the tools" },
-    { icon: "💰", label: "Get paid: collect instantly or Tracey follows up + asks for a kind review" },
+    { icon: "💰", label: "Tracey sends the invoice, follows up, and asks for a review" },
 ];
 
 const HIRE_FEATURES = [
     {
         title: EARLYMARK_SALES_PILLARS[0]?.title || "Never miss a job again",
-        desc: EARLYMARK_SALES_PILLARS[0]?.description || "With 24/7 availability, Tracey will contact the lead for you instantaneously. Oh.... and did we mention she's multilingual?",
+        desc: EARLYMARK_SALES_PILLARS[0]?.description || "Tracey answers every call 24/7, qualifies the lead, and books the job straight into your calendar — so you never lose work while you're on the tools.",
         eyebrow: "Lead capture",
-        bullets: ["Answers every call, day or night", "Logs the job straight to your CRM", "Sends quotes automatically"],
+        bullets: ["Answers every call, day or night", "Books jobs and syncs to your calendar", "Logs every lead straight to your CRM"],
     },
     {
         title: EARLYMARK_SALES_PILLARS[1]?.title || "No more admin. Chat with your CRM.",
@@ -69,44 +69,44 @@ const HIRE_FEATURES = [
         bullets: ["Chat to update any job in seconds", "Query revenue, pipeline, or schedule", "No forms, no manual data entry"],
     },
     {
-        title: EARLYMARK_SALES_PILLARS[2]?.title || "AI that actually works",
-        desc: EARLYMARK_SALES_PILLARS[2]?.description || "AI that handles convos like a human. Tracey learns your preferences and delivers a better and simpler experience.",
+        title: EARLYMARK_SALES_PILLARS[2]?.title || "Follow-up that actually happens",
+        desc: EARLYMARK_SALES_PILLARS[2]?.description || "Tracey automatically follows up on unconfirmed quotes, sends booking reminders, and asks for a review after every completed job.",
         eyebrow: "Customer experience",
-        bullets: ["Replies to texts and emails instantly", "Follows up on unpaid quotes", "Handles objections and rebooking"],
+        bullets: ["Automated quote follow-up sequences", "Booking reminders via SMS", "Post-job review requests"],
     },
     {
         title: EARLYMARK_SALES_PILLARS[3]?.title || "Total control",
         desc: EARLYMARK_SALES_PILLARS[3]?.description || "You decide how much autonomy Tracey has. Set approval rules, customize responses, and maintain full oversight of every customer interaction.",
         eyebrow: "Oversight",
-        bullets: ["Set approval rules for quotes", "Review every conversation", "Adjust Tracey&apos;s behaviour anytime"],
+        bullets: ["Choose Execution, Draft, or Info-only mode", "Review every conversation", "Adjust Tracey's behaviour anytime"],
     },
 ];
 
 const FEATURE_CARDS = [
     {
         icon: Phone,
-        title: "AI Customer Communication",
+        title: "AI Receptionist",
         desc: "Calls, texts, and emails — Tracey handles conversations across every channel, 24/7.",
     },
     {
         icon: MessageSquare,
-        title: "Automated CRM Management",
+        title: "Automated CRM",
         desc: "Tell Tracey what you need. She logs jobs, moves deals, and keeps your pipeline moving — no manual entry.",
     },
     {
         icon: Calendar,
         title: "Smart Scheduling",
-        desc: "Tracey checks your calendar and books jobs into the right slots, avoiding double-ups and dead time.",
+        desc: "Tracey checks your calendar, books jobs into open slots, and clusters nearby jobs on the same day.",
     },
     {
         icon: MapPin,
-        title: "Job Map & Route Optimisation",
-        desc: "See all your jobs on a live map and get smarter routes so you spend less time driving between sites.",
+        title: "Job Map",
+        desc: "See all your scheduled jobs on a live map — know where your crew is and what's coming up.",
     },
     {
         icon: Users,
         title: "Team Management",
-        desc: "Assign jobs, track your crew, and keep everyone aligned — all through simple chat commands.",
+        desc: "Assign jobs, set permissions, and keep everyone aligned — all through simple chat commands.",
     },
     {
         icon: BarChart3,
@@ -121,8 +121,8 @@ const CHAT_DEMO = [
         agent: "✅ Done — Henderson Plumbing is now Completed.",
     },
     {
-        user: "Call Sarah Johnson and get the quote approved",
-        agent: "📞 Calling Sarah Johnson... She confirmed the $1,850 quote. Booked for Thursday 9am! 🎉",
+        user: "Book Sarah Johnson in for a hot water system replacement next Tuesday",
+        agent: "📅 Done — Sarah Johnson booked for Tuesday 10am. Confirmation SMS sent. 🎉",
     },
     {
         user: "What's my revenue this month?",

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -45,11 +45,11 @@ const fadeUp = (delay = 0) => ({
 })
 
 const FEATURES = [
-  { icon: Phone, title: "AI Receptionist", description: "Answers calls 24/7. Multilingual." },
-  { icon: MessageSquare, title: "SMS & Email", description: "Replies and follows up natively." },
-  { icon: FileText, title: "Quotes & Invoices", description: "Drafts and chases instantly." },
-  { icon: Calendar, title: "Smart Scheduling", description: "Books jobs without double-ups." },
-  { icon: MapPin, title: "Job Map", description: "Smarter routes, less driving." },
+  { icon: Phone, title: "AI Receptionist", description: "Answers calls 24/7. Books jobs on the spot." },
+  { icon: MessageSquare, title: "SMS & Email", description: "Replies, confirms, and follows up automatically." },
+  { icon: FileText, title: "Invoicing", description: "Generate invoices and sync to Xero instantly." },
+  { icon: Calendar, title: "Smart Scheduling", description: "Books jobs and clusters nearby work on the same day." },
+  { icon: MapPin, title: "Job Map", description: "See all your jobs on a live map at a glance." },
   { icon: BarChart3, title: "Analytics", description: "Revenue and pipeline at a glance." },
   { icon: Users, title: "Team Management", description: "Assign jobs and set permissions." },
   { icon: ShieldCheck, title: "Full Control", description: "Custom rules and oversight." },
@@ -323,7 +323,7 @@ export default function PricingPage() {
                   </li>
                   <li className="flex items-start gap-3 text-sm text-slate-700 font-medium">
                     <Check className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                    Relentless quote follow-up
+                    Automated quote follow-up sequences
                   </li>
                   <li className="flex items-start gap-3 text-sm text-slate-700 font-medium">
                     <Check className="w-5 h-5 text-primary shrink-0 mt-0.5" />

--- a/components/tradie/tradie-dashboard-client.tsx
+++ b/components/tradie/tradie-dashboard-client.tsx
@@ -121,11 +121,6 @@ export function TradieDashboardClient({ initialJob, todayJobs = [], userName = "
           <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse"></span>
           {todayJobs.length} Jobs Today
         </div>
-        <Link href="/crm/tradie/estimator" className="pointer-events-auto">
-          <Button variant="secondary" size="sm" className="h-7 text-xs bg-slate-800 text-slate-200 hover:bg-slate-700 border border-slate-700 shadow-sm">
-            + Quick Estimate
-          </Button>
-        </Link>
       </div>
 
       {/* Finish Job Button — most prominent action on active job card */}

--- a/docs/messaging-improvements.md
+++ b/docs/messaging-improvements.md
@@ -1,0 +1,31 @@
+# Messaging Improvements — To Do
+
+## Pricing Page Comparison
+
+The current pricing page compares Earlymark ($149/mo) against a "Regular Assistant" at $4,500+/month (i.e., a full-time office admin).
+
+**Problem:** Tradies have never had an office admin. The comparison doesn't land for them. It reads like marketing fluff.
+
+**Real comparison:** The decision a tradie actually makes is between Earlymark and one of:
+- ServiceM8 ($49/mo)
+- Tradify ($39/user/mo)
+- Jobber ($69/mo)
+- Answering their own phone
+
+**Fix needed:** Rewrite the pricing page comparison to position against job management software competitors, not a hypothetical employee. Lead with the AI-first differentiation — they do scheduling, job tracking, and invoicing too, but none of them answer calls, book jobs, and follow up automatically.
+
+Suggested angle: "Other job management tools help you track work. Earlymark goes and gets the work for you."
+
+## Solutions Pages
+
+The per-trade solution pages (Electricians, Plumbers, etc.) use generic copy. Each should call out trade-specific pain points:
+- Electricians: compliance jobs, certificate of compliance workflow
+- Plumbers: emergency callout, hot water system replacements
+- Pest control: recurring quarterly treatments
+- HVAC: seasonal demand spikes, service contracts
+
+## Homepage Stats
+
+Current stats: "62% of missed calls never call back", "2+ hrs admin saved", "3–5 jobs recovered/month"
+
+These are good but unattributed. Add a source or change to "Based on Earlymark customer data" once real data exists.

--- a/lib/kanban-columns.ts
+++ b/lib/kanban-columns.ts
@@ -1,10 +1,10 @@
 /**
  * Maps a DealView.stage string to the Kanban column id (same rules as `kanban-board.tsx` grouping).
+ * Note: "pipeline" is a legacy stage — deal-actions.ts now maps PIPELINE → "quote_sent" upstream.
  */
 export function kanbanColumnIdForDealStage(stage: string): string {
-  const s = stage === "pipeline" ? "quote_sent" : stage
-  if (s === "pending_approval") return "completed"
-  return s
+  if (stage === "pending_approval") return "completed"
+  return stage
 }
 
 /** Left-to-right column order for sorting fetched deals. */

--- a/livekit-agent/earlymark-sales-brief.ts
+++ b/livekit-agent/earlymark-sales-brief.ts
@@ -10,9 +10,9 @@ export const EARLYMARK_SALES_PILLARS: EarlymarkSalesPillar[] = [
     id: "lead_capture",
     title: "Never miss a job again",
     description:
-      "With 24/7 availability, Tracey will contact the lead for you instantaneously. Oh.... and did we mention she's multilingual?",
+      "Tracey answers every call 24/7, qualifies the lead, and books the job straight into your calendar — so you never lose work while you're on the tools.",
     salesLine:
-      "Earlymark helps you stop missing jobs by handling calls, texts, and lead follow-up around the clock, including multilingual enquiries.",
+      "Earlymark answers every call, qualifies the lead, and books the job — so tradies never miss work while they're on-site.",
   },
   {
     id: "ops",
@@ -20,15 +20,15 @@ export const EARLYMARK_SALES_PILLARS: EarlymarkSalesPillar[] = [
     description:
       "No more fiddling with complex CRMs — just tell Tracey what you want and she'll run it for you.",
     salesLine:
-      "Earlymark cuts admin by letting you run follow-up, scheduling, CRM updates, and customer comms through one AI workflow instead of manual admin.",
+      "Earlymark cuts admin by letting you run scheduling, CRM updates, follow-up, and customer comms through one AI assistant instead of manual work.",
   },
   {
     id: "natural_ai",
-    title: "AI that actually works",
+    title: "Follow-up that actually happens",
     description:
-      "AI that handles convos like a human. Tracey learns your preferences and delivers a better and simpler experience.",
+      "Tracey automatically follows up on unconfirmed quotes, sends booking reminders, and requests a review after every completed job.",
     salesLine:
-      "Tracey is designed to sound natural, keep conversations moving, and stay aligned with the way your business actually operates.",
+      "Tracey follows up on quotes, confirms bookings, and asks for reviews automatically — so nothing falls through the cracks.",
   },
   {
     id: "control",
@@ -36,15 +36,15 @@ export const EARLYMARK_SALES_PILLARS: EarlymarkSalesPillar[] = [
     description:
       "You decide how much autonomy Tracey has. Set approval rules, customize responses, and maintain full oversight of every customer interaction.",
     salesLine:
-      "You keep control with approval rules, oversight, and guardrails over what Tracey can confirm, quote, or escalate.",
+      "You keep control with approval rules, oversight, and guardrails over what Tracey can confirm, book, or escalate.",
   },
 ];
 
 export const EARLYMARK_PLATFORM_CAPABILITIES = [
   "calls, texts, and emails handled in one system",
-  "CRM updates and follow-up without manual data entry",
-  "smart scheduling and routing support",
-  "visibility into jobs, response flow, and revenue",
+  "CRM updates and scheduling without manual data entry",
+  "automated follow-up sequences for quotes and completed jobs",
+  "visibility into jobs, bookings, and revenue at a glance",
 ] as const;
 
 export function buildEarlymarkSalesBrief() {


### PR DESCRIPTION
Pipeline stages:
- PIPELINE now maps to quote_sent (was silently remapped via kanban anyway)
- NEGOTIATION maps to scheduled (unchanged but now explicit)
- Remove pipeline from STAGE_REVERSE to prevent round-trip ambiguity
- Remove silent pipeline→quote_sent remap from kanban-columns.ts

Marketing copy (written to final product state):
- Homepage: remove "route optimisation", fix chat demo, rewrite HIRE_FEATURES with accurate bullets, update FEATURE_CARDS descriptions
- Pricing page: fix FEATURES grid (Invoicing not "Quotes & Invoices: Drafts and chases instantly"), remove "Relentless quote follow-up"
- Voice agent sales brief: remove multilingual as a headline claim, rewrite natural_ai pillar to "Follow-up that actually happens", update capabilities

Archive:
- tradie/estimator redirects to dashboard (was active with EstimatorForm)
- Remove "Quick Estimate" button from tradie dashboard client

Docs:
- Add docs/messaging-improvements.md noting pricing comparison rewrite needed

https://claude.ai/code/session_01Kk5JXehGGL6YFhDqK9FDQh