### PR TITLE
PR3: Google Review URL, unified contact timeline, recurring jobs

### DIFF
--- a/actions/deal-actions.ts
+++ b/actions/deal-actions.ts
@@ -1278,3 +1278,50 @@ export async function searchDeals(workspaceId: string, query: string): Promise<D
   const results = fuzzySearch(searchable, query);
   return results.map((r) => r.item.deal);
 }
+
+// ─── Recurring Jobs ──────────────────────────────────────────────────────────
+
+export interface RecurrenceRule {
+  unit: "day" | "week" | "fortnight" | "month"
+  interval: number
+  endDate?: string // ISO date string, optional
+}
+
+/**
+ * Set or clear a recurrence rule on a deal.
+ * Stored in deal.metadata.recurrence.
+ */
+export async function setDealRecurrence(
+  dealId: string,
+  rule: RecurrenceRule | null
+): Promise<{ success: boolean; error?: string }> {
+  const { deal } = await requireDealInCurrentWorkspace(dealId)
+  if (!deal) return { success: false, error: "Deal not found" }
+
+  const existing = (deal.metadata as Record<string, unknown>) ?? {}
+  const updated = { ...existing }
+
+  if (rule === null) {
+    delete updated.recurrence
+  } else {
+    updated.recurrence = rule
+  }
+
+  await db.deal.update({
+    where: { id: dealId },
+    data: { metadata: JSON.parse(JSON.stringify(updated)) },
+  })
+
+  return { success: true }
+}
+
+/**
+ * Get the recurrence rule for a deal, if any.
+ */
+export async function getDealRecurrence(dealId: string): Promise<RecurrenceRule | null> {
+  const deal = await db.deal.findUnique({ where: { id: dealId }, select: { metadata: true } })
+  if (!deal) return null
+  const meta = (deal.metadata as Record<string, unknown>) ?? {}
+  const rule = meta.recurrence as RecurrenceRule | undefined
+  return rule ?? null
+}

--- a/actions/settings-actions.ts
+++ b/actions/settings-actions.ts
@@ -87,6 +87,7 @@ export async function getWorkspaceSettings() {
         transcribeVoicemails: (s.transcribeVoicemails as boolean) ?? true,
         autoRespondToMessages: (s.autoRespondToMessages as boolean) ?? true,
         weeklyHours: s.weeklyHours ? normalizeWeeklyHours(s.weeklyHours) : undefined,
+        googleReviewUrl: (s.googleReviewUrl as string) ?? "",
     }
 }
 
@@ -135,6 +136,7 @@ export async function updateWorkspaceSettings(input: {
     callForwardingMode?: "full" | "backup" | "off"
     callForwardingDelaySec?: number
     callForwardingCarrier?: CallForwardingCarrier
+    googleReviewUrl?: string
 }) {
     const workspaceId = await getWorkspaceId()
     const normalizedMode = normalizeAppAgentMode(input.agentMode) as AgentMode
@@ -162,6 +164,7 @@ export async function updateWorkspaceSettings(input: {
         "recordCalls", "transcriptionQuality", "agentPersonality", "agentResponseLength",
         "voiceEnabled", "voiceLanguage", "voiceType", "voiceSpeed",
         "voiceGreeting", "voiceAfterHoursMessage", "transcribeVoicemails", "autoRespondToMessages", "weeklyHours",
+        "googleReviewUrl",
     ] as const
     let settingsUpdate: Record<string, unknown> | undefined = undefined
     const s = input as Record<string, unknown>

--- a/actions/sms-templates.ts
+++ b/actions/sms-templates.ts
@@ -96,7 +96,10 @@ export async function getMessagePreview(
   const [deal, template] = await Promise.all([
     db.deal.findUnique({
       where: { id: dealId },
-      include: { contact: true },
+      include: {
+        contact: true,
+        workspace: { select: { settings: true } },
+      },
     }),
     db.smsTemplate.findFirst({
       where: { userId, triggerEvent },
@@ -106,8 +109,12 @@ export async function getMessagePreview(
   if (!deal) return null;
 
   const contact = deal.contact;
+  const workspaceSettings = (deal.workspace?.settings as Record<string, unknown>) ?? {};
+  const googleReviewUrl = (workspaceSettings.googleReviewUrl as string) ?? "";
   const rawContent = template?.content ?? DEFAULT_TEMPLATES[triggerEvent];
-  const messageBody = rawContent.replace(/\[Name\]/g, contact.name);
+  const messageBody = rawContent
+    .replace(/\[Name\]/g, contact.name)
+    .replace(/\[Link\]/g, googleReviewUrl || "your review link");
 
   // Determine channel based on what the contact has
   const channel: "sms" | "email" =

--- a/app/api/cron/recurring-jobs/route.ts
+++ b/app/api/cron/recurring-jobs/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import type { RecurrenceRule } from "@/actions/deal-actions";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Cron: clone recurring deals whose scheduledAt has passed and haven't been cloned yet for the next cycle.
+ *
+ * Trigger this endpoint from a cron service (e.g. Vercel Cron, Supabase pg_cron) once per day.
+ * Secure with the CRON_SECRET env variable.
+ *
+ * Call: GET /api/cron/recurring-jobs
+ * Header: Authorization: Bearer <CRON_SECRET>
+ */
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  let cloned = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  // Find all deals that have a recurrence rule, are past their scheduledAt, and not in terminal stages
+  const candidates = await db.deal.findMany({
+    where: {
+      scheduledAt: { lt: now },
+      stage: { in: ["SCHEDULED", "NEGOTIATION", "CONTACTED", "NEW"] },
+      jobStatus: { notIn: ["COMPLETED", "CANCELLED"] },
+    },
+    select: {
+      id: true,
+      title: true,
+      value: true,
+      stage: true,
+      address: true,
+      latitude: true,
+      longitude: true,
+      workspaceId: true,
+      contactId: true,
+      assignedToId: true,
+      metadata: true,
+      scheduledAt: true,
+    },
+  });
+
+  for (const deal of candidates) {
+    const meta = (deal.metadata as Record<string, unknown>) ?? {};
+    const rule = meta.recurrence as RecurrenceRule | undefined;
+    if (!rule?.unit) continue;
+
+    const lastCloned = meta.recurrenceLastClonedAt as string | undefined;
+    const nextOccurrence = computeNextOccurrence(deal.scheduledAt!, rule, lastCloned);
+
+    if (!nextOccurrence) {
+      skipped++;
+      continue;
+    }
+
+    // Check if end date has passed
+    if (rule.endDate && nextOccurrence > new Date(rule.endDate)) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      // Clone the deal with the new scheduledAt
+      await db.deal.create({
+        data: {
+          title: deal.title,
+          value: deal.value,
+          stage: deal.stage,
+          address: deal.address ?? undefined,
+          latitude: deal.latitude,
+          longitude: deal.longitude,
+          workspaceId: deal.workspaceId,
+          contactId: deal.contactId ?? undefined,
+          assignedToId: deal.assignedToId ?? undefined,
+          scheduledAt: nextOccurrence,
+          metadata: JSON.parse(JSON.stringify({
+            ...meta,
+            recurrence: rule,
+            recurrenceSourceId: deal.id,
+            recurrenceLastClonedAt: undefined,
+          })),
+        },
+      });
+
+      // Update the original deal's lastClonedAt so we don't clone it again
+      await db.deal.update({
+        where: { id: deal.id },
+        data: {
+          metadata: JSON.parse(JSON.stringify({
+            ...meta,
+            recurrenceLastClonedAt: now.toISOString(),
+          })),
+        },
+      });
+
+      cloned++;
+      console.log(`[cron/recurring-jobs] Cloned "${deal.title}" → next: ${nextOccurrence.toISOString()}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${deal.id}: ${msg}`);
+      console.error(`[cron/recurring-jobs] Failed to clone ${deal.id}:`, err);
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    processed: candidates.length,
+    cloned,
+    skipped,
+    errors,
+    runAt: now.toISOString(),
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function addInterval(date: Date, unit: RecurrenceRule["unit"], interval: number): Date {
+  const next = new Date(date);
+  switch (unit) {
+    case "day":
+      next.setDate(next.getDate() + interval);
+      break;
+    case "week":
+      next.setDate(next.getDate() + interval * 7);
+      break;
+    case "fortnight":
+      next.setDate(next.getDate() + 14);
+      break;
+    case "month":
+      next.setMonth(next.getMonth() + interval);
+      break;
+  }
+  return next;
+}
+
+function computeNextOccurrence(
+  scheduledAt: Date,
+  rule: RecurrenceRule,
+  lastClonedAt?: string
+): Date | null {
+  const now = new Date();
+
+  if (!lastClonedAt) {
+    // Never cloned — next occurrence is one interval after scheduledAt
+    const next = addInterval(scheduledAt, rule.unit, rule.interval);
+    return next > now ? next : null; // only clone future occurrences
+  }
+
+  // Already cloned: next occurrence is one interval after lastClonedAt's derived base
+  const lastCloned = new Date(lastClonedAt);
+  const elapsed = now.getTime() - lastCloned.getTime();
+  const intervalMs = intervalToMs(rule.unit, rule.interval);
+
+  if (elapsed < intervalMs) {
+    return null; // too soon
+  }
+
+  return addInterval(lastCloned, rule.unit, rule.interval);
+}
+
+function intervalToMs(unit: RecurrenceRule["unit"], interval: number): number {
+  const DAY_MS = 86400000;
+  switch (unit) {
+    case "day": return DAY_MS * interval;
+    case "week": return DAY_MS * 7 * interval;
+    case "fortnight": return DAY_MS * 14;
+    case "month": return DAY_MS * 30 * interval;
+  }
+}

--- a/app/crm/contacts/[id]/page.tsx
+++ b/app/crm/contacts/[id]/page.tsx
@@ -4,10 +4,11 @@ import { notFound } from "next/navigation"
 import { ContactNotes } from "@/components/crm/contact-notes"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { ChevronLeft, ChevronRight, Edit, Mail, Phone, Building, MapPin, MessageSquare, FileText, Briefcase, AlertCircle, AlertTriangle, Home } from "lucide-react"
+import { ChevronLeft, ChevronRight, Edit, Mail, Phone, Building, MapPin, MessageSquare, FileText, Briefcase, AlertCircle, AlertTriangle, Home, PhoneCall, AtSign, StickyNote, Briefcase as BriefcaseIcon } from "lucide-react"
 import Link from "next/link"
 import { format } from "date-fns"
 import { PRISMA_STAGE_LABELS } from "@/lib/deal-utils"
+import { getActivities } from "@/actions/activity-actions"
 
 export const dynamic = "force-dynamic"
 
@@ -48,6 +49,8 @@ export default async function ContactDetailPage({ params }: PageProps) {
   const contactType = (metadata.contactType as string) === "BUSINESS" ? "BUSINESS" : "PERSON"
   const notes = (metadata.notes as string) ?? ""
   const [currentDeal, ...pastDeals] = contact.deals
+
+  const activities = await getActivities({ contactId: id, limit: 40 })
 
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)] p-4 md:p-6 gap-4 overflow-hidden">
@@ -269,13 +272,13 @@ export default async function ContactDetailPage({ params }: PageProps) {
           )}
         </div>
 
-        {/* Right: Past jobs + Notes */}
+        {/* Right: Activity timeline + Notes */}
         <div className="lg:col-span-2 flex flex-col gap-4 min-h-0">
           <div className="flex-1 min-h-0 border border-slate-200 dark:border-border rounded-lg bg-white dark:bg-card flex flex-col overflow-hidden shadow-sm">
             <div className="p-3 border-b border-slate-100 dark:border-border font-semibold text-slate-900 dark:text-foreground bg-slate-50/50 dark:bg-slate-800/40 flex items-center justify-between shrink-0">
               <span className="flex items-center gap-2">
                 <MessageSquare className="w-4 h-4" />
-                Past jobs & notes
+                Activity & history
               </span>
               <div className="flex items-center gap-1.5">
                 {contact.phone && (
@@ -302,28 +305,55 @@ export default async function ContactDetailPage({ params }: PageProps) {
               </div>
             </div>
             <div className="flex-1 overflow-hidden grid grid-cols-1 md:grid-cols-2 gap-0 min-h-0">
+              {/* Left: unified chronological timeline */}
               <div className="border-b md:border-b-0 md:border-r border-slate-100 dark:border-border flex flex-col min-h-0">
-                <p className="text-xs font-medium text-slate-500 px-3 py-2 border-b border-slate-100 dark:border-border">Past jobs</p>
-                <div className="flex-1 overflow-y-auto p-3 space-y-2">
-                  {(pastDeals.length === 0 && !currentDeal) ? (
-                    <p className="text-slate-500 text-sm">No jobs yet.</p>
-                  ) : pastDeals.length === 0 ? (
-                    <p className="text-slate-500 text-sm">No other jobs.</p>
+                <p className="text-xs font-medium text-slate-500 px-3 py-2 border-b border-slate-100 dark:border-border">Timeline</p>
+                <div className="flex-1 overflow-y-auto p-3">
+                  {activities.length === 0 && pastDeals.length === 0 ? (
+                    <p className="text-slate-500 text-sm py-4 text-center">No activity yet.</p>
                   ) : (
-                    pastDeals.map((d) => (
-                      <Link
-                        key={d.id}
-                        href={`/crm/deals/${d.id}`}
-                        className="block p-2 rounded-lg border border-slate-100 dark:border-border hover:bg-slate-50 dark:hover:bg-slate-800/50 text-sm"
-                      >
-                        <span className="font-medium text-slate-900 dark:text-foreground">{d.title}</span>
-                        <span className="text-slate-500 ml-2">${Number(d.value).toLocaleString("en-AU")}</span>
-                        <span className="text-slate-400 text-xs block mt-0.5">{PRISMA_STAGE_LABELS[d.stage] ?? d.stage} • {format(new Date(d.updatedAt), "MMM d")}</span>
-                      </Link>
-                    ))
+                    <div className="space-y-3">
+                      {/* Past jobs at the top */}
+                      {pastDeals.map((d) => (
+                        <Link
+                          key={d.id}
+                          href={`/crm/deals/${d.id}`}
+                          className="flex items-start gap-2.5 p-2 rounded-lg border border-slate-100 dark:border-border hover:bg-slate-50 dark:hover:bg-slate-800/50 text-sm"
+                        >
+                          <div className="mt-0.5 h-6 w-6 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                            <BriefcaseIcon className="w-3 h-3 text-slate-500" />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-slate-900 dark:text-foreground truncate">{d.title}</p>
+                            <p className="text-xs text-slate-400">{PRISMA_STAGE_LABELS[d.stage] ?? d.stage} • ${Number(d.value).toLocaleString("en-AU")} • {format(new Date(d.updatedAt), "MMM d")}</p>
+                          </div>
+                        </Link>
+                      ))}
+                      {/* Activity feed */}
+                      {activities.map((a) => {
+                        const icon = a.type === "call"
+                          ? <PhoneCall className="w-3 h-3 text-blue-500" />
+                          : a.type === "email"
+                          ? <AtSign className="w-3 h-3 text-purple-500" />
+                          : <StickyNote className="w-3 h-3 text-amber-500" />
+                        return (
+                          <div key={a.id} className="flex items-start gap-2.5 text-sm">
+                            <div className="mt-0.5 h-6 w-6 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center shrink-0">
+                              {icon}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <p className="font-medium text-slate-900 dark:text-foreground leading-snug truncate">{a.title}</p>
+                              {a.description && <p className="text-xs text-slate-500 truncate">{a.description}</p>}
+                              <p className="text-xs text-slate-400 mt-0.5">{a.time}</p>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
                   )}
                 </div>
               </div>
+              {/* Right: notes */}
               <div className="flex flex-col min-h-0">
                 <p className="text-xs font-medium text-slate-500 px-3 py-2 border-b border-slate-100 dark:border-border">Notes</p>
                 <div className="flex-1 overflow-y-auto p-3">

--- a/app/crm/deals/[id]/edit/deal-edit-form.tsx
+++ b/app/crm/deals/[id]/edit/deal-edit-form.tsx
@@ -7,8 +7,9 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { updateDeal, updateDealMetadata, updateDealAssignedTo } from "@/actions/deal-actions"
+import { updateDeal, updateDealMetadata, updateDealAssignedTo, setDealRecurrence, type RecurrenceRule } from "@/actions/deal-actions"
 import { toast } from "sonner"
+import { Switch } from "@/components/ui/switch"
 
 interface TeamMemberOption {
   id: string
@@ -28,6 +29,7 @@ interface DealEditFormProps {
   initialAssignedToId: string
   teamMembers: TeamMemberOption[]
   stageOptions: { value: string; label: string }[]
+  initialRecurrence?: RecurrenceRule | null
 }
 
 export function DealEditForm({
@@ -41,6 +43,7 @@ export function DealEditForm({
   initialAssignedToId,
   teamMembers,
   stageOptions,
+  initialRecurrence,
 }: DealEditFormProps) {
   const router = useRouter()
   const [title, setTitle] = useState(initialTitle)
@@ -51,6 +54,10 @@ export function DealEditForm({
   const [scheduledAt, setScheduledAt] = useState(initialScheduledAt)
   const [assignedToId, setAssignedToId] = useState(initialAssignedToId)
   const [saving, setSaving] = useState(false)
+  const [isRecurring, setIsRecurring] = useState(!!initialRecurrence)
+  const [recurrenceUnit, setRecurrenceUnit] = useState<RecurrenceRule["unit"]>(initialRecurrence?.unit ?? "week")
+  const [recurrenceInterval, setRecurrenceInterval] = useState(String(initialRecurrence?.interval ?? 1))
+  const [recurrenceEndDate, setRecurrenceEndDate] = useState(initialRecurrence?.endDate ?? "")
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -86,6 +93,12 @@ export function DealEditForm({
       if (notes !== initialNotes) {
         await updateDealMetadata(dealId, { notes })
       }
+      // Save recurrence rule
+      const interval = parseInt(recurrenceInterval, 10)
+      const recurrenceRule: RecurrenceRule | null = isRecurring
+        ? { unit: recurrenceUnit, interval: isNaN(interval) || interval < 1 ? 1 : interval, endDate: recurrenceEndDate || undefined }
+        : null
+      await setDealRecurrence(dealId, recurrenceRule)
       toast.success("Deal updated")
       router.push(`/crm/deals/${dealId}`)
       router.refresh()
@@ -141,6 +154,54 @@ export function DealEditForm({
           className="max-w-md"
         />
       </div>
+
+      {/* Recurrence */}
+      <div className="space-y-3 rounded-lg border border-slate-200 dark:border-slate-700 p-4 max-w-md">
+        <div className="flex items-center justify-between">
+          <div>
+            <Label className="font-medium">Repeat this job</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">Tracey will automatically clone this job on the next cycle.</p>
+          </div>
+          <Switch checked={isRecurring} onCheckedChange={setIsRecurring} />
+        </div>
+        {isRecurring && (
+          <div className="space-y-3 pt-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-slate-600 dark:text-slate-400 shrink-0">Every</span>
+              <Input
+                type="number"
+                min={1}
+                max={52}
+                value={recurrenceInterval}
+                onChange={(e) => setRecurrenceInterval(e.target.value)}
+                className="w-16 h-8 text-sm"
+              />
+              <Select value={recurrenceUnit} onValueChange={(v) => setRecurrenceUnit(v as RecurrenceRule["unit"])}>
+                <SelectTrigger className="w-32 h-8 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="day">day(s)</SelectItem>
+                  <SelectItem value="week">week(s)</SelectItem>
+                  <SelectItem value="fortnight">fortnight</SelectItem>
+                  <SelectItem value="month">month(s)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="recurrence-end" className="text-xs text-slate-600 dark:text-slate-400">End date (optional)</Label>
+              <Input
+                id="recurrence-end"
+                type="date"
+                value={recurrenceEndDate}
+                onChange={(e) => setRecurrenceEndDate(e.target.value)}
+                className="max-w-[160px] h-8 text-sm"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className="space-y-2">
         <Label>Stage</Label>
         <Select value={stage} onValueChange={setStage}>

--- a/app/crm/deals/[id]/edit/page.tsx
+++ b/app/crm/deals/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight, Home } from "lucide-react"
 import { getTeamMembers } from "@/actions/invite-actions"
 import { DealEditForm } from "./deal-edit-form"
 import { PRISMA_STAGE_TO_UI_STAGE, STAGE_OPTIONS } from "@/lib/deal-utils"
+import { getDealRecurrence } from "@/actions/deal-actions"
 
 interface PageProps {
   params: Promise<{ id: string }>
@@ -15,12 +16,13 @@ export default async function DealEditPage({ params }: PageProps) {
   const { id } = await params
   const actor = await requireCurrentWorkspaceAccess()
 
-  const [deal, teamMembers] = await Promise.all([
+  const [deal, teamMembers, recurrence] = await Promise.all([
     db.deal.findFirst({
       where: { id, workspaceId: actor.workspaceId },
       include: { contact: true, assignedTo: { select: { id: true, name: true } } },
     }),
     getTeamMembers(),
+    getDealRecurrence(id),
   ])
 
   if (!deal) notFound()
@@ -67,6 +69,7 @@ export default async function DealEditPage({ params }: PageProps) {
         initialAssignedToId={deal.assignedToId ?? ""}
         teamMembers={teamMembers}
         stageOptions={STAGE_OPTIONS}
+        initialRecurrence={recurrence}
       />
     </div>
   )

--- a/app/crm/settings/my-business/page.tsx
+++ b/app/crm/settings/my-business/page.tsx
@@ -8,7 +8,9 @@ import { BusinessContactForm } from "@/components/settings/business-contact-form
 import { ServiceAreasSection } from "@/components/settings/service-areas-section"
 import { PricingForAgentSection } from "@/components/settings/pricing-for-agent-section"
 import { AttachmentLibrarySection } from "@/components/settings/attachment-library-section"
+import { GoogleReviewUrlSection } from "@/components/settings/google-review-url-section"
 import { db } from "@/lib/db"
+import { getWorkspaceSettings } from "@/actions/settings-actions"
 
 export const dynamic = "force-dynamic"
 
@@ -26,6 +28,9 @@ export default async function MyBusinessSettingsPage() {
     where: { workspaceId: workspace.id },
     orderBy: { createdAt: 'desc' }
   })
+
+  const wsSettings = await getWorkspaceSettings()
+  const googleReviewUrl = wsSettings?.googleReviewUrl ?? ""
 
   return (
     <div className="space-y-8">
@@ -101,6 +106,12 @@ export default async function MyBusinessSettingsPage() {
             fileType: d.fileType ?? null,
           }))}
         />
+      </section>
+      <Separator />
+
+      <section>
+        <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">Reviews</h4>
+        <GoogleReviewUrlSection initialUrl={googleReviewUrl} />
       </section>
     </div>
   )

--- a/components/settings/google-review-url-section.tsx
+++ b/components/settings/google-review-url-section.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Star, ExternalLink } from "lucide-react"
+import { toast } from "sonner"
+import { updateWorkspaceSettings, getWorkspaceSettings } from "@/actions/settings-actions"
+
+interface GoogleReviewUrlSectionProps {
+  initialUrl: string
+}
+
+export function GoogleReviewUrlSection({ initialUrl }: GoogleReviewUrlSectionProps) {
+  const [url, setUrl] = useState(initialUrl)
+  const [saving, setSaving] = useState(false)
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      const current = await getWorkspaceSettings()
+      if (!current) throw new Error("Could not load settings")
+      await updateWorkspaceSettings({
+        ...current,
+        agentMode: current.agentMode ?? "DRAFT",
+        workingHoursStart: current.workingHoursStart ?? "08:00",
+        workingHoursEnd: current.workingHoursEnd ?? "17:00",
+        agendaNotifyTime: current.agendaNotifyTime ?? "07:30",
+        wrapupNotifyTime: current.wrapupNotifyTime ?? "17:30",
+        googleReviewUrl: url.trim(),
+      })
+      toast.success("Google Review URL saved")
+    } catch {
+      toast.error("Failed to save")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Star className="h-5 w-5 text-amber-500" />
+          <CardTitle className="text-base">Google Review link</CardTitle>
+        </div>
+        <CardDescription>
+          Tracey sends this link to customers after a job is completed. Get your link from Google Business Profile → Ask for reviews.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="review-url">Review URL</Label>
+          <div className="flex gap-2 max-w-lg">
+            <Input
+              id="review-url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://g.page/r/your-business/review"
+              className="flex-1"
+            />
+            {url && (
+              <Button variant="outline" size="icon" asChild>
+                <a href={url} target="_blank" rel="noopener noreferrer" aria-label="Test link">
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            This replaces the <code className="bg-slate-100 dark:bg-slate-800 px-1 rounded">[Link]</code> placeholder in your job completion SMS template.
+          </p>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={save} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
- Reviews: add googleReviewUrl to workspace settings (JSON field), wire [Link] placeholder in JOB_COMPLETE SMS to the review URL, add GoogleReviewUrlSection to My Business settings page
- Contact timeline: replace "Past jobs" column on contact detail page with a unified chronological activity feed (calls, emails, notes, voice calls via getActivities), past jobs shown above the feed
- Recurring jobs: setDealRecurrence/getDealRecurrence actions store recurrence rule in deal.metadata; /api/cron/recurring-jobs clones deals each cycle; deal edit form now has "Repeat this job" toggle with interval, unit (day/week/fortnight/month), and end date

https://claude.ai/code/session_01Kk5JXehGGL6YFhDqK9FDQh