### PR TITLE
Make dashboard status and health text human-readable

### DIFF
--- a/app/admin/customer-usage/page.tsx
+++ b/app/admin/customer-usage/page.tsx
@@ -104,6 +104,15 @@ function formatRelativeDate(value: string | null | undefined) {
   return { text: `${diffDays}d ago`, className: "text-red-600" };
 }
 
+function formatProvisioningIssue(status: string | null) {
+  if (!status) return null;
+  if (status === "failed") return "Setup failed";
+  if (status === "blocked_duplicate") return "Setup blocked (duplicate)";
+  if (status === "requested") return "Setup pending";
+  if (status === "provisioning") return "Setting up";
+  return status;
+}
+
 function CoverageDots({ coverage }: { coverage: { stripe: CoverageStatus; twilio: CoverageStatus; aiEstimate: CoverageStatus } }) {
   const dotColor = (status: CoverageStatus) =>
     status === "live" ? "bg-emerald-500" : status === "degraded" ? "bg-amber-400" : "bg-red-500";
@@ -366,16 +375,12 @@ function CustomerTable({
                 {/* Status: subscription + voice enabled + onboarding */}
                 <TableCell>
                   <Badge variant={statusVariant(row.attentionLevel)}>{row.subscriptionStatus}</Badge>
-                  <div className="mt-1.5 flex items-center gap-2">
-                    <span
-                      className={`inline-block h-2 w-2 rounded-full ${row.voiceEnabled ? "bg-emerald-500" : "bg-slate-300"}`}
-                      title={row.voiceEnabled ? "Voice enabled" : "Voice disabled"}
-                    />
-                    <span
-                      className={`text-[11px] ${row.onboardingComplete ? "text-emerald-600" : "text-slate-400"}`}
-                      title={row.onboardingComplete ? "Onboarding complete" : "Onboarding incomplete"}
-                    >
-                      {row.onboardingComplete ? "\u2713" : "\u2717"}
+                  <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px]">
+                    <span className={row.voiceEnabled ? "text-emerald-600" : "text-slate-400"}>
+                      {row.voiceEnabled ? "\u25CF Voice on" : "\u25CB Voice off"}
+                    </span>
+                    <span className={row.onboardingComplete ? "text-emerald-600" : "text-slate-400"}>
+                      {row.onboardingComplete ? "\u2713 Onboarded" : "\u2717 Not onboarded"}
                     </span>
                   </div>
                 </TableCell>
@@ -426,9 +431,9 @@ function CustomerTable({
                       </span>
                     ) : null}
                   </div>
-                  {row.provisioningIssue || row.attentionReasons[0] ? (
-                    <div className="mt-1 truncate text-[11px] text-slate-500" title={row.provisioningIssue || row.attentionReasons[0]}>
-                      {row.provisioningIssue || row.attentionReasons[0]}
+                  {formatProvisioningIssue(row.provisioningIssue) || row.attentionReasons[0] ? (
+                    <div className="mt-1 truncate text-[11px] text-slate-500" title={formatProvisioningIssue(row.provisioningIssue) || row.attentionReasons[0] || ""}>
+                      {formatProvisioningIssue(row.provisioningIssue) || row.attentionReasons[0]}
                     </div>
                   ) : null}
                   <div className="mt-1">

--- a/lib/admin/customer-usage.ts
+++ b/lib/admin/customer-usage.ts
@@ -1005,40 +1005,51 @@ function buildAttentionState(input: {
   const criticalReasons: string[] = [];
   const warningReasons: string[] = [];
 
-  if (["past_due", "unpaid", "canceled", "incomplete_expired"].includes(input.subscriptionStatus.toLowerCase())) {
-    criticalReasons.push(`Subscription ${input.subscriptionStatus}`);
+  const subStatus = input.subscriptionStatus.toLowerCase();
+  if (subStatus === "past_due") {
+    criticalReasons.push("Billing past due");
+  } else if (subStatus === "unpaid") {
+    criticalReasons.push("Billing unpaid");
+  } else if (subStatus === "canceled") {
+    criticalReasons.push("Subscription cancelled");
+  } else if (subStatus === "incomplete_expired") {
+    criticalReasons.push("Subscription expired");
   }
 
-  if (input.provisioningIssue?.provisioningStatus === "failed" || input.provisioningIssue?.provisioningStatus === "blocked_duplicate") {
-    criticalReasons.push(`Provisioning ${input.provisioningIssue.provisioningStatus}`);
-  } else if (input.provisioningIssue?.provisioningStatus === "requested" || input.provisioningIssue?.provisioningStatus === "provisioning") {
-    warningReasons.push(`Provisioning ${input.provisioningIssue.provisioningStatus}`);
+  if (input.provisioningIssue?.provisioningStatus === "failed") {
+    criticalReasons.push("Setup failed");
+  } else if (input.provisioningIssue?.provisioningStatus === "blocked_duplicate") {
+    criticalReasons.push("Setup blocked (duplicate)");
+  } else if (input.provisioningIssue?.provisioningStatus === "requested") {
+    warningReasons.push("Setup pending");
+  } else if (input.provisioningIssue?.provisioningStatus === "provisioning") {
+    warningReasons.push("Setting up");
   }
 
   if (input.incidents > 0) {
-    criticalReasons.push(`${input.incidents} open voice incident${input.incidents === 1 ? "" : "s"}`);
+    criticalReasons.push(`${input.incidents} voice issue${input.incidents === 1 ? "" : "s"}`);
   }
 
   if (input.passiveWorkspaceHealth?.overallStatus === "unhealthy") {
-    criticalReasons.push(`Passive production ${input.passiveWorkspaceHealth.overallClassification}`);
+    criticalReasons.push(`Health check: ${input.passiveWorkspaceHealth.overallClassification}`);
   } else if (input.passiveWorkspaceHealth?.overallStatus === "degraded") {
-    warningReasons.push(`Passive production ${input.passiveWorkspaceHealth.overallClassification}`);
+    warningReasons.push(`Health check: ${input.passiveWorkspaceHealth.overallClassification}`);
   }
 
   if (!input.lastActivityAt || input.lastActivityAt < subDays(new Date(), 30)) {
-    warningReasons.push("No meaningful workspace activity in the last 30 days");
+    warningReasons.push("Inactive 30+ days");
   }
 
   if (input.rowVoiceEnabled && input.twilioCoverage !== "live") {
-    warningReasons.push(`Twilio coverage ${input.twilioCoverage}`);
+    warningReasons.push(input.twilioCoverage === "missing" ? "Twilio not connected" : "Twilio degraded");
   }
 
   if (input.subscriptionStatus.toLowerCase() === "active" && input.stripeCoverage !== "live") {
-    warningReasons.push(`Stripe coverage ${input.stripeCoverage}`);
+    warningReasons.push(input.stripeCoverage === "missing" ? "Stripe not connected" : "Stripe degraded");
   }
 
   if (!input.rowVoiceEnabled) {
-    warningReasons.push("Voice disabled");
+    warningReasons.push("Voice off");
   }
 
   if (criticalReasons.length > 0) {


### PR DESCRIPTION
Replace raw internal strings in attention reasons with plain-English labels (e.g. "Billing past due" instead of "Subscription past_due", "Inactive 30+ days" instead of "No meaningful workspace activity in the last 30 days"). Add visible text labels to Status column voice and onboarding indicators instead of bare dots/symbols. Map raw provisioning status codes to friendly labels in the Health column.

https://claude.ai/code/session_01P4UL4kt4mhxvAYVHP7P6GU