### PR TITLE
PR2: voice scheduling tools, SMS automations, Teach Tracey page

### DIFF
--- a/actions/automation-actions.ts
+++ b/actions/automation-actions.ts
@@ -46,7 +46,7 @@ export interface TriggerConfig {
 }
 
 export interface ActionConfig {
-  type: "notify" | "email" | "create_task" | "move_stage";
+  type: "notify" | "email" | "create_task" | "move_stage" | "send_sms";
   channel?: string;
   template?: string;
   message?: string;
@@ -64,7 +64,7 @@ const CreateAutomationSchema = z.object({
     stage: z.string().optional(),
   }),
   action: z.object({
-    type: z.enum(["notify", "email", "create_task", "move_stage"]),
+    type: z.enum(["notify", "email", "create_task", "move_stage", "send_sms"]),
     channel: z.string().optional(),
     template: z.string().optional(),
     message: z.string().optional(),
@@ -433,6 +433,45 @@ export async function evaluateAutomations(
             console.log(`[Automation] Moved deal ${event.dealId} to stage ${prismaStage}`);
           } catch (error) {
             console.error(`[Automation] Failed to move stage for ${automation.name}:`, error);
+          }
+        }
+        // 5. Send SMS
+        if (action.type === "send_sms") {
+          try {
+            const contact = event.contactId
+              ? await db.contact.findUnique({ where: { id: event.contactId }, select: { phone: true } })
+              : event.dealId
+              ? await db.deal.findUnique({ where: { id: event.dealId }, include: { contact: { select: { phone: true } } } }).then((d) => d?.contact)
+              : null;
+
+            const phone = contact?.phone;
+            if (!phone) {
+              console.log(`[Automation] Skipped SMS for ${automation.name}: no phone number on contact`);
+              continue;
+            }
+
+            const workspace = await db.workspace.findUnique({
+              where: { id: workspaceId },
+              select: { twilioPhoneNumber: true, name: true },
+            });
+            if (!workspace?.twilioPhoneNumber) {
+              console.log(`[Automation] Skipped SMS for ${automation.name}: workspace has no Twilio number`);
+              continue;
+            }
+
+            const { Twilio } = await import("twilio");
+            const twilioClient = new Twilio(
+              process.env.TWILIO_ACCOUNT_SID!,
+              process.env.TWILIO_AUTH_TOKEN!
+            );
+            await twilioClient.messages.create({
+              body: action.message || `Hi from ${workspace.name}`,
+              from: workspace.twilioPhoneNumber,
+              to: phone,
+            });
+            console.log(`[Automation] SMS sent: ${automation.name} → ${phone}`);
+          } catch (error) {
+            console.error(`[Automation] Failed to send SMS for ${automation.name}:`, error);
           }
         }
       } catch (err) {

--- a/app/api/internal/voice-scheduling/route.ts
+++ b/app/api/internal/voice-scheduling/route.ts
@@ -1,0 +1,233 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { isVoiceAgentSecretAuthorized } from "@/lib/voice-agent-auth";
+import { runCreateJobNatural } from "@/actions/chat-actions";
+
+export const dynamic = "force-dynamic";
+
+// ── Inline geocode (Nominatim) so the agent doesn't need a separate endpoint ──
+async function geocodeAddress(address: string): Promise<{ latitude: number; longitude: number } | null> {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&limit=1`,
+      { headers: { "User-Agent": "Earlymark/1.0" } }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data?.length) return null;
+    return { latitude: parseFloat(data[0].lat), longitude: parseFloat(data[0].lon) };
+  } catch {
+    return null;
+  }
+}
+
+function calculateDistance(lat1: number, lng1: number, lat2: number, lng2: number) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+const payloadSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("check_availability"),
+    workspaceId: z.string(),
+    date: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("find_nearby"),
+    workspaceId: z.string(),
+    address: z.string(),
+    date: z.string(),
+  }),
+  z.object({
+    action: z.literal("create_job"),
+    workspaceId: z.string(),
+    clientName: z.string(),
+    address: z.string(),
+    workDescription: z.string(),
+    schedule: z.string().optional(),
+    phone: z.string().optional(),
+    email: z.string().optional(),
+    price: z.number().optional(),
+  }),
+]);
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+async function handleCheckAvailability(workspaceId: string, dateHint?: string) {
+  const workspace = await db.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { workingHoursStart: true, workingHoursEnd: true },
+  });
+
+  const from = new Date();
+  const to = new Date();
+  to.setDate(to.getDate() + 7);
+
+  const booked = await db.deal.findMany({
+    where: {
+      workspaceId,
+      scheduledAt: { gte: from, lte: to },
+      stage: { in: ["SCHEDULED", "NEGOTIATION", "CONTACTED"] },
+      jobStatus: { notIn: ["COMPLETED", "CANCELLED"] },
+    },
+    select: { scheduledAt: true, title: true },
+    orderBy: { scheduledAt: "asc" },
+  });
+
+  const workStart = workspace?.workingHoursStart ?? "08:00";
+  const workEnd = workspace?.workingHoursEnd ?? "17:00";
+
+  if (booked.length === 0) {
+    return {
+      summary: `No jobs are currently booked in the next 7 days. Working hours are ${workStart}–${workEnd}. The team is available to book a job any time this week.`,
+    };
+  }
+
+  const bookedSlots = booked
+    .map((d) => {
+      if (!d.scheduledAt) return null;
+      const dt = new Date(d.scheduledAt);
+      return dt.toLocaleString("en-AU", { weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    })
+    .filter(Boolean);
+
+  return {
+    summary: `Working hours are ${workStart}–${workEnd}. Booked slots in the next 7 days: ${bookedSlots.join(", ")}. Use this to suggest open times around these bookings.`,
+    bookedSlots,
+    dateHint,
+  };
+}
+
+async function handleFindNearby(workspaceId: string, address: string, date: string) {
+  const coords = await geocodeAddress(address);
+  if (!coords) {
+    return { summary: "Could not geocode the job address — no nearby-job check available." };
+  }
+
+  let targetDate: Date;
+  try {
+    targetDate = new Date(date);
+    if (isNaN(targetDate.getTime())) targetDate = new Date();
+  } catch {
+    targetDate = new Date();
+  }
+
+  const startDate = new Date(targetDate);
+  startDate.setDate(startDate.getDate() - 1);
+  const endDate = new Date(targetDate);
+  endDate.setDate(endDate.getDate() + 1);
+
+  const candidates = await db.deal.findMany({
+    where: {
+      workspaceId,
+      scheduledAt: { gte: startDate, lte: endDate },
+      latitude: { not: null },
+      longitude: { not: null },
+      stage: { in: ["SCHEDULED", "NEGOTIATION", "CONTACTED", "WON", "INVOICED"] },
+      jobStatus: { notIn: ["COMPLETED", "CANCELLED"] },
+    },
+    select: { title: true, latitude: true, longitude: true, scheduledAt: true },
+  });
+
+  let closest: { title: string; distance: number; scheduledAt: Date | null } | null = null;
+  let minDist = 10.0;
+
+  for (const deal of candidates) {
+    if (deal.latitude === null || deal.longitude === null) continue;
+    const dist = calculateDistance(coords.latitude, coords.longitude, deal.latitude, deal.longitude);
+    if (dist < minDist) {
+      minDist = dist;
+      closest = { title: deal.title, distance: dist, scheduledAt: deal.scheduledAt };
+    }
+  }
+
+  if (!closest) {
+    return { summary: "No other jobs are currently booked nearby on that day." };
+  }
+
+  const when = closest.scheduledAt
+    ? new Date(closest.scheduledAt).toLocaleString("en-AU", { weekday: "short", hour: "2-digit", minute: "2-digit" })
+    : "that day";
+  return {
+    summary: `There is already a job "${closest.title}" booked ${closest.distance.toFixed(1)}km away on ${when}. Mention to the caller that this area works well and you can cluster jobs efficiently.`,
+    nearbyJob: closest,
+  };
+}
+
+async function handleCreateJob(
+  workspaceId: string,
+  params: {
+    clientName: string;
+    address: string;
+    workDescription: string;
+    schedule?: string;
+    phone?: string;
+    email?: string;
+    price?: number;
+  }
+) {
+  const result = await runCreateJobNatural(workspaceId, {
+    clientName: params.clientName,
+    address: params.address,
+    workDescription: params.workDescription,
+    schedule: params.schedule,
+    phone: params.phone,
+    email: params.email,
+    price: params.price,
+  });
+
+  return result;
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  try {
+    const providedSecret = req.headers.get("x-voice-agent-secret") || "";
+    if (!isVoiceAgentSecretAuthorized(providedSecret)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await req.json();
+    const parsed = payloadSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues[0]?.message || "Invalid payload" }, { status: 400 });
+    }
+
+    const data = parsed.data;
+
+    if (data.action === "check_availability") {
+      const result = await handleCheckAvailability(data.workspaceId, data.date);
+      return NextResponse.json({ success: true, ...result });
+    }
+
+    if (data.action === "find_nearby") {
+      const result = await handleFindNearby(data.workspaceId, data.address, data.date);
+      return NextResponse.json({ success: true, ...result });
+    }
+
+    if (data.action === "create_job") {
+      const result = await handleCreateJob(data.workspaceId, {
+        clientName: data.clientName,
+        address: data.address,
+        workDescription: data.workDescription,
+        schedule: data.schedule,
+        phone: data.phone,
+        email: data.email,
+        price: data.price,
+      });
+      return NextResponse.json(result);
+    }
+
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  } catch (error) {
+    console.error("[voice-scheduling] Error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/crm/settings/automations/automation-list.tsx
+++ b/app/crm/settings/automations/automation-list.tsx
@@ -5,7 +5,7 @@ import { ActionConfig, AutomationView, TriggerConfig, toggleAutomation, createAu
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
-import { Plus, Zap, ArrowRight, Bell, CheckSquare, Mail } from "lucide-react"
+import { Plus, Zap, ArrowRight, Bell, CheckSquare, Mail, MessageSquare } from "lucide-react"
 import { toast } from "sonner"
 import {
     Dialog,
@@ -112,6 +112,7 @@ export function AutomationList({ initialAutomations, workspaceId }: AutomationLi
             case "notify": return <Bell className="h-4 w-4 text-slate-500" />
             case "create_task": return <CheckSquare className="h-4 w-4 text-blue-500" />
             case "email": return <Mail className="h-4 w-4 text-purple-500" />
+            case "send_sms": return <MessageSquare className="h-4 w-4 text-green-500" />
             default: return <ArrowRight className="h-4 w-4" />
         }
     }
@@ -169,7 +170,7 @@ export function AutomationList({ initialAutomations, workspaceId }: AutomationLi
                                         <SelectContent>
                                             <SelectItem value="notify">Send Browser Notification</SelectItem>
                                             <SelectItem value="create_task">Create Follow-up Task</SelectItem>
-                                            {/* <SelectItem value="email">Send Email (Stub)</SelectItem> */}
+                                            <SelectItem value="send_sms">Send SMS</SelectItem>
                                         </SelectContent>
                                     </Select>
                                 </div>

--- a/app/crm/settings/layout.tsx
+++ b/app/crm/settings/layout.tsx
@@ -25,6 +25,11 @@ const sidebarNavSections: { label?: string; items: { title: string; href: string
     },
     {
         items: [
+            { title: "Teach Tracey", href: "/crm/settings/training" },
+        ],
+    },
+    {
+        items: [
             { title: "My business", href: "/crm/settings/my-business" },
         ],
     },

--- a/app/crm/settings/training/page.tsx
+++ b/app/crm/settings/training/page.tsx
@@ -1,0 +1,51 @@
+import { Separator } from "@/components/ui/separator"
+import { getAuthUserId } from "@/lib/auth"
+import { getOrCreateWorkspace, getWorkspaceWithSettings } from "@/actions/workspace-actions"
+import { db } from "@/lib/db"
+import { TrainingTabs } from "./training-tabs"
+
+export const dynamic = "force-dynamic"
+
+export default async function TeachTraceyPage() {
+  const userId = (await getAuthUserId()) as string;
+  const workspace = await getOrCreateWorkspace(userId)
+  const workspaceWithSettings = await getWorkspaceWithSettings(workspace.id)
+
+  const documents = await db.businessDocument.findMany({
+    where: { workspaceId: workspace.id },
+    orderBy: { createdAt: "desc" },
+  })
+
+  const callOutFee = (workspaceWithSettings as { callOutFee?: number })?.callOutFee ?? 0
+  const agentMode = (workspaceWithSettings as { agentMode?: string })?.agentMode ?? "DRAFT"
+  const aiPreferences = (workspaceWithSettings as { aiPreferences?: string })?.aiPreferences ?? ""
+  const workingHoursStart = (workspaceWithSettings as { workingHoursStart?: string })?.workingHoursStart ?? "08:00"
+  const workingHoursEnd = (workspaceWithSettings as { workingHoursEnd?: string })?.workingHoursEnd ?? "17:00"
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-slate-900 dark:text-white">Teach Tracey</h3>
+        <p className="text-sm text-slate-500">
+          Everything Tracey needs to represent your business accurately — services, pricing, rules, and documents.
+        </p>
+      </div>
+      <Separator />
+
+      <TrainingTabs
+        callOutFee={callOutFee}
+        agentMode={agentMode}
+        aiPreferences={aiPreferences}
+        workingHoursStart={workingHoursStart}
+        workingHoursEnd={workingHoursEnd}
+        documents={(documents ?? []).map((d) => ({
+          id: d.id,
+          name: d.name,
+          description: d.description,
+          fileUrl: d.fileUrl,
+          fileType: d.fileType ?? null,
+        }))}
+      />
+    </div>
+  )
+}

--- a/app/crm/settings/training/training-tabs.tsx
+++ b/app/crm/settings/training/training-tabs.tsx
@@ -1,0 +1,309 @@
+"use client"
+
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+import { ServiceAreasSection } from "@/components/settings/service-areas-section"
+import { PricingForAgentSection } from "@/components/settings/pricing-for-agent-section"
+import { AttachmentLibrarySection } from "@/components/settings/attachment-library-section"
+import { WorkingHoursForm } from "@/components/settings/working-hours-form"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Plus, X, Bot } from "lucide-react"
+import { toast } from "sonner"
+import { updateWorkspaceSettings } from "@/actions/settings-actions"
+
+interface BusinessDocument {
+  id: string
+  name: string
+  description: string
+  fileUrl: string
+  fileType: string | null
+}
+
+interface TrainingTabsProps {
+  callOutFee: number
+  agentMode: string
+  aiPreferences: string
+  workingHoursStart: string
+  workingHoursEnd: string
+  documents: BusinessDocument[]
+}
+
+const TABS = [
+  { id: "services", label: "Services & Pricing" },
+  { id: "rules", label: "Rules & Boundaries" },
+  { id: "documents", label: "Documents" },
+  { id: "preferences", label: "Preferences" },
+] as const
+
+type TabId = (typeof TABS)[number]["id"]
+
+export function TrainingTabs({
+  callOutFee,
+  agentMode: initialAgentMode,
+  aiPreferences,
+  workingHoursStart,
+  workingHoursEnd,
+  documents,
+}: TrainingTabsProps) {
+  const [activeTab, setActiveTab] = useState<TabId>("services")
+
+  return (
+    <div className="space-y-6">
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700 overflow-x-auto">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors",
+              activeTab === tab.id
+                ? "border-emerald-600 text-emerald-700 dark:border-emerald-400 dark:text-emerald-400"
+                : "border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab panels */}
+      {activeTab === "services" && (
+        <div className="space-y-8">
+          <section>
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1">Service areas</h4>
+            <p className="text-sm text-slate-500 mb-4">
+              Tell Tracey where you work and your service radius so she can answer coverage questions accurately.
+            </p>
+            <ServiceAreasSection />
+          </section>
+          <Separator />
+          <section>
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1">Services & pricing</h4>
+            <p className="text-sm text-slate-500 mb-4">
+              Add your services with price ranges so Tracey can give accurate quotes during calls.
+            </p>
+            <PricingForAgentSection initialCallOutFee={callOutFee} />
+          </section>
+        </div>
+      )}
+
+      {activeTab === "rules" && (
+        <RulesTab initialAiPreferences={aiPreferences} />
+      )}
+
+      {activeTab === "documents" && (
+        <div className="space-y-4">
+          <div>
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1">AI Attachment Library</h4>
+            <p className="text-sm text-slate-500 mb-4">
+              Upload PDF guides, price lists, or insurance forms. Tracey will automatically email these to callers when requested.
+            </p>
+          </div>
+          <AttachmentLibrarySection documents={documents} />
+        </div>
+      )}
+
+      {activeTab === "preferences" && (
+        <PreferencesTab
+          initialAgentMode={initialAgentMode}
+          workingHoursStart={workingHoursStart}
+          workingHoursEnd={workingHoursEnd}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Rules Tab ─────────────────────────────────────────────────────────────────
+
+function RulesTab({ initialAiPreferences }: { initialAiPreferences: string }) {
+  const MAX_RULES = 20
+  const [saving, setSaving] = useState(false)
+  const [rules, setRules] = useState<string[]>(() =>
+    (initialAiPreferences || "")
+      .split("\n")
+      .map((line) => line.replace(/^\s*-\s*/, "").trim())
+      .filter(Boolean)
+  )
+  const [draft, setDraft] = useState("")
+
+  const addRule = () => {
+    const next = draft.trim()
+    if (!next) return
+    if (rules.length >= MAX_RULES) {
+      toast.error(`Maximum ${MAX_RULES} rules. Remove one to add another.`)
+      return
+    }
+    setRules((prev) => [...prev, next])
+    setDraft("")
+  }
+
+  const removeRule = (i: number) => setRules((prev) => prev.filter((_, idx) => idx !== i))
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      const aiPreferences = rules.map((r) => `- ${r}`).join("\n")
+      await updateWorkspaceSettings({ aiPreferences })
+      toast.success("Rules saved")
+    } catch {
+      toast.error("Failed to save rules")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Behavioural rules</CardTitle>
+          <CardDescription>
+            Instructions Tracey follows on every call — boundaries, preferences, and how to handle specific situations.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-2">
+            <Input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="e.g. Never quote over $500 without owner approval."
+              disabled={rules.length >= MAX_RULES}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault()
+                  addRule()
+                }
+              }}
+            />
+            <Button type="button" variant="outline" onClick={addRule} disabled={rules.length >= MAX_RULES}>
+              <Plus className="h-4 w-4 mr-1" />
+              Add
+            </Button>
+          </div>
+          <div className="text-xs text-muted-foreground text-right">{rules.length}/{MAX_RULES}</div>
+          <div className="space-y-2">
+            {rules.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center border-2 border-dashed rounded-lg">
+                No rules yet. Add a rule above to guide Tracey&apos;s behaviour.
+              </p>
+            ) : (
+              rules.map((rule, i) => (
+                <div key={i} className="flex items-center justify-between rounded-md border px-3 py-2">
+                  <span className="text-sm flex-1 mr-2">{rule}</span>
+                  <Button type="button" variant="ghost" size="icon" onClick={() => removeRule(i)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button onClick={save} disabled={saving}>
+          {saving ? "Saving..." : "Save rules"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ── Preferences Tab ───────────────────────────────────────────────────────────
+
+function PreferencesTab({
+  initialAgentMode,
+  workingHoursStart,
+  workingHoursEnd,
+}: {
+  initialAgentMode: string
+  workingHoursStart: string
+  workingHoursEnd: string
+}) {
+  const [agentMode, setAgentMode] = useState(initialAgentMode)
+  const [saving, setSaving] = useState(false)
+
+  const saveMode = async () => {
+    setSaving(true)
+    try {
+      await updateWorkspaceSettings({ agentMode })
+      toast.success("Autonomy mode saved")
+    } catch {
+      toast.error("Failed to save")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bot className="h-5 w-5 text-indigo-500" />
+            <CardTitle className="text-base">Autonomy mode</CardTitle>
+          </div>
+          <CardDescription>How much Tracey can do without your approval.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <RadioGroup
+            value={agentMode}
+            onValueChange={setAgentMode}
+            className="flex flex-col space-y-3"
+          >
+            <Label className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer">
+              <RadioGroupItem value="EXECUTION" id="mode-exec" className="mt-0.5" />
+              <div>
+                <div className="font-medium">Execution</div>
+                <p className="text-xs text-muted-foreground">Tracey books jobs, sends quotes, and handles follow-up automatically.</p>
+              </div>
+            </Label>
+            <Label className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer">
+              <RadioGroupItem value="DRAFT" id="mode-draft" className="mt-0.5" />
+              <div>
+                <div className="font-medium">Review &amp; approve</div>
+                <p className="text-xs text-muted-foreground">Tracey captures everything and creates drafts. You confirm before anything is sent or booked.</p>
+              </div>
+            </Label>
+            <Label className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer">
+              <RadioGroupItem value="INFO_ONLY" id="mode-info" className="mt-0.5" />
+              <div>
+                <div className="font-medium">Info only</div>
+                <p className="text-xs text-muted-foreground">Tracey answers questions and takes messages only. No bookings or outbound actions.</p>
+              </div>
+            </Label>
+          </RadioGroup>
+          <div className="flex justify-end pt-2">
+            <Button onClick={saveMode} disabled={saving}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      <section>
+        <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1">Working hours</h4>
+        <p className="text-sm text-slate-500 mb-4">
+          Tracey uses these to know when to book jobs and when to tell callers the team will be in touch the next business day.
+        </p>
+        <WorkingHoursForm
+          initialData={{
+            workingHoursStart,
+            workingHoursEnd,
+            agendaNotifyTime: "07:30",
+            wrapupNotifyTime: "17:30",
+          }}
+        />
+      </section>
+    </div>
+  )
+}

--- a/livekit-agent/agent.ts
+++ b/livekit-agent/agent.ts
@@ -1451,6 +1451,105 @@ function buildWorkspaceLookupTools(grounding: WorkspaceVoiceGrounding): livekitL
   };
 }
 
+function buildSchedulingTools(grounding: WorkspaceVoiceGrounding): livekitLlm.ToolContext<unknown> {
+  const appUrl = getAppBaseUrl();
+  const secret = getVoiceAgentWebhookSecret();
+  const workspaceId = grounding.workspaceId;
+  const mode = grounding.customerContactMode;
+
+  const callSchedulingApi = async (body: Record<string, unknown>) => {
+    if (!appUrl || !secret) throw new Error("Missing APP URL or webhook secret");
+    const response = await fetch(`${appUrl.replace(/\/$/, "")}/api/internal/voice-scheduling`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-voice-agent-secret": secret },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`voice-scheduling API ${response.status}: ${text}`);
+    }
+    return response.json();
+  };
+
+  const tools: livekitLlm.ToolContext<unknown> = {
+    check_availability: livekitLlm.tool({
+      description:
+        "Check when the business has availability to book a job. Call this when a caller asks about scheduling or wants to book a time.",
+      parameters: z.object({
+        date_hint: z
+          .string()
+          .optional()
+          .describe("Optional preferred date or week the caller mentioned, e.g. 'this week' or 'Monday'"),
+      }),
+      execute: async ({ date_hint }) => {
+        try {
+          const result = await callSchedulingApi({ action: "check_availability", workspaceId, date: date_hint });
+          return (result as { summary?: string }).summary ?? "Availability information retrieved.";
+        } catch (e) {
+          console.error("[scheduling] check_availability failed:", e);
+          return "Could not retrieve availability right now. Let the caller know the team will follow up to confirm a time.";
+        }
+      },
+    }),
+
+    find_nearby_jobs: livekitLlm.tool({
+      description:
+        "Check if there are other jobs booked nearby on the same day. Call this after the caller gives an address and a preferred date, before confirming a booking, to flag efficient clustering.",
+      parameters: z.object({
+        address: z.string().describe("The job address provided by the caller"),
+        date: z.string().describe("The proposed booking date, e.g. 'Monday' or '2024-03-18'"),
+      }),
+      execute: async ({ address, date }) => {
+        try {
+          const result = await callSchedulingApi({ action: "find_nearby", workspaceId, address, date });
+          return (result as { summary?: string }).summary ?? "No nearby jobs found on that day.";
+        } catch (e) {
+          console.error("[scheduling] find_nearby_jobs failed:", e);
+          return "Could not check nearby jobs.";
+        }
+      },
+    }),
+  };
+
+  if (mode === "execute") {
+    (tools as Record<string, livekitLlm.ToolContext<unknown>[string]>).create_and_schedule_job = livekitLlm.tool({
+      description:
+        "Book and schedule a job for the caller. Only call this when you have all required details (name, address, work description) AND the caller has verbally confirmed the booking. This creates the job immediately in the system.",
+      parameters: z.object({
+        clientName: z.string().describe("Caller's full name"),
+        address: z.string().describe("Job site address"),
+        workDescription: z.string().describe("Description of the work requested"),
+        schedule: z
+          .string()
+          .optional()
+          .describe("Agreed date and time, e.g. 'Monday 9am' or '2024-03-18 09:00'"),
+        phone: z.string().optional().describe("Caller's phone number"),
+        email: z.string().optional().describe("Caller's email address"),
+        price: z.number().optional().describe("Agreed price in dollars if discussed"),
+      }),
+      execute: async (params) => {
+        try {
+          const result = await callSchedulingApi({ action: "create_job", workspaceId, ...params }) as {
+            success?: boolean;
+            dealId?: string;
+            contactId?: string;
+            error?: string;
+          };
+          if (result.success) {
+            return `Job booked successfully. Confirm the booking with the caller and let them know the team will be in touch to confirm the exact time.`;
+          }
+          return `Could not book the job: ${result.error ?? "unknown error"}. Let the caller know the team will follow up within the hour to confirm.`;
+        } catch (e) {
+          console.error("[scheduling] create_and_schedule_job failed:", e);
+          return "Booking system unavailable right now. Let the caller know the team will call them back within 30 minutes to confirm.";
+        }
+      },
+    });
+  }
+
+  return tools;
+}
+
 export default defineAgent({
   prewarm: async () => {
     await prewarmVoiceProcess();
@@ -1748,6 +1847,7 @@ export default defineAgent({
     }
 
     const normalLookupTools = normalVoiceGrounding ? buildWorkspaceLookupTools(normalVoiceGrounding) : {};
+    const normalSchedulingTools = normalVoiceGrounding ? buildSchedulingTools(normalVoiceGrounding) : {};
     const tools: livekitLlm.ToolContext<unknown> = isEarlymarkCall
       ? {
         log_lead: logLeadTool,
@@ -1756,6 +1856,7 @@ export default defineAgent({
       : {
         transfer_call: transferCallTool,
         ...normalLookupTools,
+        ...normalSchedulingTools,
       };
 
     class TraceyVoiceAgent extends voice.Agent {


### PR DESCRIPTION
- Voice agent: add check_availability, find_nearby_jobs, and create_and_schedule_job (EXECUTION mode only) tools backed by new /api/internal/voice-scheduling HTTP endpoint
- Automations: add send_sms action type with Twilio execution + SMS option in automation UI
- Settings: add /crm/settings/training (Teach Tracey) page with 4 tabs — Services & Pricing, Rules & Boundaries, Documents, Preferences — and add it to the settings sidebar nav

https://claude.ai/code/session_01Kk5JXehGGL6YFhDqK9FDQh