### PR TITLE
Place chat-initiated calls + close 11 verified security/correctness bugs

### DIFF
--- a/.github/workflows/passive-communications-health.yml
+++ b/.github/workflows/passive-communications-health.yml
@@ -1,6 +1,10 @@
 name: Passive Communications Health
 
 on:
+  schedule:
+    # Every 30 min, staggered against the other health monitors so the
+    # fleet doesn't stampede the API on the same minute.
+    - cron: "17,47 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/voice-agent-health.yml
+++ b/.github/workflows/voice-agent-health.yml
@@ -1,6 +1,10 @@
 name: Voice Agent Health
 
 on:
+  schedule:
+    # Every 30 min, staggered against voice-monitor-watchdog (7,37) and
+    # customer-agent-reconcile (22,52) so the fleet doesn't stampede.
+    - cron: "12,42 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/voice-synthetic-probe.yml
+++ b/.github/workflows/voice-synthetic-probe.yml
@@ -1,6 +1,11 @@
 name: Voice Synthetic Probe
 
 on:
+  schedule:
+    # Every 30 min, staggered against the other health monitors. Each
+    # probe places a real outbound test call, so cost scales with this
+    # cadence — bump down if Twilio spend is a concern.
+    - cron: "5,35 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -17,5 +17,17 @@ them and Claude will pick the next pass off the same list.
 - **Why:** The hardening on `/api/webhooks/email` requires the env var to be set. Without it the route returns 503 on every inbound email and lead-provider forwarders (hipages, airtasker, oneflare) will start failing silently.
 - **What:** Pick a strong random secret (e.g. `openssl rand -hex 32`), set it as `EMAIL_WEBHOOK_SECRET` in Vercel project settings for all environments, then update each lead-provider's webhook URL config to send the value in the `x-email-webhook-secret` header.
 
+## Open — for Claude to pick up later (not blocked on you)
+
+### Fan jest-axe out across every Dialog/Sheet/Drawer
+- **Why:** The pattern is established in `__tests__/a11y-stale-job-modal.test.tsx` but only the stale-job dialog is covered. Every other dialog still mocks the Dialog primitives in its test file, so axe can't evaluate the real ARIA contract.
+- **What:** For each dialog (new-deal, deal-detail, deal-edit, stale-deal-follow-up, kanban-automation, personal-phone, job-completion, loss-reason, etc.), add an axe test that renders with the REAL Dialog primitives and stubs only the action-layer dependencies.
+
+### Verify kanban deal-card touch targets on mobile
+- **Why:** Audit flagged various `size="icon" className="h-8 w-8"` buttons in `components/crm/deal-card.tsx`. I didn't audit each one individually — needs a sweep with the rule: every interactive icon inside a card must be ≥40×40px on phone.
+
+### Audit the rest of the app
+- **Why:** The UI audit only covered `components/` and top-level `app/**/*.tsx` modal/dialog/sheet components. Other surfaces (forms outside dialogs, kanban itself, settings pages, public marketing pages) haven't been audited the same way.
+
 ## Done
 <!-- Move items here once complete so the trail is preserved. -->

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,0 +1,21 @@
+# Manual follow-ups
+
+Items that need a human (you) because they require running a dev
+server, judgement calls on infra config, or domain knowledge I can't
+infer from the codebase alone. Claude appends to this file when it
+hits something blocked on your action — please clear items as you do
+them and Claude will pick the next pass off the same list.
+
+## Open
+
+### Visual regression baselines — generate once
+- **Why:** `e2e/visual/stale-job-dialog.spec.ts` references `toHaveScreenshot()` snapshots that don't exist yet. Without baselines, the `visual` Playwright project fails on first run and CI can't enforce drift.
+- **What:** With the local dev server + seeded E2E Postgres harness running, run `npm run test:visual:update`, review the PNGs that land under `e2e/visual/__screenshots__/`, then commit and push them.
+- **Caveat:** Baselines must be generated on Linux (where CI runs). macOS font rendering produces spurious diffs that won't match in CI.
+
+### `EMAIL_WEBHOOK_SECRET` env var — set in every deployment
+- **Why:** The hardening on `/api/webhooks/email` requires the env var to be set. Without it the route returns 503 on every inbound email and lead-provider forwarders (hipages, airtasker, oneflare) will start failing silently.
+- **What:** Pick a strong random secret (e.g. `openssl rand -hex 32`), set it as `EMAIL_WEBHOOK_SECRET` in Vercel project settings for all environments, then update each lead-provider's webhook URL config to send the value in the `x-email-webhook-secret` header.
+
+## Done
+<!-- Move items here once complete so the trail is preserved. -->

--- a/__tests__/a11y-stale-job-modal.test.tsx
+++ b/__tests__/a11y-stale-job-modal.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
+
+const { reconcileStaleJob, useIsDesktop } = vi.hoisted(() => ({
+  reconcileStaleJob: vi.fn(),
+  useIsDesktop: vi.fn(),
+}));
+
+vi.mock("@/actions/stale-job-actions", () => ({ reconcileStaleJob }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/hooks/use-is-desktop", () => ({ useIsDesktop }));
+
+// Render the real Dialog / Drawer primitives — axe needs them to evaluate
+// the actual ARIA contract (roles, labels, focus management).
+
+import { StaleJobReconciliationModal } from "@/components/crm/stale-job-reconciliation-modal";
+
+const deal = {
+  id: "deal_1",
+  title: "Blocked Drain",
+  contactName: "Alex Harper",
+  scheduledAt: new Date("2026-04-09T10:00:00.000Z"),
+  address: "1 King St",
+} as never;
+
+describe("StaleJobReconciliationModal — accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reconcileStaleJob.mockResolvedValue({ success: true });
+  });
+
+  it("desktop dialog: axe-clean before any input", async () => {
+    useIsDesktop.mockReturnValue(true);
+    const { baseElement } = render(
+      <StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+    const results = await axe(baseElement);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("desktop dialog: axe-clean after selecting an outcome", async () => {
+    useIsDesktop.mockReturnValue(true);
+    const { baseElement, getByRole } = render(
+      <StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+    fireEvent.click(getByRole("radio", { name: /completed/i }));
+    const results = await axe(baseElement);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("mobile drawer: axe-clean before any input", async () => {
+    useIsDesktop.mockReturnValue(false);
+    const { baseElement } = render(
+      <StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+    const results = await axe(baseElement);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("the outcome picker is a labelled radiogroup with named radios", async () => {
+    useIsDesktop.mockReturnValue(true);
+    const { getByRole, getAllByRole } = render(
+      <StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+
+    expect(getByRole("radiogroup")).toHaveAttribute("aria-label", "Job outcome");
+    const radios = getAllByRole("radio");
+    expect(radios).toHaveLength(5);
+    for (const radio of radios) {
+      expect(radio).toHaveAccessibleName();
+      expect(radio.getAttribute("aria-checked")).toMatch(/^(true|false)$/);
+    }
+  });
+});

--- a/__tests__/chat-actions.test.ts
+++ b/__tests__/chat-actions.test.ts
@@ -75,8 +75,10 @@ const hoisted = vi.hoisted(() => ({
   requiresCustomerContactApproval: vi.fn(),
   getAttentionSignalsForDeal: vi.fn(),
   loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
   resendSend: vi.fn(),
   createSupportTicket: vi.fn(),
+  initiateOutboundCall: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({ db: hoisted.db }));
@@ -167,10 +169,14 @@ vi.mock("@/lib/deal-attention", () => ({
 vi.mock("@/lib/logging", () => ({
   logger: {
     error: hoisted.loggerError,
+    info: hoisted.loggerInfo,
   },
 }));
 vi.mock("@/lib/support-tickets", () => ({
   createSupportTicket: hoisted.createSupportTicket,
+}));
+vi.mock("@/lib/outbound-call", () => ({
+  initiateOutboundCall: hoisted.initiateOutboundCall,
 }));
 vi.mock("resend", () => ({
   Resend: class {
@@ -197,6 +203,7 @@ import {
   runListDeals,
   runListIncompleteOrBlockedJobs,
   runListInvoiceReadyJobs,
+  runMakeCall,
   runMoveDeal,
   runProposeReschedule,
   runRestoreDeal,
@@ -1354,6 +1361,62 @@ describe("chat-actions", () => {
     expect(hoisted.db.deal.update).toHaveBeenCalledWith({
       where: { id: "deal_1" },
       data: { stage: "NEW" },
+    });
+  });
+
+  describe("runMakeCall", () => {
+    beforeEach(() => {
+      hoisted.searchContacts.mockResolvedValue([
+        { id: "contact_1", name: "Michael", phone: "+61434955958" },
+      ]);
+      hoisted.db.workspace.findUnique.mockResolvedValue({
+        twilioPhoneNumber: "+61300000000",
+      });
+      hoisted.initiateOutboundCall.mockResolvedValue({
+        roomName: "outbound-ws_1-abc",
+        normalizedPhone: "+61434955958",
+        resolvedTrunkId: "trunk_1",
+        callerNumber: "+61300000000",
+        transport: "livekit_control",
+      });
+      hoisted.logActivity.mockResolvedValue(undefined);
+    });
+
+    it("actually dispatches the outbound call via initiateOutboundCall", async () => {
+      const result = await runMakeCall("ws_1", {
+        contactName: "Michael",
+        purpose: "Confirm sink repair tomorrow at 2pm",
+      });
+
+      expect(hoisted.initiateOutboundCall).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        contactPhone: "+61434955958",
+        contactName: "Michael",
+        reason: "Confirm sink repair tomorrow at 2pm",
+      });
+      expect(hoisted.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "CALL", contactId: "contact_1" })
+      );
+      expect(result).toContain("Calling Michael");
+    });
+
+    it("does NOT log a CALL activity when the dispatcher throws", async () => {
+      hoisted.initiateOutboundCall.mockRejectedValue(new Error("SIP trunk unavailable"));
+
+      const result = await runMakeCall("ws_1", { contactName: "Michael" });
+
+      expect(hoisted.logActivity).not.toHaveBeenCalled();
+      expect(result).toContain("couldn't place the call");
+      expect(result).toContain("SIP trunk unavailable");
+    });
+
+    it("refuses to call when the workspace has no Twilio number", async () => {
+      hoisted.db.workspace.findUnique.mockResolvedValue({ twilioPhoneNumber: null });
+
+      const result = await runMakeCall("ws_1", { contactName: "Michael" });
+
+      expect(hoisted.initiateOutboundCall).not.toHaveBeenCalled();
+      expect(result).toContain("No phone number configured");
     });
   });
 });

--- a/__tests__/complete-tutorial-route.test.ts
+++ b/__tests__/complete-tutorial-route.test.ts
@@ -1,57 +1,53 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { completeTutorial } = vi.hoisted(() => ({
+const hoisted = vi.hoisted(() => ({
+  requireCurrentWorkspaceAccess: vi.fn(),
   completeTutorial: vi.fn(),
 }));
 
+vi.mock("@/lib/workspace-access", () => ({
+  requireCurrentWorkspaceAccess: hoisted.requireCurrentWorkspaceAccess,
+}));
+
 vi.mock("@/actions/workspace-actions", () => ({
-  completeTutorial,
+  completeTutorial: hoisted.completeTutorial,
 }));
 
 import { POST } from "@/app/api/workspace/complete-tutorial/route";
 
-function makeRequest(body: unknown) {
-  return new Request("https://www.earlymark.ai/api/workspace/complete-tutorial", {
-    method: "POST",
-    body: JSON.stringify(body),
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 describe("POST /api/workspace/complete-tutorial", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("requires a workspaceId", async () => {
-    const response = await POST(makeRequest({}));
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      success: false,
-      error: "workspaceId is required",
+    hoisted.requireCurrentWorkspaceAccess.mockResolvedValue({
+      id: "user_1",
+      workspaceId: "ws_session",
+      role: "OWNER",
     });
+    hoisted.completeTutorial.mockResolvedValue(undefined);
   });
 
-  it("marks the tutorial complete for the workspace", async () => {
-    completeTutorial.mockResolvedValue(undefined);
+  it("rejects unauthenticated callers with 401 and does not run the action", async () => {
+    hoisted.requireCurrentWorkspaceAccess.mockRejectedValue(new Error("Unauthorized"));
 
-    const response = await POST(makeRequest({ workspaceId: "ws_1" }));
+    const res = await POST();
 
-    expect(completeTutorial).toHaveBeenCalledWith("ws_1");
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(res.status).toBe(401);
+    expect(hoisted.completeTutorial).not.toHaveBeenCalled();
   });
 
-  it("returns a 500 when the action throws", async () => {
-    completeTutorial.mockRejectedValue(new Error("db offline"));
+  it("marks the session workspace tutorial complete, never a body workspaceId", async () => {
+    const res = await POST();
 
-    const response = await POST(makeRequest({ workspaceId: "ws_1" }));
+    expect(res.status).toBe(200);
+    expect(hoisted.completeTutorial).toHaveBeenCalledWith("ws_session");
+    expect(hoisted.completeTutorial).toHaveBeenCalledTimes(1);
+  });
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      success: false,
-      error: "Failed to complete tutorial",
-    });
+  it("returns 500 when the action throws", async () => {
+    hoisted.completeTutorial.mockRejectedValue(new Error("db offline"));
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
   });
 });

--- a/__tests__/contacts-search-route.test.ts
+++ b/__tests__/contacts-search-route.test.ts
@@ -1,82 +1,77 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { searchContacts } = vi.hoisted(() => ({
+const hoisted = vi.hoisted(() => ({
+  requireCurrentWorkspaceAccess: vi.fn(),
   searchContacts: vi.fn(),
 }));
 
+vi.mock("@/lib/workspace-access", () => ({
+  requireCurrentWorkspaceAccess: hoisted.requireCurrentWorkspaceAccess,
+}));
+
 vi.mock("@/actions/contact-actions", () => ({
-  searchContacts,
+  searchContacts: hoisted.searchContacts,
 }));
 
 import { POST } from "@/app/api/contacts/search/route";
 
+function jsonRequest(body: unknown): Request {
+  return new Request("https://earlymark.ai/api/contacts/search", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 describe("POST /api/contacts/search", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    searchContacts.mockResolvedValue([{ id: "contact_1", name: "Jane Citizen" }]);
-  });
-
-  it("requires a workspace id", async () => {
-    const response = await POST(
-      new Request("https://earlymark.ai/api/contacts/search", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "", query: "Jane" }),
-      }),
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      success: false,
-      error: "workspaceId is required",
+    hoisted.requireCurrentWorkspaceAccess.mockResolvedValue({
+      id: "user_1",
+      workspaceId: "ws_session",
+      role: "OWNER",
     });
+    hoisted.searchContacts.mockResolvedValue([{ id: "contact_1", name: "Jane Citizen" }]);
   });
 
-  it("returns empty results when the query is blank", async () => {
-    const response = await POST(
-      new Request("https://earlymark.ai/api/contacts/search", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "ws_1", query: "   " }),
-      }),
-    );
+  it("rejects unauthenticated callers with 401 and runs no query", async () => {
+    hoisted.requireCurrentWorkspaceAccess.mockRejectedValue(new Error("Unauthorized"));
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ results: [] });
-    expect(searchContacts).not.toHaveBeenCalled();
+    const res = await POST(jsonRequest({ query: "Jane" }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.searchContacts).not.toHaveBeenCalled();
+  });
+
+  it("ignores any workspaceId in the body and uses the session workspace", async () => {
+    const res = await POST(jsonRequest({ workspaceId: "ws_attacker", query: "Jane" }));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.searchContacts).toHaveBeenCalledWith("ws_session", "Jane");
+  });
+
+  it("returns empty results when the query is blank without hitting the action", async () => {
+    const res = await POST(jsonRequest({ query: "   " }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ results: [] });
+    expect(hoisted.searchContacts).not.toHaveBeenCalled();
   });
 
   it("returns matching contacts for valid searches", async () => {
-    const response = await POST(
-      new Request("https://earlymark.ai/api/contacts/search", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "ws_1", query: "Jane" }),
-      }),
-    );
+    const res = await POST(jsonRequest({ query: "Jane" }));
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
       results: [{ id: "contact_1", name: "Jane Citizen" }],
     });
-    expect(searchContacts).toHaveBeenCalledWith("ws_1", "Jane");
   });
 
-  it("returns a 500 when contact search throws", async () => {
-    searchContacts.mockRejectedValue(new Error("search crashed"));
+  it("returns 500 when the action throws after auth passes", async () => {
+    hoisted.searchContacts.mockRejectedValue(new Error("search crashed"));
 
-    const response = await POST(
-      new Request("https://earlymark.ai/api/contacts/search", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "ws_1", query: "Jane" }),
-      }),
-    );
+    const res = await POST(jsonRequest({ query: "Jane" }));
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      success: false,
-      error: "Search failed",
-    });
+    expect(res.status).toBe(500);
   });
 });

--- a/__tests__/email-webhook-auth.test.ts
+++ b/__tests__/email-webhook-auth.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  db: {
+    workspace: {
+      findUnique: vi.fn(),
+    },
+  },
+  findWorkspaceByInboundEmail: vi.fn(),
+  classifyMessage: vi.fn(),
+  generateObject: vi.fn(),
+  createGoogleGenerativeAI: vi.fn(() => () => ({})),
+}));
+
+vi.mock("@/lib/db", () => ({ db: hoisted.db }));
+vi.mock("@/lib/workspace-routing", () => ({
+  findWorkspaceByInboundEmail: hoisted.findWorkspaceByInboundEmail,
+}));
+vi.mock("@/lib/spam-classifier", () => ({
+  classifyMessage: hoisted.classifyMessage,
+}));
+vi.mock("ai", () => ({ generateObject: hoisted.generateObject }));
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: hoisted.createGoogleGenerativeAI,
+}));
+
+import { POST } from "@/app/api/webhooks/email/route";
+
+function emailRequest(headers: Record<string, string>): Request {
+  return new Request("https://earlymark.ai/api/webhooks/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({
+      to: "ws_alias@earlymark.ai",
+      from: "jobs@hipages.com.au",
+      subject: "New lead",
+      text: "phone: 0434955958",
+    }),
+  });
+}
+
+describe("POST /api/webhooks/email auth gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 503 when EMAIL_WEBHOOK_SECRET is missing and never routes the email", async () => {
+    vi.stubEnv("EMAIL_WEBHOOK_SECRET", "");
+
+    const res = await POST(emailRequest({}));
+
+    expect(res.status).toBe(503);
+    expect(hoisted.findWorkspaceByInboundEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the header is missing", async () => {
+    vi.stubEnv("EMAIL_WEBHOOK_SECRET", "the-secret");
+
+    const res = await POST(emailRequest({}));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.findWorkspaceByInboundEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the header value is wrong", async () => {
+    vi.stubEnv("EMAIL_WEBHOOK_SECRET", "the-secret");
+
+    const res = await POST(emailRequest({ "x-email-webhook-secret": "wrong" }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.findWorkspaceByInboundEmail).not.toHaveBeenCalled();
+  });
+
+  it("passes the auth gate when the header matches and proceeds to routing", async () => {
+    vi.stubEnv("EMAIL_WEBHOOK_SECRET", "the-secret");
+    hoisted.findWorkspaceByInboundEmail.mockResolvedValue(null);
+
+    const res = await POST(emailRequest({ "x-email-webhook-secret": "the-secret" }));
+
+    expect(hoisted.findWorkspaceByInboundEmail).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/global-search.test.tsx
+++ b/__tests__/global-search.test.tsx
@@ -81,7 +81,7 @@ describe("GlobalSearch", () => {
     });
 
     await waitFor(() => {
-      expect(globalSearchClient).toHaveBeenCalledWith("ws_1", "pat");
+      expect(globalSearchClient).toHaveBeenCalledWith("pat");
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Pat Customer/i }));

--- a/__tests__/log-crash-route.test.ts
+++ b/__tests__/log-crash-route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  getAuthUser: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: hoisted.getAuthUser,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  logger: {
+    error: hoisted.loggerError,
+  },
+}));
+
+import { POST } from "@/app/api/log-crash/route";
+
+function jsonRequest(body: unknown): Request {
+  return new Request("https://earlymark.ai/api/log-crash", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/log-crash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getAuthUser.mockResolvedValue({ id: "user_1", email: "owner@example.com" });
+  });
+
+  it("rejects unauthenticated callers with 401 and does not log", async () => {
+    hoisted.getAuthUser.mockResolvedValue(null);
+
+    const res = await POST(jsonRequest({ message: "boom", stack: "stack" }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+  });
+
+  it("logs the crash with the authenticated user id when authorised", async () => {
+    const res = await POST(jsonRequest({ message: "TypeError x", stack: "at foo" }));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.loggerError).toHaveBeenCalledTimes(1);
+    const call = hoisted.loggerError.mock.calls[0];
+    expect(call[0]).toBe("Client-side crash reported");
+    expect(call[1]).toMatchObject({
+      component: "client-error-boundary",
+      userId: "user_1",
+      stack: "at foo",
+    });
+    expect(call[2]).toBeInstanceOf(Error);
+    expect((call[2] as Error).message).toBe("TypeError x");
+  });
+
+  it("clamps oversized payloads instead of trusting them verbatim", async () => {
+    const giantMessage = "x".repeat(50_000);
+    const giantStack = "y".repeat(50_000);
+
+    const res = await POST(jsonRequest({ message: giantMessage, stack: giantStack }));
+
+    expect(res.status).toBe(200);
+    const call = hoisted.loggerError.mock.calls[0];
+    expect((call[2] as Error).message.length).toBeLessThanOrEqual(2_000);
+    expect((call[1].stack as string).length).toBeLessThanOrEqual(10_000);
+  });
+
+  it("returns 400 for invalid JSON bodies", async () => {
+    const badReq = new Request("https://earlymark.ai/api/log-crash", {
+      method: "POST",
+      body: "{not json",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(badReq);
+
+    expect(res.status).toBe(400);
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/messaging-actions.test.ts
+++ b/__tests__/messaging-actions.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   db: {
+    contact: {
+      findUnique: vi.fn(),
+    },
     deal: {
       findUnique: vi.fn(),
     },
@@ -73,5 +76,69 @@ describe("messaging-actions", () => {
         subject: "We'd love your feedback on your recent job",
       }),
     );
+  });
+
+  describe("sendViaTwilio audit trail", () => {
+    beforeEach(() => {
+      vi.stubEnv("TWILIO_AUTH_TOKEN", "auth_token_x");
+      hoisted.db.workspace.findUnique.mockResolvedValue({
+        twilioSubaccountId: "AC_workspace",
+        twilioPhoneNumber: "+61400000000",
+      });
+      hoisted.db.contact.findUnique.mockResolvedValue({
+        id: "contact_1",
+        name: "Alex",
+        phone: "+61434955958",
+        workspaceId: "ws_1",
+      });
+    });
+
+    it("surfaces audit-trail write failures via console.error instead of swallowing them", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ sid: "SM_123" }), { status: 200 }),
+      );
+      hoisted.db.webhookEvent.create.mockRejectedValueOnce(new Error("DB down"));
+
+      const { sendSMS } = await import("@/actions/messaging-actions");
+      const result = await sendSMS("contact_1", "hi");
+
+      expect(result.success).toBe(true);
+      expect(hoisted.db.webhookEvent.create).toHaveBeenCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("safeRecordWebhookEvent"),
+        expect.anything(),
+      );
+
+      fetchSpy.mockRestore();
+      consoleSpy.mockRestore();
+    });
+
+    it("awaits the audit write rather than firing-and-forgetting it", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ sid: "SM_456" }), { status: 200 }),
+      );
+      let resolveWrite: () => void = () => {};
+      const writePromise = new Promise<{ id: string }>((resolve) => {
+        resolveWrite = () => resolve({ id: "webhook_1" });
+      });
+      hoisted.db.webhookEvent.create.mockReturnValueOnce(writePromise);
+
+      const { sendSMS } = await import("@/actions/messaging-actions");
+      let resolved = false;
+      const callPromise = sendSMS("contact_1", "hi").then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      resolveWrite();
+      await callPromise;
+      expect(resolved).toBe(true);
+
+      fetchSpy.mockRestore();
+    });
   });
 });

--- a/__tests__/new-deal-modal.test.tsx
+++ b/__tests__/new-deal-modal.test.tsx
@@ -47,6 +47,7 @@ vi.mock("sonner", () => ({
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
   DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/__tests__/post-job-followups.test.ts
+++ b/__tests__/post-job-followups.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  db: {
+    deal: { findMany: vi.fn() },
+    automatedMessageRule: { findFirst: vi.fn() },
+    activity: { findFirst: vi.fn(), create: vi.fn() },
+  },
+  runIdempotent: vi.fn(),
+  sendSMS: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: hoisted.db }));
+vi.mock("@/lib/idempotency", () => ({ runIdempotent: hoisted.runIdempotent }));
+vi.mock("@/actions/messaging-actions", () => ({ sendSMS: hoisted.sendSMS }));
+vi.mock("@/actions/notification-actions", () => ({ createNotification: vi.fn() }));
+vi.mock("@/lib/messaging/safe-recipient", () => ({ assertSafeRecipient: vi.fn((_: string, value: string) => value) }));
+vi.mock("@/lib/cost-ceiling", () => ({ withCostCeiling: vi.fn(async (_a: string, _b: number, fn: () => Promise<unknown>) => fn()) }));
+
+import { processPostJobFollowUps } from "@/actions/followup-actions";
+
+const completedAt = new Date("2026-05-17T08:00:00.000Z");
+const sampleDeal = {
+  id: "deal_1",
+  title: "Fix sink",
+  contactId: "contact_1",
+  workspaceId: "ws_1",
+  stageChangedAt: completedAt,
+  contact: { name: "Michael", phone: "+61434955958" },
+  workspace: { name: "Friendly Plumbing" },
+};
+
+describe("processPostJobFollowUps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.db.deal.findMany.mockResolvedValue([sampleDeal]);
+    hoisted.db.automatedMessageRule.findFirst.mockResolvedValue({
+      enabled: true,
+      messageTemplate: "Hi {{clientName}}, thanks for {{jobTitle}}.",
+    });
+    hoisted.sendSMS.mockResolvedValue({ success: true });
+    hoisted.runIdempotent.mockImplementation(async ({ resultFactory }) => {
+      const result = await resultFactory();
+      return { idempotencyKey: "k", created: true, result };
+    });
+  });
+
+  it("routes the send through runIdempotent with a stable per-deal key", async () => {
+    await processPostJobFollowUps();
+
+    expect(hoisted.runIdempotent).toHaveBeenCalledTimes(1);
+    const args = hoisted.runIdempotent.mock.calls[0][0];
+    expect(args.actionType).toBe("POST_JOB_FOLLOWUP");
+    expect(args.parts).toEqual(["deal_1"]);
+    expect(args.bucketAt).toBe(completedAt);
+  });
+
+  it("counts a duplicate claim as skipped without sending again", async () => {
+    hoisted.runIdempotent.mockResolvedValue({
+      idempotencyKey: "k",
+      created: false,
+      result: { success: true },
+    });
+
+    const result = await processPostJobFollowUps();
+
+    expect(hoisted.sendSMS).not.toHaveBeenCalled();
+    expect(result.sent).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not write an activity row when sendSMS fails", async () => {
+    hoisted.sendSMS.mockResolvedValue({ success: false, error: "Twilio down" });
+
+    const result = await processPostJobFollowUps();
+
+    expect(hoisted.db.activity.create).not.toHaveBeenCalled();
+    expect(result.sent).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("caps the deal scan with a take limit so a backlog can't OOM the cron", async () => {
+    await processPostJobFollowUps();
+
+    const findManyCall = hoisted.db.deal.findMany.mock.calls[0][0];
+    expect(typeof findManyCall.take).toBe("number");
+    expect(findManyCall.take).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/reminders-route.test.ts
+++ b/__tests__/reminders-route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const hoisted = vi.hoisted(() => ({
+  requireCurrentWorkspaceAccess: vi.fn(),
+  requireDealInCurrentWorkspace: vi.fn(),
+  manualSendJobReminder: vi.fn(),
+  manualSendTripSms: vi.fn(),
+  getReminderStats: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace-access", () => ({
+  requireCurrentWorkspaceAccess: hoisted.requireCurrentWorkspaceAccess,
+  requireDealInCurrentWorkspace: hoisted.requireDealInCurrentWorkspace,
+}));
+
+vi.mock("@/actions/reminder-actions", () => ({
+  manualSendJobReminder: hoisted.manualSendJobReminder,
+  manualSendTripSms: hoisted.manualSendTripSms,
+  getReminderStats: hoisted.getReminderStats,
+}));
+
+import { GET, POST } from "@/app/api/reminders/route";
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest("https://earlymark.ai/api/reminders", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/reminders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.requireCurrentWorkspaceAccess.mockResolvedValue({
+      id: "user_1",
+      workspaceId: "ws_1",
+      role: "OWNER",
+    });
+    hoisted.requireDealInCurrentWorkspace.mockResolvedValue({
+      actor: { id: "user_1", workspaceId: "ws_1", role: "OWNER" },
+      deal: { id: "deal_1", workspaceId: "ws_1" },
+    });
+    hoisted.manualSendJobReminder.mockResolvedValue({ success: true });
+    hoisted.manualSendTripSms.mockResolvedValue({ success: true });
+  });
+
+  it("rejects unauthenticated callers with 401 and sends nothing", async () => {
+    hoisted.requireCurrentWorkspaceAccess.mockRejectedValue(new Error("Unauthorized"));
+
+    const res = await POST(postRequest({ action: "sendReminder", dealId: "deal_1" }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.manualSendJobReminder).not.toHaveBeenCalled();
+    expect(hoisted.manualSendTripSms).not.toHaveBeenCalled();
+  });
+
+  it("refuses to send a reminder for a deal in another workspace", async () => {
+    hoisted.requireDealInCurrentWorkspace.mockRejectedValue(new Error("Deal not found"));
+
+    const res = await POST(postRequest({ action: "sendReminder", dealId: "deal_other" }));
+
+    expect(res.status).toBe(403);
+    expect(hoisted.manualSendJobReminder).not.toHaveBeenCalled();
+  });
+
+  it("refuses to send a trip SMS for a deal in another workspace", async () => {
+    hoisted.requireDealInCurrentWorkspace.mockRejectedValue(new Error("Deal not found"));
+
+    const res = await POST(postRequest({ action: "sendTripSms", dealId: "deal_other" }));
+
+    expect(res.status).toBe(403);
+    expect(hoisted.manualSendTripSms).not.toHaveBeenCalled();
+  });
+
+  it("sends a reminder when the deal is in the caller's workspace", async () => {
+    const res = await POST(postRequest({ action: "sendReminder", dealId: "deal_1" }));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.manualSendJobReminder).toHaveBeenCalledWith("deal_1", "user_1");
+  });
+
+  it("rejects unknown actions with 400", async () => {
+    const res = await POST(postRequest({ action: "dropAllReminders", dealId: "deal_1" }));
+
+    expect(res.status).toBe(400);
+    expect(hoisted.manualSendJobReminder).not.toHaveBeenCalled();
+    expect(hoisted.manualSendTripSms).not.toHaveBeenCalled();
+  });
+
+  it("requires both action and dealId", async () => {
+    const res = await POST(postRequest({ action: "sendReminder" }));
+
+    expect(res.status).toBe(400);
+    expect(hoisted.requireDealInCurrentWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/reminders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.requireCurrentWorkspaceAccess.mockResolvedValue({
+      id: "user_1",
+      workspaceId: "ws_1",
+      role: "OWNER",
+    });
+    hoisted.getReminderStats.mockResolvedValue({ sent: 0 });
+  });
+
+  it("rejects unauthenticated callers with 401", async () => {
+    hoisted.requireCurrentWorkspaceAccess.mockRejectedValue(new Error("Unauthorized"));
+
+    const res = await GET(new NextRequest("https://earlymark.ai/api/reminders"));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.getReminderStats).not.toHaveBeenCalled();
+  });
+
+  it("refuses to return stats for another workspace via query string", async () => {
+    const res = await GET(new NextRequest("https://earlymark.ai/api/reminders?workspaceId=ws_other"));
+
+    expect(res.status).toBe(403);
+    expect(hoisted.getReminderStats).not.toHaveBeenCalled();
+  });
+
+  it("returns stats for the session workspace by default", async () => {
+    const res = await GET(new NextRequest("https://earlymark.ai/api/reminders"));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.getReminderStats).toHaveBeenCalledWith("ws_1");
+  });
+});

--- a/__tests__/search-dialog.test.tsx
+++ b/__tests__/search-dialog.test.tsx
@@ -90,7 +90,7 @@ describe("SearchDialog", () => {
     });
 
     await waitFor(() => {
-      expect(globalSearchClient).toHaveBeenCalledWith("ws_1", "blocked");
+      expect(globalSearchClient).toHaveBeenCalledWith("blocked");
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Blocked Drain/i }));

--- a/__tests__/search-global-route.test.ts
+++ b/__tests__/search-global-route.test.ts
@@ -1,63 +1,78 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { globalSearch } = vi.hoisted(() => ({
+const hoisted = vi.hoisted(() => ({
+  requireCurrentWorkspaceAccess: vi.fn(),
   globalSearch: vi.fn(),
 }));
 
+vi.mock("@/lib/workspace-access", () => ({
+  requireCurrentWorkspaceAccess: hoisted.requireCurrentWorkspaceAccess,
+}));
+
 vi.mock("@/actions/search-actions", () => ({
-  globalSearch,
+  globalSearch: hoisted.globalSearch,
 }));
 
 import { POST } from "@/app/api/search/global/route";
 
+function jsonRequest(body: unknown): Request {
+  return new Request("https://earlymark.ai/api/search/global", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 describe("POST /api/search/global", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    globalSearch.mockResolvedValue([{ id: "deal_1", type: "deal", label: "Blocked drain" }]);
+    hoisted.requireCurrentWorkspaceAccess.mockResolvedValue({
+      id: "user_1",
+      workspaceId: "ws_session",
+      role: "OWNER",
+    });
+    hoisted.globalSearch.mockResolvedValue([{ id: "deal_1", type: "deal", label: "Blocked drain" }]);
   });
 
-  it("returns empty results for missing workspace or too-short queries", async () => {
-    const response = await POST(
-      new Request("https://earlymark.ai/api/search/global", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "", query: "a" }),
-      }),
-    );
+  it("rejects unauthenticated callers with 401 and runs no query", async () => {
+    hoisted.requireCurrentWorkspaceAccess.mockRejectedValue(new Error("Unauthorized"));
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ results: [] });
-    expect(globalSearch).not.toHaveBeenCalled();
+    const res = await POST(jsonRequest({ query: "blocked drain" }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.globalSearch).not.toHaveBeenCalled();
   });
 
-  it("returns global search results for valid requests", async () => {
-    const response = await POST(
-      new Request("https://earlymark.ai/api/search/global", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "ws_1", query: "blocked drain" }),
-      }),
-    );
+  it("ignores any workspaceId in the body and uses the session workspace", async () => {
+    const res = await POST(jsonRequest({ workspaceId: "ws_attacker", query: "blocked drain" }));
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    expect(res.status).toBe(200);
+    expect(hoisted.globalSearch).toHaveBeenCalledWith("ws_session", "blocked drain");
+  });
+
+  it("returns empty results for too-short queries without hitting the action", async () => {
+    const res = await POST(jsonRequest({ query: "a" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ results: [] });
+    expect(hoisted.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it("returns search results for valid requests", async () => {
+    const res = await POST(jsonRequest({ query: "blocked drain" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
       results: [{ id: "deal_1", type: "deal", label: "Blocked drain" }],
     });
-    expect(globalSearch).toHaveBeenCalledWith("ws_1", "blocked drain");
   });
 
-  it("returns a 500 payload with empty results when search fails", async () => {
-    globalSearch.mockRejectedValue(new Error("search offline"));
+  it("returns 500 with empty results when search fails", async () => {
+    hoisted.globalSearch.mockRejectedValue(new Error("search offline"));
 
-    const response = await POST(
-      new Request("https://earlymark.ai/api/search/global", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workspaceId: "ws_1", query: "blocked drain" }),
-      }),
-    );
+    const res = await POST(jsonRequest({ query: "blocked drain" }));
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ results: [] });
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ results: [] });
   });
 });

--- a/__tests__/stale-deal-follow-up-modal.test.tsx
+++ b/__tests__/stale-deal-follow-up-modal.test.tsx
@@ -229,7 +229,7 @@ describe("StaleDealFollowUpModal", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /Phone Call \(schedule reminder\)/i }));
+    await user.click(screen.getByRole("radio", { name: /Phone call/i }));
 
     await user.type(screen.getByLabelText(/When to call/i), "2026-04-20T09:30");
     await user.type(screen.getByLabelText(/Call notes/i), "Check whether the quote is still in play.");

--- a/__tests__/stale-job-reconciliation-modal.test.tsx
+++ b/__tests__/stale-job-reconciliation-modal.test.tsx
@@ -2,121 +2,117 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-const { reconcileStaleJob, toastSuccess, toastError } = vi.hoisted(() => ({
+const { reconcileStaleJob, toastSuccess, toastError, useIsDesktop } = vi.hoisted(() => ({
   reconcileStaleJob: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  useIsDesktop: vi.fn(),
 }));
 
-vi.mock("@/actions/stale-job-actions", () => ({
-  reconcileStaleJob,
-}));
-
-vi.mock("sonner", () => ({
-  toast: {
-    success: toastSuccess,
-    error: toastError,
-  },
-}));
+vi.mock("@/actions/stale-job-actions", () => ({ reconcileStaleJob }));
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
+vi.mock("@/hooks/use-is-desktop", () => ({ useIsDesktop }));
 
 vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Dialog: ({ children }: { children: React.ReactNode }) => <div data-surface="dialog">{children}</div>,
   DialogContent: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
   DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
 }));
 
-vi.mock("@/components/ui/select", () => ({
-  Select: ({
-    value,
-    onValueChange,
-    children,
-  }: {
-    value?: string;
-    onValueChange?: (value: string) => void;
-    children: React.ReactNode;
-  }) => (
-    <div>
-      <select aria-label="Select an outcome" value={value} onChange={(e) => onValueChange?.(e.target.value)}>
-        <option value="">Select an outcome</option>
-        <option value="COMPLETED">Completed</option>
-        <option value="RESCHEDULED">Rescheduled</option>
-        <option value="PARKED">Parked (date unknown)</option>
-        <option value="NO_SHOW">No Show</option>
-        <option value="CANCELLED">Cancelled</option>
-      </select>
-      {children}
-    </div>
-  ),
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
-  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+vi.mock("@/components/ui/drawer", () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => <div data-surface="drawer">{children}</div>,
+  DrawerContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DrawerDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
 }));
 
 import { StaleJobReconciliationModal } from "@/components/crm/stale-job-reconciliation-modal";
 
-describe("StaleJobReconciliationModal", () => {
-  const deal = {
-    id: "deal_1",
-    title: "Blocked Drain",
-    contactName: "Alex Harper",
-    scheduledAt: new Date("2026-04-09T10:00:00.000Z"),
-    address: "1 King St",
-  } as never;
+const deal = {
+  id: "deal_1",
+  title: "Blocked Drain",
+  contactName: "Alex Harper",
+  scheduledAt: new Date("2026-04-09T10:00:00.000Z"),
+  address: "1 King St",
+} as never;
 
+describe("StaleJobReconciliationModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useIsDesktop.mockReturnValue(true);
   });
 
-  it("explains what happens next for the selected outcome", async () => {
+  it("renders a Dialog on desktop and a Drawer on mobile (responsive surface swap)", () => {
+    const { rerender, container } = render(
+      <StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+    expect(container.querySelector('[data-surface="dialog"]')).not.toBeNull();
+    expect(container.querySelector('[data-surface="drawer"]')).toBeNull();
+
+    useIsDesktop.mockReturnValue(false);
+    rerender(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    expect(container.querySelector('[data-surface="drawer"]')).not.toBeNull();
+    expect(container.querySelector('[data-surface="dialog"]')).toBeNull();
+  });
+
+  it("exposes outcomes as a radiogroup with five radios — no hidden dropdown", () => {
     render(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />);
 
-    fireEvent.change(screen.getByLabelText(/select an outcome/i), {
-      target: { value: "RESCHEDULED" },
-    });
-
-    expect(
-      await screen.findByText(/clears the old scheduled date and moves the job back so you can book a new time/i),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: /job outcome/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(5);
   });
 
-  it("shows success feedback when reconciliation saves", async () => {
+  it("disables the primary action until an outcome is picked", () => {
+    render(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /update job/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("radio", { name: /completed/i }));
+    expect(screen.getByRole("button", { name: /mark completed/i })).toBeEnabled();
+  });
+
+  it("submits the selected outcome and shows success feedback", async () => {
     reconcileStaleJob.mockResolvedValue({ success: true });
     const onSuccess = vi.fn();
 
     render(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={onSuccess} />);
 
-    fireEvent.change(screen.getByLabelText(/select an outcome/i), {
-      target: { value: "COMPLETED" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /update job/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /completed/i }));
+    fireEvent.click(screen.getByRole("button", { name: /mark completed/i }));
 
     await waitFor(() => {
       expect(reconcileStaleJob).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dealId: "deal_1",
-          actualOutcome: "COMPLETED",
-        }),
+        expect.objectContaining({ dealId: "deal_1", actualOutcome: "COMPLETED" }),
       );
     });
     expect(toastSuccess).toHaveBeenCalledWith("Job updated");
     expect(onSuccess).toHaveBeenCalled();
   });
 
-  it("shows the returned error when reconciliation fails", async () => {
+  it("surfaces the returned error when reconciliation fails", async () => {
     reconcileStaleJob.mockResolvedValue({ success: false, error: "Could not save outcome" });
 
     render(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />);
 
-    fireEvent.change(screen.getByLabelText(/select an outcome/i), {
-      target: { value: "CANCELLED" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /update job/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /cancelled/i }));
+    fireEvent.click(screen.getByRole("button", { name: /mark cancelled/i }));
 
     await waitFor(() => {
       expect(toastError).toHaveBeenCalledWith("Could not save outcome");
     });
+  });
+
+  it("updates aria-checked on the selected outcome only", () => {
+    render(<StaleJobReconciliationModal deal={deal} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /parked/i }));
+    const radios = screen.getAllByRole("radio");
+    const checked = radios.filter((r) => r.getAttribute("aria-checked") === "true");
+    expect(checked).toHaveLength(1);
+    expect(checked[0]).toHaveAccessibleName(/parked/i);
   });
 });

--- a/__tests__/sync-replay-route.test.ts
+++ b/__tests__/sync-replay-route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  getAuthUser: vi.fn(),
+  requireDealInCurrentWorkspace: vi.fn(),
+  requireContactInCurrentWorkspace: vi.fn(),
+  updateJobStatus: vi.fn(),
+  createQuoteVariation: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: hoisted.getAuthUser,
+}));
+
+vi.mock("@/lib/workspace-access", () => ({
+  requireDealInCurrentWorkspace: hoisted.requireDealInCurrentWorkspace,
+  requireContactInCurrentWorkspace: hoisted.requireContactInCurrentWorkspace,
+}));
+
+vi.mock("@/actions/tradie-actions", () => ({
+  updateJobStatus: hoisted.updateJobStatus,
+  createQuoteVariation: hoisted.createQuoteVariation,
+}));
+
+vi.mock("@/actions/activity-actions", () => ({
+  logActivity: hoisted.logActivity,
+}));
+
+import { POST } from "@/app/api/sync/replay/route";
+
+function jsonRequest(body: unknown): Request {
+  return new Request("https://earlymark.ai/api/sync/replay", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/sync/replay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getAuthUser.mockResolvedValue({ id: "user_1", email: "a@b.com" });
+    hoisted.requireDealInCurrentWorkspace.mockResolvedValue({
+      actor: { id: "user_1", workspaceId: "ws_1", role: "OWNER" },
+      deal: { id: "deal_1", workspaceId: "ws_1" },
+    });
+    hoisted.requireContactInCurrentWorkspace.mockResolvedValue({
+      actor: { id: "user_1", workspaceId: "ws_1", role: "OWNER" },
+      contact: { id: "contact_1", workspaceId: "ws_1" },
+    });
+    hoisted.updateJobStatus.mockResolvedValue({ success: true });
+    hoisted.createQuoteVariation.mockResolvedValue({ success: true, total: 50 });
+    hoisted.logActivity.mockResolvedValue({ success: true, activityId: "act_1" });
+  });
+
+  it("rejects unauthenticated callers with 401 and runs nothing", async () => {
+    hoisted.getAuthUser.mockResolvedValue(null);
+
+    const res = await POST(jsonRequest({ actionName: "updateJobStatus", payload: { jobId: "deal_x", status: "COMPLETED" } }));
+
+    expect(res.status).toBe(401);
+    expect(hoisted.updateJobStatus).not.toHaveBeenCalled();
+    expect(hoisted.createQuoteVariation).not.toHaveBeenCalled();
+    expect(hoisted.logActivity).not.toHaveBeenCalled();
+  });
+
+  it("forwards updateJobStatus only after auth passes", async () => {
+    const res = await POST(jsonRequest({ actionName: "updateJobStatus", payload: { jobId: "deal_1", status: "COMPLETED" } }));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.updateJobStatus).toHaveBeenCalledWith("deal_1", "COMPLETED");
+  });
+
+  it("rejects unknown job statuses with 400 instead of forwarding", async () => {
+    const res = await POST(jsonRequest({ actionName: "updateJobStatus", payload: { jobId: "deal_1", status: "BOGUS" } }));
+
+    expect(res.status).toBe(400);
+    expect(hoisted.updateJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("logActivity is blocked when the dealId belongs to another workspace", async () => {
+    hoisted.requireDealInCurrentWorkspace.mockRejectedValue(new Error("Deal not found"));
+
+    const res = await POST(jsonRequest({
+      actionName: "logActivity",
+      payload: { type: "NOTE", title: "Hi", dealId: "deal_other", content: "" },
+    }));
+
+    expect(res.status).toBe(403);
+    expect(hoisted.logActivity).not.toHaveBeenCalled();
+  });
+
+  it("logActivity is blocked when the contactId belongs to another workspace", async () => {
+    hoisted.requireContactInCurrentWorkspace.mockRejectedValue(new Error("Contact not found"));
+
+    const res = await POST(jsonRequest({
+      actionName: "logActivity",
+      payload: { type: "NOTE", title: "Hi", contactId: "contact_other", content: "" },
+    }));
+
+    expect(res.status).toBe(403);
+    expect(hoisted.logActivity).not.toHaveBeenCalled();
+  });
+
+  it("logActivity requires at least one of dealId/contactId", async () => {
+    const res = await POST(jsonRequest({
+      actionName: "logActivity",
+      payload: { type: "NOTE", title: "Hi", content: "" },
+    }));
+
+    expect(res.status).toBe(400);
+    expect(hoisted.logActivity).not.toHaveBeenCalled();
+  });
+
+  it("logActivity succeeds when ownership checks pass", async () => {
+    const res = await POST(jsonRequest({
+      actionName: "logActivity",
+      payload: { type: "NOTE", title: "Hi", dealId: "deal_1", content: "x" },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.logActivity).toHaveBeenCalledWith({
+      type: "NOTE",
+      title: "Hi",
+      content: "x",
+      description: undefined,
+      dealId: "deal_1",
+      contactId: undefined,
+    });
+  });
+
+  it("rejects unknown actionName", async () => {
+    const res = await POST(jsonRequest({ actionName: "deleteEverything", payload: {} }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/twilio-voice-status-route.test.ts
+++ b/__tests__/twilio-voice-status-route.test.ts
@@ -10,6 +10,7 @@ const {
   recordCallbackEvent,
   assessInboundLeadGuard,
   recordInboundLeadGuardEvent,
+  runIdempotent,
 } = vi.hoisted(() => ({
   db: {
     contact: { create: vi.fn() },
@@ -24,7 +25,10 @@ const {
   recordCallbackEvent: vi.fn(),
   assessInboundLeadGuard: vi.fn(),
   recordInboundLeadGuardEvent: vi.fn(),
+  runIdempotent: vi.fn(),
 }));
+
+vi.mock("@/lib/idempotency", () => ({ runIdempotent }));
 
 vi.mock("@/lib/db", () => ({ db }));
 vi.mock("@/lib/workspace-routing", () => ({
@@ -77,6 +81,10 @@ describe("POST /api/webhooks/twilio-voice-status", () => {
     recordCallbackEvent.mockResolvedValue(undefined);
     assessInboundLeadGuard.mockResolvedValue({ blocked: false, payload: null });
     recordInboundLeadGuardEvent.mockResolvedValue(undefined);
+    runIdempotent.mockImplementation(async ({ resultFactory }: { resultFactory: () => Promise<unknown> }) => {
+      const result = await resultFactory();
+      return { idempotencyKey: "k", created: true, result };
+    });
   });
 
   it("creates a deal and queues a callback when the inbound dial gets no answer", async () => {
@@ -172,13 +180,24 @@ describe("POST /api/webhooks/twilio-voice-status", () => {
     expect(scheduleLeadCallback).not.toHaveBeenCalled();
   });
 
-  it("is idempotent — the same CallSid does not create duplicate deals", async () => {
+  it("is idempotent — the same CallSid does not create duplicate deals or schedule a second callback", async () => {
     findWorkspaceByTwilioNumber.mockResolvedValue({
       id: "ws_1",
       voiceEnabled: true,
-      settings: {},
+      autoCallLeads: true,
+      autoCallDelaySec: 90,
+      agentMode: "EXECUTION",
+      twilioPhoneNumber: "+61411111111",
+      settings: { callAllowedStart: "00:00", callAllowedEnd: "23:59" },
     });
-    db.webhookEvent.findFirst.mockResolvedValue({ id: "evt_1" });
+    // Simulate the duplicate-delivery case: runIdempotent returns
+    // created:false because the first invocation already claimed the
+    // CallSid. The route must NOT re-create the deal or re-schedule.
+    runIdempotent.mockResolvedValue({
+      idempotencyKey: "k",
+      created: false,
+      result: { contactId: "contact_1", dealId: "deal_1" },
+    });
 
     const response = await POST(
       buildRequest({
@@ -192,5 +211,33 @@ describe("POST /api/webhooks/twilio-voice-status", () => {
     expect(response.status).toBe(200);
     expect(db.deal.create).not.toHaveBeenCalled();
     expect(scheduleLeadCallback).not.toHaveBeenCalled();
+  });
+
+  it("routes the missed-call processing through runIdempotent keyed on CallSid", async () => {
+    findWorkspaceByTwilioNumber.mockResolvedValue({
+      id: "ws_1",
+      voiceEnabled: true,
+      autoCallLeads: true,
+      autoCallDelaySec: 90,
+      agentMode: "EXECUTION",
+      twilioPhoneNumber: "+61411111111",
+      settings: { callAllowedStart: "00:00", callAllowedEnd: "23:59" },
+    });
+    findContactByPhone.mockResolvedValue({ id: "contact_1", name: "Caller" });
+    db.deal.create.mockResolvedValue({ id: "deal_1" });
+
+    await POST(
+      buildRequest({
+        From: "+61400000000",
+        To: "+61411111111",
+        DialCallStatus: "no-answer",
+        CallSid: "CA-XYZ",
+      }),
+    );
+
+    expect(runIdempotent).toHaveBeenCalledTimes(1);
+    const args = runIdempotent.mock.calls[0][0];
+    expect(args.actionType).toBe("TWILIO_MISSED_CALL");
+    expect(args.parts).toEqual(["CA-XYZ"]);
   });
 });

--- a/__tests__/voice-calls-route.test.ts
+++ b/__tests__/voice-calls-route.test.ts
@@ -19,7 +19,10 @@ const hoisted = vi.hoisted(() => ({
   isVoiceAgentSecretAuthorized: vi.fn(),
   syncVoiceCallToCRM: vi.fn(),
   recordCallbackEvent: vi.fn(),
+  runIdempotent: vi.fn(),
 }));
+
+vi.mock("@/lib/idempotency", () => ({ runIdempotent: hoisted.runIdempotent }));
 
 vi.mock("@/lib/db", () => ({
   db: hoisted.db,
@@ -61,6 +64,10 @@ describe("POST /api/internal/voice-calls", () => {
       skipped: false,
     });
     hoisted.recordCallbackEvent.mockResolvedValue(undefined);
+    hoisted.runIdempotent.mockImplementation(async ({ resultFactory }: { resultFactory: () => Promise<unknown> }) => {
+      const result = await resultFactory();
+      return { idempotencyKey: "k", created: true, result };
+    });
   });
 
   function makePayload(overrides: Record<string, unknown> = {}) {
@@ -139,6 +146,7 @@ describe("POST /api/internal/voice-calls", () => {
     );
     await expect(response.json()).resolves.toEqual({
       success: true,
+      duplicate: false,
       crmSync: {
         contactId: "contact_1",
         dealId: "deal_1",
@@ -147,6 +155,31 @@ describe("POST /api/internal/voice-calls", () => {
         skipped: false,
       },
     });
+  });
+
+  it("on duplicate webhook delivery, returns the cached crmSync result and runs no side effects", async () => {
+    hoisted.runIdempotent.mockResolvedValueOnce({
+      idempotencyKey: "k",
+      created: false,
+      result: {
+        crmSync: { contactId: "contact_1", dealId: "deal_1", contactCreated: false, dealCreated: false, skipped: false },
+      },
+    });
+
+    const response = await POST(
+      new NextRequest("https://earlymark.ai/api/internal/voice-calls", {
+        method: "POST",
+        headers: { "x-voice-agent-secret": "secret" },
+        body: JSON.stringify(makePayload({ callId: "call_dup" })),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.syncVoiceCallToCRM).not.toHaveBeenCalled();
+    expect(hoisted.recordCallbackEvent).not.toHaveBeenCalled();
+    expect(hoisted.db.task.create).not.toHaveBeenCalled();
+    expect(hoisted.db.activity.create).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({ duplicate: true });
   });
 
   it("creates an urgent callback task for new escalated calls", async () => {

--- a/actions/automated-message-actions.ts
+++ b/actions/automated-message-actions.ts
@@ -198,6 +198,8 @@ export async function processBookingReminders(): Promise<{
     const windowStart = new Date(now.getTime() + 23 * 60 * 60 * 1000);
     const windowEnd = new Date(now.getTime() + 25 * 60 * 60 * 1000);
 
+    // Cap per-workspace fan-out so one busy workspace cannot fill an
+    // entire cron invocation with hundreds of SMS sends.
     const upcomingJobs = await db.deal.findMany({
       where: {
         workspaceId: rule.workspaceId,
@@ -212,6 +214,8 @@ export async function processBookingReminders(): Promise<{
           select: { id: true, name: true, phone: true, email: true },
         },
       },
+      orderBy: { scheduledAt: "asc" },
+      take: 100,
     });
 
     const workspace = await db.workspace.findUnique({

--- a/actions/chat-actions.ts
+++ b/actions/chat-actions.ts
@@ -2446,22 +2446,17 @@ export async function runSendSms(
     });
 
     if (!workspace?.twilioPhoneNumber || !workspace.twilioSubaccountId) {
-      // Fallback: log as activity instead of sending
-      await logActivity({
-        type: "NOTE",
-        title: `SMS to ${contact.name}`,
-        content: `Message: "${params.message}" (Not sent — Twilio not configured for this workspace)`,
+      // Provisioning gap — every workspace should have a Twilio number
+      // by signup (Tracey number policy). Do NOT write a ChatMessage
+      // or Activity here: the conversation thread would render those
+      // as "delivered" even though nothing went out.
+      logger.error("runSendSms blocked: workspace has no provisioned Twilio sender", {
+        component: "chat-actions",
+        action: "runSendSms",
+        workspaceId,
         contactId: contact.id,
       });
-      await db.chatMessage.create({
-        data: {
-          role: "assistant",
-          content: params.message,
-          workspaceId,
-          metadata: { contactId: contact.id, channel: "sms", direction: "outbound" },
-        },
-      });
-      return `Logged SMS to ${contact.name} (${contact.phone}): "${params.message}". Note: Twilio is not yet configured so the message was recorded but not delivered.`;
+      return `SMS isn't set up for this workspace yet — I didn't send anything to ${contact.name}. Reach out to support so they can provision your number.`;
     }
 
     // Send via Twilio
@@ -2576,7 +2571,6 @@ export async function runSendEmail(
         const workspace = await db.workspace.findUnique({ where: { id: workspaceId }, select: { name: true } });
         const _senderName = workspace?.name ?? "Earlymark";
 
-        let delivered = false;
         const resendKey = process.env.RESEND_API_KEY;
         const fromDomain = process.env.RESEND_FROM_DOMAIN;
 
@@ -2604,25 +2598,37 @@ export async function runSendEmail(
         }
         // LOGIC END
 
-        if (resendKey && fromDomain) {
-          const { Resend } = await import("resend");
-          const resend = new Resend(resendKey);
-          const safeEmailTo = assertSafeRecipient("email", contactEmail);
-          const { error } = await withCostCeiling("resend", RESEND_EMAIL_COST_USD, () =>
-            resend.emails.send({
-              from: fromAddress,
-              to: [safeEmailTo],
-              subject: params.subject,
-              text: params.body,
-              replyTo: replyToAddress,
-              bcc: bccAddress,
-            }),
-          );
-          if (error) {
-            logger.error("Resend send email failed", { component: "chat-actions", action: "runSendEmailAction", workspaceId, contactId: contact.id }, error as Error);
-            return { returnMessage: `Failed to send email to ${contact.name}: ${error.message}` };
-          }
-          delivered = true;
+        if (!resendKey || !fromDomain) {
+          // Provisioning gap. Do NOT write a ChatMessage or Activity:
+          // the conversation thread would render the row as delivered
+          // even though nothing went out.
+          logger.error("runSendEmail blocked: Resend not configured", {
+            component: "chat-actions",
+            action: "runSendEmail",
+            workspaceId,
+            contactId: contact.id,
+          });
+          return {
+            returnMessage: `Email isn't set up for this workspace yet — I didn't send anything to ${contact.name}. Reach out to support so they can wire up email delivery.`,
+          };
+        }
+
+        const { Resend } = await import("resend");
+        const resend = new Resend(resendKey);
+        const safeEmailTo = assertSafeRecipient("email", contactEmail);
+        const { error } = await withCostCeiling("resend", RESEND_EMAIL_COST_USD, () =>
+          resend.emails.send({
+            from: fromAddress,
+            to: [safeEmailTo],
+            subject: params.subject,
+            text: params.body,
+            replyTo: replyToAddress,
+            bcc: bccAddress,
+          }),
+        );
+        if (error) {
+          logger.error("Resend send email failed", { component: "chat-actions", action: "runSendEmailAction", workspaceId, contactId: contact.id }, error as Error);
+          return { returnMessage: `Failed to send email to ${contact.name}: ${error.message}` };
         }
 
         await logActivity({
@@ -2640,12 +2646,7 @@ export async function runSendEmail(
           },
         });
 
-        if (delivered) {
-          return { returnMessage: `Email sent to ${contact.name} (${contactEmail}). Subject: "${params.subject}".` };
-        }
-        return {
-          returnMessage: `Email logged to ${contact.name} (${contactEmail}) but not delivered (Resend not configured). Subject: "${params.subject}".`,
-        };
+        return { returnMessage: `Email sent to ${contact.name} (${contactEmail}). Subject: "${params.subject}".` };
       },
     });
 

--- a/actions/chat-actions.ts
+++ b/actions/chat-actions.ts
@@ -1959,6 +1959,18 @@ export async function runMarkInvoicePaidAction(
   if (!result.success) {
     return { success: false, message: `Failed to mark invoice ${invoice.number} as paid.`, quickActions: [] };
   }
+  await recordWorkspaceAuditEventForCurrentActor({
+    workspaceId,
+    action: "invoice.marked_paid",
+    entityType: "invoice",
+    entityId: invoice.id,
+    metadata: {
+      invoiceNumber: invoice.number,
+      dealId: invoice.dealId,
+      previousStatus: invoice.status,
+      source: "chat-actions.runMarkInvoicePaidAction",
+    },
+  });
   revalidatePath("/crm", "layout");
   const dealTitle = invoice.deal.title;
   return {

--- a/actions/chat-actions.ts
+++ b/actions/chat-actions.ts
@@ -44,6 +44,7 @@ import { getAttentionSignalsForDeal } from "@/lib/deal-attention";
 import { logger } from "@/lib/logging";
 import { formatDateTimeInTimezone, resolveWorkspaceTimezone } from "@/lib/timezone";
 import { createSupportTicket } from "@/lib/support-tickets";
+import { initiateOutboundCall } from "@/lib/outbound-call";
 
 /**
  * Find similar contact names using fuzzy matching
@@ -2711,7 +2712,20 @@ export async function runMakeCall(
       return `No phone number configured for this workspace. Set up a Twilio number in workspace settings first.`;
     }
 
-    // Log the outbound call as an activity — LiveKit voice agent handles the call via SIP
+    let dispatch;
+    try {
+      dispatch = await initiateOutboundCall({
+        workspaceId,
+        contactPhone: contact.phone,
+        contactName: contact.name,
+        reason: params.purpose ?? "Call placed by AI assistant",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("runMakeCall dispatch failed", { workspaceId, contactId: contact.id, error: message });
+      return `I couldn't place the call to ${contact.name}: ${message}`;
+    }
+
     await logActivity({
       type: "CALL",
       title: `Outbound call to ${contact.name}`,
@@ -2719,7 +2733,14 @@ export async function runMakeCall(
       contactId: contact.id,
     });
 
-    return `📞 Calling ${contact.name} (${contact.phone}) via LiveKit voice agent...`;
+    logger.info("runMakeCall dispatched", {
+      workspaceId,
+      contactId: contact.id,
+      roomName: dispatch.roomName,
+      transport: dispatch.transport,
+    });
+
+    return `📞 Calling ${contact.name} (${contact.phone}) now.`;
   } catch (err) {
     return `Error making call: ${err instanceof Error ? err.message : String(err)}`;
   }

--- a/actions/followup-actions.ts
+++ b/actions/followup-actions.ts
@@ -7,6 +7,7 @@ import { sendSMS } from "./messaging-actions";
 import { createNotification } from "./notification-actions";
 import { assertSafeRecipient } from "@/lib/messaging/safe-recipient";
 import { withCostCeiling } from "@/lib/cost-ceiling";
+import { runIdempotent } from "@/lib/idempotency";
 
 const RESEND_EMAIL_COST_USD = 0.001;
 
@@ -441,9 +442,11 @@ export async function processPostJobFollowUps(): Promise<{
         title: true,
         contactId: true,
         workspaceId: true,
+        stageChangedAt: true,
         contact: { select: { name: true, phone: true } },
         workspace: { select: { name: true } },
       },
+      take: 200,
     });
 
     for (const deal of completedDeals) {
@@ -466,19 +469,6 @@ export async function processPostJobFollowUps(): Promise<{
         continue;
       }
 
-      // Check if we already sent a post-job follow-up for this deal
-      const alreadySent = await db.activity.findFirst({
-        where: {
-          dealId: deal.id,
-          title: { contains: "Post-job follow-up" },
-        },
-      });
-
-      if (alreadySent) {
-        skipped++;
-        continue;
-      }
-
       // Personalize the template
       const message = rule.messageTemplate
         .replace(/\{\{clientName\}\}/g, deal.contact.name)
@@ -486,21 +476,36 @@ export async function processPostJobFollowUps(): Promise<{
         .replace(/\{\{businessName\}\}/g, deal.workspace.name || "us");
 
       try {
-        const result = await sendSMS(deal.contactId, message, deal.id);
-        if (result.success) {
-          // Log the post-job follow-up activity
-          await db.activity.create({
-            data: {
-              type: "NOTE",
-              title: "Post-job follow-up sent",
-              content: `Automated follow-up SMS to ${deal.contact.name}: "${message.substring(0, 100)}..."`,
-              dealId: deal.id,
-              contactId: deal.contactId,
-            },
-          });
+        const claim = await runIdempotent<{ success: boolean; error?: string }>({
+          actionType: "POST_JOB_FOLLOWUP",
+          // bucketAt is intentionally the stage change time so the key is
+          // stable across cron runs — same deal cannot fire twice ever.
+          bucketAt: deal.stageChangedAt ?? new Date(),
+          parts: [deal.id],
+          resultFactory: async () => {
+            const result = await sendSMS(deal.contactId, message, deal.id);
+            if (!result.success) {
+              return { success: false, error: result.error };
+            }
+            await db.activity.create({
+              data: {
+                type: "NOTE",
+                title: "Post-job follow-up sent",
+                content: `Automated follow-up SMS to ${deal.contact.name}: "${message.substring(0, 100)}..."`,
+                dealId: deal.id,
+                contactId: deal.contactId,
+              },
+            });
+            return { success: true };
+          },
+        });
+
+        if (!claim.created) {
+          skipped++;
+        } else if (claim.result?.success) {
           sent++;
         } else {
-          errors.push(`SMS to ${deal.contact.name} failed: ${result.error}`);
+          errors.push(`SMS to ${deal.contact.name} failed: ${claim.result?.error ?? "unknown"}`);
         }
       } catch (err) {
         errors.push(`Post-job follow-up for deal ${deal.id} failed: ${err}`);

--- a/actions/followup-actions.ts
+++ b/actions/followup-actions.ts
@@ -285,7 +285,9 @@ export async function processFollowUpReminders(): Promise<{
   const errors: string[] = [];
 
   try {
-    // Find all deals with follow-ups due today or overdue
+    // Find all deals with follow-ups due today or overdue. Capped so a
+    // long backlog cannot fan-out into thousands of notifications in one
+    // cron invocation — leftovers are picked up on the next tick.
     const dueDeals = await db.deal.findMany({
       where: {
         followUpAt: { lte: endOfToday },
@@ -301,6 +303,8 @@ export async function processFollowUpReminders(): Promise<{
         workspaceId: true,
         contact: { select: { name: true, phone: true, email: true } },
       },
+      orderBy: { followUpAt: "asc" },
+      take: 200,
     });
 
     // Group by workspace

--- a/actions/messaging-actions.ts
+++ b/actions/messaging-actions.ts
@@ -2,6 +2,7 @@
 import { formatCurrency, formatDate, formatDateTime } from "@/lib/format";
 
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import { db } from "@/lib/db";
 import { buildPublicFeedbackUrl } from "@/lib/public-feedback";
 import { DEFAULT_WORKSPACE_TIMEZONE, resolveWorkspaceTimezone, formatDateTimeInTimezone } from "@/lib/timezone";
@@ -171,7 +172,15 @@ async function safeRecordWebhookEvent(data: {
   payload: Record<string, unknown>;
 }): Promise<void> {
   try {
-    await db.webhookEvent.create({ data });
+    await db.webhookEvent.create({
+      data: {
+        provider: data.provider,
+        eventType: data.eventType,
+        status: data.status,
+        error: data.error,
+        payload: data.payload as Prisma.InputJsonValue,
+      },
+    });
   } catch (err) {
     console.error(
       `[safeRecordWebhookEvent] failed to persist ${data.provider}/${data.eventType}/${data.status}:`,

--- a/actions/messaging-actions.ts
+++ b/actions/messaging-actions.ts
@@ -130,42 +130,53 @@ async function sendViaTwilio(
 
     if (!res.ok) {
       const errMsg = data.message ?? "Twilio API error";
-      db.webhookEvent.create({
-        data: {
-          provider: "twilio",
-          eventType: `sms.${channel}`,
-          status: "error",
-          error: errMsg,
-          payload: { to: to.slice(0, 6) + "***", channel },
-        },
-      }).catch(() => {});
-      return { success: false, error: errMsg };
-    }
-
-    db.webhookEvent.create({
-      data: {
-        provider: "twilio",
-        eventType: `sms.${channel}`,
-        status: "success",
-        payload: { sid: data.sid, channel },
-      },
-    }).catch(() => {});
-    return { success: true, sid: data.sid };
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : "Network error";
-    db.webhookEvent.create({
-      data: {
+      await safeRecordWebhookEvent({
         provider: "twilio",
         eventType: `sms.${channel}`,
         status: "error",
         error: errMsg,
-        payload: { channel },
-      },
-    }).catch(() => {});
+        payload: { to: to.slice(0, 6) + "***", channel },
+      });
+      return { success: false, error: errMsg };
+    }
+
+    await safeRecordWebhookEvent({
+      provider: "twilio",
+      eventType: `sms.${channel}`,
+      status: "success",
+      payload: { sid: data.sid, channel },
+    });
+    return { success: true, sid: data.sid };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : "Network error";
+    await safeRecordWebhookEvent({
+      provider: "twilio",
+      eventType: `sms.${channel}`,
+      status: "error",
+      error: errMsg,
+      payload: { channel },
+    });
     return {
       success: false,
       error: errMsg,
     };
+  }
+}
+
+async function safeRecordWebhookEvent(data: {
+  provider: string;
+  eventType: string;
+  status: string;
+  error?: string;
+  payload: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await db.webhookEvent.create({ data });
+  } catch (err) {
+    console.error(
+      `[safeRecordWebhookEvent] failed to persist ${data.provider}/${data.eventType}/${data.status}:`,
+      err instanceof Error ? err.message : err,
+    );
   }
 }
 

--- a/actions/referral-actions.ts
+++ b/actions/referral-actions.ts
@@ -285,22 +285,52 @@ async function applyHalfPriceMonthsToReferrer(referrerUserId: string, earnedMont
     name: `Earlymark referral 50% off (${totalMonths} month${totalMonths === 1 ? "" : "s"})`,
   });
 
-  await stripe.subscriptions.update(workspace.stripeSubscriptionId, {
-    discounts: [{ coupon: coupon.id }],
-    proration_behavior: "none",
-  });
+  try {
+    await stripe.subscriptions.update(workspace.stripeSubscriptionId, {
+      discounts: [{ coupon: coupon.id }],
+      proration_behavior: "none",
+    });
+  } catch (err) {
+    // The coupon exists in Stripe but never got attached to a
+    // subscription — compensate by deleting it so it can't be
+    // hand-applied later, then re-throw so the caller can retry.
+    await stripe.coupons.del(coupon.id).catch((delErr) => {
+      console.error(
+        "[applyHalfPriceMonthsToReferrer] failed to delete orphan coupon after subscription update failed:",
+        coupon.id,
+        delErr instanceof Error ? delErr.message : delErr,
+      );
+    });
+    throw err;
+  }
 
-  const settings = (workspace.settings as Record<string, unknown>) ?? {};
-  await db.workspace.update({
-    where: { id: workspace.id },
-    data: {
-      settings: {
-        ...settings,
-        referralHalfPriceMonthsRemaining: totalMonths,
-        referralLastAppliedAt: new Date().toISOString(),
+  try {
+    const settings = (workspace.settings as Record<string, unknown>) ?? {};
+    await db.workspace.update({
+      where: { id: workspace.id },
+      data: {
+        settings: {
+          ...settings,
+          referralHalfPriceMonthsRemaining: totalMonths,
+          referralLastAppliedAt: new Date().toISOString(),
+          referralLastCouponId: coupon.id,
+        },
       },
-    },
-  });
+    });
+  } catch (err) {
+    // The customer keeps their discount (do NOT compensate by
+    // detaching), but our DB row is now out of sync. Log loudly
+    // so ops can reconcile from the coupon id stored in Stripe.
+    console.error(
+      "[applyHalfPriceMonthsToReferrer] subscription updated but DB write failed — coupon",
+      coupon.id,
+      "is live on subscription",
+      workspace.stripeSubscriptionId,
+      "without a DB record. Manual reconciliation required.",
+      err instanceof Error ? err.message : err,
+    );
+    throw err;
+  }
 
   return { success: true, totalMonths };
 }

--- a/actions/reminder-actions.ts
+++ b/actions/reminder-actions.ts
@@ -10,6 +10,7 @@ import { NotificationScenario } from "@/lib/messaging/channel-router";
 import { DEFAULT_WORKSPACE_TIMEZONE, formatDateTimeInTimezone } from "@/lib/timezone";
 import { assertSafeRecipient } from "@/lib/messaging/safe-recipient";
 import { withCostCeiling } from "@/lib/cost-ceiling";
+import { requireDealInCurrentWorkspace } from "@/lib/workspace-access";
 
 const TWILIO_SMS_COST_USD = 0.05;
 
@@ -360,8 +361,14 @@ export async function checkAndSendReminders() {
 
 // Manual update functions for admin control
 export async function manualSendJobReminder(dealId: string, adminId?: string) {
+  try {
+    await requireDealInCurrentWorkspace(dealId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   console.log(`🔧 [MANUAL] Admin ${adminId || 'unknown'} manually triggering job reminder for: ${dealId}`);
-  
+
   const result = await sendJobReminder(dealId);
   
   if (result.success) {
@@ -383,8 +390,14 @@ export async function manualSendJobReminder(dealId: string, adminId?: string) {
 }
 
 export async function manualSendTripSms(dealId: string, adminId?: string) {
+  try {
+    await requireDealInCurrentWorkspace(dealId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   console.log(`🚗 [MANUAL] Admin ${adminId || 'unknown'} manually triggering trip SMS for: ${dealId}`);
-  
+
   const result = await sendTripSms(dealId);
   
   if (result.success) {

--- a/app/api/contacts/search/route.ts
+++ b/app/api/contacts/search/route.ts
@@ -1,21 +1,32 @@
 import { NextResponse } from "next/server"
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access"
 import { searchContacts } from "@/actions/contact-actions"
 
 export async function POST(request: Request) {
+  let actor
   try {
-    const body = await request.json()
-    const workspaceId = typeof body?.workspaceId === "string" ? body.workspaceId : ""
-    const query = typeof body?.query === "string" ? body.query : ""
+    actor = await requireCurrentWorkspaceAccess()
+  } catch {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 })
+  }
 
-    if (!workspaceId) {
-      return NextResponse.json({ success: false, error: "workspaceId is required" }, { status: 400 })
-    }
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid JSON" }, { status: 400 })
+  }
 
-    if (!query.trim()) {
-      return NextResponse.json({ results: [] })
-    }
+  const query = (body && typeof body === "object" && typeof (body as Record<string, unknown>).query === "string")
+    ? ((body as Record<string, unknown>).query as string)
+    : ""
 
-    const results = await searchContacts(workspaceId, query)
+  if (!query.trim()) {
+    return NextResponse.json({ results: [] })
+  }
+
+  try {
+    const results = await searchContacts(actor.workspaceId, query)
     return NextResponse.json({ results })
   } catch (error) {
     console.error("POST /api/contacts/search failed:", error)

--- a/app/api/cron/job-reminders/route.ts
+++ b/app/api/cron/job-reminders/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     console.log(`🔐 [API] Checking authorization...`);
     
     if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-      console.error(`❌ [API] Unauthorized cron job attempt. Header: ${authHeader?.substring(0, 20)}...`);
+      console.error(`❌ [API] Unauthorized cron job attempt. Header present: ${Boolean(authHeader)}`);
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/app/api/cron/recurring-jobs/route.ts
+++ b/app/api/cron/recurring-jobs/route.ts
@@ -16,7 +16,7 @@ export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   const authHeader = req.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -25,7 +25,8 @@ export async function GET(req: NextRequest) {
   let skipped = 0;
   const errors: string[] = [];
 
-  // Find all deals that have a recurrence rule, are past their scheduledAt, and not in terminal stages
+  // Find candidate deals to clone for their next recurrence. Capped so a
+  // long backlog cannot fan-out into thousands of clones per cron tick.
   const candidates = await db.deal.findMany({
     where: {
       scheduledAt: { lt: now },
@@ -46,6 +47,8 @@ export async function GET(req: NextRequest) {
       metadata: true,
       scheduledAt: true,
     },
+    orderBy: { scheduledAt: "asc" },
+    take: 200,
   });
 
   for (const deal of candidates) {

--- a/app/api/cron/task-overdue/route.ts
+++ b/app/api/cron/task-overdue/route.ts
@@ -19,7 +19,9 @@ export async function GET(request: NextRequest) {
   const startTime = Date.now();
 
   try {
-    // Find all workspaces that have at least one overdue, incomplete task
+    // Find workspaces that have at least one overdue, incomplete task.
+    // Capped so a long backlog cannot blow the cron invocation budget;
+    // remaining workspaces are picked up on the next tick.
     const overdueTasks = await db.task.findMany({
       where: {
         completed: false,
@@ -32,6 +34,8 @@ export async function GET(request: NextRequest) {
         deal: { select: { workspaceId: true } },
         contact: { select: { workspaceId: true } },
       },
+      orderBy: { dueAt: "asc" },
+      take: 500,
     });
 
     // Group by workspace

--- a/app/api/internal/voice-calls/route.ts
+++ b/app/api/internal/voice-calls/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "@/lib/db";
+import { runIdempotent } from "@/lib/idempotency";
 import { findContactByPhone, findWorkspaceByTwilioNumber } from "@/lib/workspace-routing";
 import { isVoiceAgentSecretAuthorized } from "@/lib/voice-agent-auth";
 import { syncVoiceCallToCRM } from "@/lib/post-call-sync";
@@ -175,10 +176,6 @@ export async function POST(req: NextRequest) {
     }
 
     const payload = parsed.data;
-    const existingVoiceCall = await db.voiceCall.findUnique({
-      where: { callId: payload.callId },
-      select: { callId: true },
-    });
     const roomMetadata = getNestedRecord(payload.metadata, "roomMetadata");
     const isOutboundCallback = Boolean(
       roomMetadata?.outbound === true || roomMetadata?.outbound === "true",
@@ -259,97 +256,121 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    // ── Post-call CRM sync: create Contact + Deal for normal calls ──
-    if (workspaceId && isOutboundCallback && !existingVoiceCall && callbackOutcome) {
-      await recordCallbackEvent({
-        eventType: "callback_call_finished",
-        payload: {
-          workspaceId,
-          contactId,
-          contactPhone: payload.callerPhone || null,
-          contactName: payload.callerName || null,
-          dealId: callbackDealId,
-          reason: callbackReason,
-          triggerSource: "voice_agent",
-          callbackKind,
-          callStatus: callbackOutcome,
-          providerCallSid: readOptionalString(getNestedRecord(payload.metadata, "providerCallIds"), "twilioCallSid"),
-        },
-      });
-    }
+    // ── Post-call side effects ─────────────────────────────────────────
+    // Twilio/LiveKit retries (same callId) used to slip past the
+    // findUnique-then-create dedupe and create duplicate callback events,
+    // duplicate urgent-callback Tasks, and duplicate CALL Activities.
+    // runIdempotent's actionExecution unique constraint on the
+    // idempotencyKey makes this exactly-once per callId. bucketAt is
+    // pinned to epoch so the key never expires.
+    const postCallClaim = await runIdempotent<{
+      crmSync: {
+        contactId: string | null;
+        dealId: string | null;
+        contactCreated: boolean;
+        dealCreated: boolean;
+        skipped: boolean;
+      } | null;
+    }>({
+      actionType: "VOICE_CALL_POST_PROCESS",
+      bucketAt: new Date(0),
+      parts: [payload.callId],
+      resultFactory: async () => {
+        if (workspaceId && isOutboundCallback && callbackOutcome) {
+          await recordCallbackEvent({
+            eventType: "callback_call_finished",
+            payload: {
+              workspaceId,
+              contactId,
+              contactPhone: payload.callerPhone || null,
+              contactName: payload.callerName || null,
+              dealId: callbackDealId,
+              reason: callbackReason,
+              triggerSource: "voice_agent",
+              callbackKind,
+              callStatus: callbackOutcome,
+              providerCallSid: readOptionalString(getNestedRecord(payload.metadata, "providerCallIds"), "twilioCallSid"),
+            },
+          });
+        }
 
-    let syncResult = null;
-    if (workspaceId && payload.callType === "normal" && transcriptText && !isOutboundCallback) {
-      try {
-        syncResult = await syncVoiceCallToCRM(workspaceId, {
-          callId: payload.callId,
-          callType: payload.callType,
-          callerPhone: payload.callerPhone,
-          calledPhone: payload.calledPhone,
-          callerName: payload.callerName,
-          businessName: payload.businessName,
-          transcriptText,
-          transcriptTurns: payload.transcriptTurns,
-          summary,
-          voiceCallId: payload.callId,
-          urgentEscalationReason: urgentEscalation?.reason ?? null,
-        });
-        console.log(`[voice-call-webhook] CRM sync result:`, syncResult);
-      } catch (err) {
-        // Non-fatal: the VoiceCall is already saved, CRM sync is best-effort
-        console.error("[voice-call-webhook] CRM sync failed (non-fatal):", err);
-      }
-    }
+        let syncResult: Awaited<ReturnType<typeof syncVoiceCallToCRM>> | null = null;
+        if (workspaceId && payload.callType === "normal" && transcriptText && !isOutboundCallback) {
+          try {
+            syncResult = await syncVoiceCallToCRM(workspaceId, {
+              callId: payload.callId,
+              callType: payload.callType,
+              callerPhone: payload.callerPhone,
+              calledPhone: payload.calledPhone,
+              callerName: payload.callerName,
+              businessName: payload.businessName,
+              transcriptText,
+              transcriptTurns: payload.transcriptTurns,
+              summary,
+              voiceCallId: payload.callId,
+              urgentEscalationReason: urgentEscalation?.reason ?? null,
+            });
+            console.log(`[voice-call-webhook] CRM sync result:`, syncResult);
+          } catch (err) {
+            console.error("[voice-call-webhook] CRM sync failed (non-fatal):", err);
+          }
+        }
 
-    if (workspaceId && urgentEscalation && !existingVoiceCall) {
-      const callbackTitle = payload.callerName
-        ? `Urgent callback: ${payload.callerName}`
-        : payload.callerPhone
-          ? `Urgent callback: ${payload.callerPhone}`
-          : "Urgent callback requested";
-      const callbackDescription = [
-        `Reason: ${urgentEscalation.reason}`,
-        payload.callerPhone ? `Caller: ${payload.callerPhone}` : null,
-        summary,
-      ].filter(Boolean).join("\n");
+        if (workspaceId && urgentEscalation) {
+          const callbackTitle = payload.callerName
+            ? `Urgent callback: ${payload.callerName}`
+            : payload.callerPhone
+              ? `Urgent callback: ${payload.callerPhone}`
+              : "Urgent callback requested";
+          const callbackDescription = [
+            `Reason: ${urgentEscalation.reason}`,
+            payload.callerPhone ? `Caller: ${payload.callerPhone}` : null,
+            summary,
+          ].filter(Boolean).join("\n");
 
-      await db.task.create({
-        data: {
-          title: callbackTitle,
-          description: callbackDescription,
-          dueAt: new Date(Date.now() + 15 * 60 * 1000),
-          contactId: contactId ?? syncResult?.contactId ?? undefined,
-          dealId: syncResult?.dealId ?? undefined,
-        },
-      });
-    }
+          await db.task.create({
+            data: {
+              title: callbackTitle,
+              description: callbackDescription,
+              dueAt: new Date(Date.now() + 15 * 60 * 1000),
+              contactId: contactId ?? syncResult?.contactId ?? undefined,
+              dealId: syncResult?.dealId ?? undefined,
+            },
+          });
+        }
 
-    // For non-normal calls or if sync was skipped, still log activity
-    if (workspaceId && transcriptText && (!syncResult || syncResult.skipped) && !isOutboundCallback) {
-      await db.activity.create({
-        data: {
-          type: "CALL",
-          title: urgentEscalation
-            ? "Urgent callback requested"
-            : payload.callType === "normal"
-              ? "Voice call handled by Tracey"
-              : "Earlymark AI voice call",
-          content: summary,
-          description: transcriptText.slice(0, 2000),
-          contactId: contactId ?? undefined,
-        },
-      });
-    }
+        if (workspaceId && transcriptText && (!syncResult || syncResult.skipped) && !isOutboundCallback) {
+          await db.activity.create({
+            data: {
+              type: "CALL",
+              title: urgentEscalation
+                ? "Urgent callback requested"
+                : payload.callType === "normal"
+                  ? "Voice call handled by Tracey"
+                  : "Earlymark AI voice call",
+              content: summary,
+              description: transcriptText.slice(0, 2000),
+              contactId: contactId ?? undefined,
+            },
+          });
+        }
+
+        return {
+          crmSync: syncResult ? {
+            contactId: syncResult.contactId,
+            dealId: syncResult.dealId,
+            contactCreated: syncResult.contactCreated,
+            dealCreated: syncResult.dealCreated,
+            skipped: syncResult.skipped,
+          } : null,
+        };
+      },
+    });
 
     return NextResponse.json({
       success: true,
-      crmSync: syncResult ? {
-        contactId: syncResult.contactId,
-        dealId: syncResult.dealId,
-        contactCreated: syncResult.contactCreated,
-        dealCreated: syncResult.dealCreated,
-        skipped: syncResult.skipped,
-      } : null,
+      duplicate: !postCallClaim.created,
+      crmSync: postCallClaim.result?.crmSync ?? null,
     });
   } catch (error) {
     console.error("[voice-call-webhook] Error:", error);

--- a/app/api/log-crash/route.ts
+++ b/app/api/log-crash/route.ts
@@ -1,7 +1,39 @@
-import { NextResponse } from 'next/server';
-import fs from 'fs';
-export async function POST(r: Request) {
-    const j = await r.json();
-    fs.writeFileSync('tmp-err.log', JSON.stringify(j));
-    return NextResponse.json({});
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { logger } from "@/lib/logging";
+
+const MAX_MESSAGE_LENGTH = 2_000;
+const MAX_STACK_LENGTH = 10_000;
+
+function clampString(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+export async function POST(request: Request) {
+  const user = await getAuthUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const payload = (body && typeof body === "object") ? body as Record<string, unknown> : {};
+  const message = clampString(payload.message, MAX_MESSAGE_LENGTH) ?? "(no message)";
+  const stack = clampString(payload.stack, MAX_STACK_LENGTH);
+
+  logger.error("Client-side crash reported", {
+    component: "client-error-boundary",
+    userId: user.id,
+    stack,
+  }, new Error(message));
+
+  return NextResponse.json({ ok: true });
 }

--- a/app/api/reminders/route.ts
+++ b/app/api/reminders/route.ts
@@ -1,29 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 import { manualSendJobReminder, manualSendTripSms, getReminderStats } from "@/actions/reminder-actions";
-import { getAuthUser } from "@/lib/auth";
-import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
+import { requireCurrentWorkspaceAccess, requireDealInCurrentWorkspace } from "@/lib/workspace-access";
 
 export async function POST(request: NextRequest) {
+  let actor;
   try {
-    const user = await getAuthUser();
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    actor = await requireCurrentWorkspaceAccess();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    const body = await request.json();
-    const { action, dealId } = body;
+  let body: { action?: unknown; dealId?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
 
-    if (!action || !dealId) {
-      return NextResponse.json({ error: "Missing action or dealId" }, { status: 400 });
-    }
+  const action = typeof body.action === "string" ? body.action : "";
+  const dealId = typeof body.dealId === "string" ? body.dealId : "";
 
+  if (!action || !dealId) {
+    return NextResponse.json({ error: "Missing action or dealId" }, { status: 400 });
+  }
+
+  try {
+    await requireDealInCurrentWorkspace(dealId);
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
     let result;
     switch (action) {
       case "sendReminder":
-        result = await manualSendJobReminder(dealId, user.id);
+        result = await manualSendJobReminder(dealId, actor.id);
         break;
       case "sendTripSms":
-        result = await manualSendTripSms(dealId, user.id);
+        result = await manualSendTripSms(dealId, actor.id);
         break;
       default:
         return NextResponse.json({ error: "Invalid action" }, { status: 400 });
@@ -40,21 +54,21 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  let actor;
   try {
-    const user = await getAuthUser();
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    const actor = await requireCurrentWorkspaceAccess();
+    actor = await requireCurrentWorkspaceAccess();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    const { searchParams } = new URL(request.url);
-    const requestedWorkspaceId = searchParams.get("workspaceId");
-    if (requestedWorkspaceId && requestedWorkspaceId !== actor.workspaceId) {
-      return NextResponse.json({ error: "Forbidden workspace access" }, { status: 403 });
-    }
+  const { searchParams } = new URL(request.url);
+  const requestedWorkspaceId = searchParams.get("workspaceId");
+  if (requestedWorkspaceId && requestedWorkspaceId !== actor.workspaceId) {
+    return NextResponse.json({ error: "Forbidden workspace access" }, { status: 403 });
+  }
 
+  try {
     const result = await getReminderStats(actor.workspaceId);
-
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error getting reminder stats:", error);

--- a/app/api/search/global/route.ts
+++ b/app/api/search/global/route.ts
@@ -1,17 +1,32 @@
 import { NextResponse } from "next/server"
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access"
 import { globalSearch } from "@/actions/search-actions"
 
 export async function POST(request: Request) {
+  let actor
   try {
-    const body = await request.json()
-    const workspaceId = typeof body?.workspaceId === "string" ? body.workspaceId : ""
-    const query = typeof body?.query === "string" ? body.query : ""
+    actor = await requireCurrentWorkspaceAccess()
+  } catch {
+    return NextResponse.json({ results: [], error: "Unauthorized" }, { status: 401 })
+  }
 
-    if (!workspaceId || query.trim().length < 2) {
-      return NextResponse.json({ results: [] })
-    }
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ results: [], error: "Invalid JSON" }, { status: 400 })
+  }
 
-    const results = await globalSearch(workspaceId, query)
+  const query = (body && typeof body === "object" && typeof (body as Record<string, unknown>).query === "string")
+    ? ((body as Record<string, unknown>).query as string)
+    : ""
+
+  if (query.trim().length < 2) {
+    return NextResponse.json({ results: [] })
+  }
+
+  try {
+    const results = await globalSearch(actor.workspaceId, query)
     return NextResponse.json({ results })
   } catch (error) {
     console.error("POST /api/search/global failed:", error)

--- a/app/api/sync/replay/route.ts
+++ b/app/api/sync/replay/route.ts
@@ -1,55 +1,105 @@
 import { NextResponse } from "next/server"
+import { getAuthUser } from "@/lib/auth"
+import { requireContactInCurrentWorkspace, requireDealInCurrentWorkspace } from "@/lib/workspace-access"
 import { updateJobStatus, createQuoteVariation } from "@/actions/tradie-actions"
 import { logActivity } from "@/actions/activity-actions"
 
+type ActivityType = "NOTE" | "CALL" | "EMAIL" | "TASK" | "MEETING"
+
+const ACTIVITY_TYPES: ReadonlySet<ActivityType> = new Set([
+  "NOTE",
+  "CALL",
+  "EMAIL",
+  "TASK",
+  "MEETING",
+])
+
+const JOB_STATUSES = ["SCHEDULED", "TRAVELING", "ON_SITE", "COMPLETED", "CANCELLED"] as const
+type JobStatus = typeof JOB_STATUSES[number]
+
 export async function POST(request: Request) {
+  const user = await getAuthUser()
+  if (!user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body: unknown
   try {
-    const body = await request.json()
-    const actionName = typeof body?.actionName === "string" ? body.actionName : ""
-    const payload = (body?.payload ?? {}) as Record<string, unknown>
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid JSON" }, { status: 400 })
+  }
 
-    if (!actionName) {
-      return NextResponse.json({ success: false, error: "actionName is required" }, { status: 400 })
-    }
+  const parsed = (body && typeof body === "object") ? body as Record<string, unknown> : {}
+  const actionName = typeof parsed.actionName === "string" ? parsed.actionName : ""
+  const payload = (parsed.payload && typeof parsed.payload === "object")
+    ? parsed.payload as Record<string, unknown>
+    : {}
 
+  if (!actionName) {
+    return NextResponse.json({ success: false, error: "actionName is required" }, { status: 400 })
+  }
+
+  try {
     if (actionName === "updateJobStatus") {
       const jobId = typeof payload.jobId === "string" ? payload.jobId : ""
       const status = typeof payload.status === "string" ? payload.status : ""
-      if (!jobId || !status) {
-        return NextResponse.json({ success: false, error: "jobId and status are required" }, { status: 400 })
+      if (!jobId || !(JOB_STATUSES as readonly string[]).includes(status)) {
+        return NextResponse.json({ success: false, error: "jobId and valid status are required" }, { status: 400 })
       }
-      const result = await updateJobStatus(jobId, status as "SCHEDULED" | "TRAVELING" | "ON_SITE" | "COMPLETED" | "CANCELLED")
+      const result = await updateJobStatus(jobId, status as JobStatus)
       return NextResponse.json(result, { status: result?.success ? 200 : 400 })
     }
 
     if (actionName === "createQuoteVariation") {
       const jobId = typeof payload.jobId === "string" ? payload.jobId : ""
-      const items = Array.isArray(payload.items) ? payload.items : []
+      const rawItems = Array.isArray(payload.items) ? payload.items : []
       if (!jobId) {
         return NextResponse.json({ success: false, error: "jobId is required" }, { status: 400 })
       }
-      const result = await createQuoteVariation(jobId, items as Array<{ desc: string; price: number }>)
+      const items: Array<{ desc: string; price: number }> = []
+      for (const raw of rawItems) {
+        if (!raw || typeof raw !== "object") continue
+        const item = raw as Record<string, unknown>
+        if (typeof item.desc !== "string" || typeof item.price !== "number") continue
+        if (!Number.isFinite(item.price)) continue
+        items.push({ desc: item.desc, price: item.price })
+      }
+      const result = await createQuoteVariation(jobId, items)
       return NextResponse.json(result, { status: result?.success ? 200 : 400 })
     }
 
     if (actionName === "logActivity") {
-      const normalizedPayload = {
-        ...payload,
-        content: typeof payload.content === "string" ? payload.content : "",
+      const type = typeof payload.type === "string" ? payload.type : ""
+      const title = typeof payload.title === "string" ? payload.title.trim() : ""
+      if (!ACTIVITY_TYPES.has(type as ActivityType) || !title) {
+        return NextResponse.json({ success: false, error: "type and title are required" }, { status: 400 })
       }
-      const result = await logActivity(normalizedPayload as {
-        type: "NOTE" | "CALL" | "EMAIL" | "TASK" | "MEETING"
-        title: string
-        content: string
-        description?: string
-        dealId?: string
-        contactId?: string
+      const dealId = typeof payload.dealId === "string" && payload.dealId ? payload.dealId : undefined
+      const contactId = typeof payload.contactId === "string" && payload.contactId ? payload.contactId : undefined
+      if (!dealId && !contactId) {
+        return NextResponse.json({ success: false, error: "dealId or contactId is required" }, { status: 400 })
+      }
+      if (dealId) await requireDealInCurrentWorkspace(dealId)
+      if (contactId) await requireContactInCurrentWorkspace(contactId)
+
+      const result = await logActivity({
+        type: type as ActivityType,
+        title,
+        content: typeof payload.content === "string" ? payload.content : "",
+        description: typeof payload.description === "string" ? payload.description : undefined,
+        dealId,
+        contactId,
       })
       return NextResponse.json(result, { status: result?.success ? 200 : 400 })
     }
 
     return NextResponse.json({ success: false, error: `Unsupported action: ${actionName}` }, { status: 400 })
   } catch (error) {
+    const message = error instanceof Error ? error.message : "Sync replay failed"
+    if (/unauthor|not found|forbidden/i.test(message)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 })
+    }
     console.error("POST /api/sync/replay failed:", error)
     return NextResponse.json({ success: false, error: "Sync replay failed" }, { status: 500 })
   }

--- a/app/api/webhooks/email/route.ts
+++ b/app/api/webhooks/email/route.ts
@@ -1,10 +1,25 @@
 import { NextResponse } from "next/server"
+import { timingSafeEqual } from "crypto"
 import { db } from "@/lib/db"
 import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { generateObject } from "ai"
 import { z } from "zod"
 import { classifyMessage } from "@/lib/spam-classifier"
 import { findWorkspaceByInboundEmail } from "@/lib/workspace-routing"
+
+function verifyEmailWebhookSecret(req: Request): { ok: boolean; reason?: "missing-config" | "missing-header" | "mismatch" } {
+    const configured = (process.env.EMAIL_WEBHOOK_SECRET || "").trim()
+    if (!configured) return { ok: false, reason: "missing-config" }
+
+    const provided = (req.headers.get("x-email-webhook-secret") || "").trim()
+    if (!provided) return { ok: false, reason: "missing-header" }
+
+    const a = Buffer.from(configured)
+    const b = Buffer.from(provided)
+    if (a.length !== b.length) return { ok: false, reason: "mismatch" }
+    if (!timingSafeEqual(a, b)) return { ok: false, reason: "mismatch" }
+    return { ok: true }
+}
 
 // ─── Lead Provider Patterns (Tier 1) ────────────────────────────────
 const LEAD_PROVIDERS: Record<string, RegExp> = {
@@ -32,6 +47,15 @@ const LEAD_KEYWORDS = [
 ]
 
 export async function POST(req: Request) {
+    const verification = verifyEmailWebhookSecret(req)
+    if (!verification.ok) {
+        if (verification.reason === "missing-config") {
+            console.error("[POST /api/webhooks/email] EMAIL_WEBHOOK_SECRET is not set; rejecting all inbound email until configured")
+            return NextResponse.json({ error: "Email webhook is not configured" }, { status: 503 })
+        }
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
     try {
         let rawTo = ""
         let rawFrom = ""

--- a/app/api/webhooks/twilio-voice-status/route.ts
+++ b/app/api/webhooks/twilio-voice-status/route.ts
@@ -16,6 +16,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { runIdempotent } from "@/lib/idempotency";
 import {
   getTwilioRequestPublicUrl,
   readTwilioFormParams,
@@ -76,53 +77,70 @@ export async function POST(req: NextRequest) {
     const workspace = await findWorkspaceByTwilioNumber(calledNumber);
     if (!workspace) return twimlHangup();
 
-    // Idempotency: if we've already logged this CallSid as a missed call,
-    // don't create a duplicate Deal or queue a second callback.
-    if (callSid) {
-      const existing = await db.webhookEvent.findFirst({
-        where: {
-          provider: "twilio",
-          eventType: "missed_call",
-          payload: { path: ["callSid"], equals: callSid },
-        },
-        select: { id: true },
-      });
-      if (existing) return twimlHangup();
-    }
+    // Atomic dedupe + create. runIdempotent's actionExecution row carries
+    // a unique constraint on the idempotencyKey, so the first concurrent
+    // webhook invocation for a callSid wins, and any retry/duplicate
+    // delivery from Twilio receives the cached deal+contact ids without
+    // creating a second Deal.
+    if (!callSid) return twimlHangup();
 
-    // Find or create the caller contact in this workspace.
-    let contact = await findContactByPhone(workspace.id, callerNumber);
-    if (!contact) {
-      contact = await db.contact.create({
-        data: {
-          workspaceId: workspace.id,
-          name: `Caller ${callerNumber}`,
-          phone: callerNumber,
-        },
-      });
-    }
+    const claim = await runIdempotent<{ contactId: string; dealId: string }>({
+      actionType: "TWILIO_MISSED_CALL",
+      bucketAt: new Date(0),
+      parts: [callSid],
+      resultFactory: async () => {
+        let contact = await findContactByPhone(workspace.id, callerNumber);
+        if (!contact) {
+          contact = await db.contact.create({
+            data: {
+              workspaceId: workspace.id,
+              name: `Caller ${callerNumber}`,
+              phone: callerNumber,
+            },
+          });
+        }
 
-    const deal = await db.deal.create({
-      data: {
-        workspaceId: workspace.id,
-        contactId: contact.id,
-        title: `Missed call from ${contact.name || callerNumber}`,
-        stage: "NEW",
-        value: 0,
-        source: "missed_call",
-        metadata: { leadSource: "missed_call", twilioCallSid: callSid, dialStatus },
-      } as Parameters<typeof db.deal.create>[0]["data"],
+        const deal = await db.deal.create({
+          data: {
+            workspaceId: workspace.id,
+            contactId: contact.id,
+            title: `Missed call from ${contact.name || callerNumber}`,
+            stage: "NEW",
+            value: 0,
+            source: "missed_call",
+            metadata: { leadSource: "missed_call", twilioCallSid: callSid, dialStatus },
+          } as Parameters<typeof db.deal.create>[0]["data"],
+        });
+
+        await db.activity.create({
+          data: {
+            type: "CALL",
+            title: "Missed inbound call",
+            content: `Caller ${callerNumber} dialled ${calledNumber}; the assistant did not pick up (${dialStatus}).`,
+            contactId: contact.id,
+            dealId: deal.id,
+          },
+        }).catch(() => {});
+
+        return { contactId: contact.id, dealId: deal.id };
+      },
     });
 
-    await db.activity.create({
-      data: {
-        type: "CALL",
-        title: "Missed inbound call",
-        content: `Caller ${callerNumber} dialled ${calledNumber}; the assistant did not pick up (${dialStatus}).`,
-        contactId: contact.id,
-        dealId: deal.id,
-      },
-    }).catch(() => {});
+    if (!claim.created) {
+      // Duplicate delivery — first call already created the deal and
+      // queued any callback work. Acknowledge with a hangup so Twilio
+      // stops retrying.
+      return twimlHangup();
+    }
+
+    if (!claim.result) {
+      // Claim raced and the original work crashed; we didn't create a
+      // deal here so don't proceed with callback dispatch.
+      return twimlHangup();
+    }
+
+    const contact = { id: claim.result.contactId, name: `Caller ${callerNumber}` };
+    const deal = { id: claim.result.dealId };
 
     // Queue an automatic callback if the workspace policy allows it (auto-
     // call on, voice enabled, agent mode EXECUTION, workspace has a number)

--- a/app/api/webhooks/whatsapp/route.ts
+++ b/app/api/webhooks/whatsapp/route.ts
@@ -52,12 +52,14 @@ export async function POST(req: Request) {
 
     // Twilio retries deliver the same MessageSid for the same inbound message.
     // Wrap the rest of the work so a retry does not double-fire the AI agent
-    // or send a second outbound WhatsApp message.
+    // or send a second outbound WhatsApp message. bucketAt is intentionally
+    // fixed (epoch) so the key is stable across hours — a retry an hour later
+    // still hits the same idempotency row.
     const dedupKey = messageSid || `${cleanNumber}:${body.slice(0, 64)}:${Math.floor(Date.now() / 60_000)}`;
     const idempotency = await runIdempotent({
       actionType: "whatsapp.inbound",
       parts: [dedupKey],
-      bucketAt: new Date(),
+      bucketAt: new Date(0),
       resultFactory: () => processWhatsappMessage({ user, body, cleanNumber, inboundPayload }),
       waitForCompletionMs: 4000,
     });

--- a/app/api/workspace/complete-tutorial/route.ts
+++ b/app/api/workspace/complete-tutorial/route.ts
@@ -1,16 +1,17 @@
 import { NextResponse } from "next/server"
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access"
 import { completeTutorial } from "@/actions/workspace-actions"
 
-export async function POST(request: Request) {
+export async function POST() {
+  let actor
   try {
-    const body = await request.json()
-    const workspaceId = typeof body?.workspaceId === "string" ? body.workspaceId : ""
+    actor = await requireCurrentWorkspaceAccess()
+  } catch {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 })
+  }
 
-    if (!workspaceId) {
-      return NextResponse.json({ success: false, error: "workspaceId is required" }, { status: 400 })
-    }
-
-    await completeTutorial(workspaceId)
+  try {
+    await completeTutorial(actor.workspaceId)
     return NextResponse.json({ success: true })
   } catch (error) {
     console.error("POST /api/workspace/complete-tutorial failed:", error)

--- a/components/core/command-palette.tsx
+++ b/components/core/command-palette.tsx
@@ -51,7 +51,7 @@ export function CommandPalette() {
     setLoading(true)
     const timer = setTimeout(async () => {
       try {
-        const data = await globalSearchClient(workspaceId, query)
+        const data = await globalSearchClient(query)
         setResults(data)
       } catch (error) {
         console.error(error)

--- a/components/core/search-command.tsx
+++ b/components/core/search-command.tsx
@@ -60,7 +60,7 @@ export function SearchCommand() {
           const response = await fetch("/api/contacts/search", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ workspaceId, query }),
+            body: JSON.stringify({ query }),
           })
           if (!response.ok) {
             throw new Error(`Search failed (${response.status})`)

--- a/components/crm/deal-detail-modal.tsx
+++ b/components/crm/deal-detail-modal.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { ActivityFeed } from "@/components/crm/activity-feed"
 import { DealNotes } from "@/components/crm/deal-notes"
@@ -112,8 +112,11 @@ export function DealDetailModal({ dealId, open, onOpenChange, currentUserRole = 
         onOpenChange(nextOpen)
       }}
     >
-      <DialogContent className="ott-dialog max-w-[1440px] h-[90vh] overflow-hidden flex flex-col p-0 gap-0" aria-describedby={undefined}>
+      <DialogContent className="ott-dialog max-w-[1440px] h-[90vh] overflow-hidden flex flex-col p-0 gap-0">
         <DialogTitle className="sr-only">Deal details</DialogTitle>
+        <DialogDescription className="sr-only">
+          View and edit the job details, activity timeline, notes, and follow-up actions for this deal.
+        </DialogDescription>
         {loading && (
           <div className="flex items-center justify-center flex-1 min-h-[200px]">
             <p className="text-muted-foreground">Loading...</p>

--- a/components/crm/deal-detail-modal.tsx
+++ b/components/crm/deal-detail-modal.tsx
@@ -398,7 +398,7 @@ function DealDetailContent({
               type="button"
               size="icon"
               variant="ghost"
-              className="h-8 w-8 text-white hover:bg-card/20"
+              className="h-10 w-10 text-white hover:bg-card/20"
               aria-label="Dismiss overdue warning"
               onClick={() => setOverdueDismissed(true)}
             >

--- a/components/crm/deal-edit-modal.tsx
+++ b/components/crm/deal-edit-modal.tsx
@@ -96,7 +96,7 @@ export function DealEditModal({ dealId, open, onOpenChange, onDealUpdated, curre
       <DialogContent className="ott-dialog max-w-lg flex flex-col p-0 gap-0">
         <DialogTitle className="sr-only">Edit job</DialogTitle>
         <DialogDescription className="sr-only">
-          Update this job's title, value, stage, and team-member assignment.
+          Update this job&apos;s title, value, stage, and team-member assignment.
         </DialogDescription>
         <div className="overflow-y-auto p-6">
           {loading && <p className="app-body-secondary py-8 text-center">Loading…</p>}

--- a/components/crm/deal-edit-modal.tsx
+++ b/components/crm/deal-edit-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
 import { DealEditForm } from "@/app/crm/deals/[id]/edit/deal-edit-form"
 import { getDealRecurrence, type RecurrenceRule } from "@/actions/deal-actions"
 import { getTeamMembers } from "@/actions/invite-actions"
@@ -93,8 +93,11 @@ export function DealEditModal({ dealId, open, onOpenChange, onDealUpdated, curre
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="ott-dialog max-w-lg flex flex-col p-0 gap-0" aria-describedby={undefined}>
+      <DialogContent className="ott-dialog max-w-lg flex flex-col p-0 gap-0">
         <DialogTitle className="sr-only">Edit job</DialogTitle>
+        <DialogDescription className="sr-only">
+          Update this job's title, value, stage, and team-member assignment.
+        </DialogDescription>
         <div className="overflow-y-auto p-6">
           {loading && <p className="app-body-secondary py-8 text-center">Loading…</p>}
           {error && <p className="app-body-secondary py-8 text-center text-destructive">{error}</p>}

--- a/components/crm/kanban-automation-modal.tsx
+++ b/components/crm/kanban-automation-modal.tsx
@@ -252,29 +252,46 @@ export function KanbanAutomationModal({ open, onOpenChange, deal, onAction }: Ka
 
               {selectedAction === "move-stage" && (
                 <div className="space-y-2">
-                  <Label htmlFor="target-stage">Target Stage</Label>
-                  <Select value={targetStage} onValueChange={setTargetStage}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select target stage" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {stageOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
+                  <Label className="app-field-label">Target stage</Label>
+                  <div role="radiogroup" aria-label="Target stage" className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {stageOptions.map((option) => {
+                      const selected = targetStage === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          role="radio"
+                          aria-checked={selected}
+                          onClick={() => setTargetStage(option.value)}
+                          className={
+                            "rounded-md border px-3 py-2 text-left text-sm transition-colors focus-visible:outline-none " +
+                            (selected
+                              ? "border-primary bg-primary/5 font-medium"
+                              : "border-border bg-card hover:border-primary/40 hover:bg-muted/40")
+                          }
+                        >
                           {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
             </div>
           )}
 
-          <DialogFooter>
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <DialogFooter className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end">
+            {!selectedAction && !isExecuting ? (
+              <p id="execute-hint" className="app-body-secondary mr-auto">Pick an action above to enable.</p>
+            ) : null}
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button onClick={handleExecute} disabled={!selectedAction || isExecuting}>
+            <Button
+              onClick={handleExecute}
+              disabled={!selectedAction || isExecuting}
+              aria-describedby={!selectedAction && !isExecuting ? "execute-hint" : undefined}
+            >
               {isExecuting ? (
                 <>
                   <div className="mr-2 h-4 w-4 animate-spin rounded-full border-b-2 border-white" />

--- a/components/crm/stale-deal-follow-up-modal.tsx
+++ b/components/crm/stale-deal-follow-up-modal.tsx
@@ -224,21 +224,38 @@ export function StaleDealFollowUpModal({
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="channel">Channel</Label>
-              <Select value={selectedChannel} onValueChange={setSelectedChannel}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select channel" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="sms" disabled={!hasPhone}>
-                    SMS {!hasPhone && "(no phone)"}
-                  </SelectItem>
-                  <SelectItem value="email" disabled={!hasEmail}>
-                    Email {!hasEmail && "(no email)"}
-                  </SelectItem>
-                  <SelectItem value="phone">Phone Call (schedule reminder)</SelectItem>
-                </SelectContent>
-              </Select>
+              <Label className="app-field-label">Channel</Label>
+              <div role="radiogroup" aria-label="Follow-up channel" className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                {[
+                  { value: "sms", label: "SMS", disabled: !hasPhone, hint: hasPhone ? "Text the customer now" : "No phone on file" },
+                  { value: "email", label: "Email", disabled: !hasEmail, hint: hasEmail ? "Email the customer now" : "No email on file" },
+                  { value: "phone", label: "Phone call", disabled: false, hint: "Schedule a call reminder" },
+                ].map((opt) => {
+                  const selected = selectedChannel === opt.value;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      aria-disabled={opt.disabled || undefined}
+                      disabled={opt.disabled}
+                      onClick={() => !opt.disabled && setSelectedChannel(opt.value)}
+                      className={
+                        "flex flex-col items-start gap-0.5 rounded-md border p-3 text-left transition-colors focus-visible:outline-none " +
+                        (opt.disabled
+                          ? "cursor-not-allowed border-border bg-muted/30 text-muted-foreground"
+                          : selected
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-card hover:border-primary/40 hover:bg-muted/40")
+                      }
+                    >
+                      <span className="app-panel-title">{opt.label}</span>
+                      <span className="app-body-secondary">{opt.hint}</span>
+                    </button>
+                  );
+                })}
+              </div>
               {!hasPhone && !hasEmail ? (
                 <div className="flex flex-wrap items-center gap-2">
                   <p className="text-xs text-amber-600">

--- a/components/crm/stale-deal-follow-up-modal.tsx
+++ b/components/crm/stale-deal-follow-up-modal.tsx
@@ -185,7 +185,7 @@ export function StaleDealFollowUpModal({
                 <p className="text-sm text-muted-foreground">{deal.contactName}</p>
                 <div className="mt-2 flex items-center gap-4 text-sm text-muted-foreground">
                   <span>Value: {formatCurrency(deal.value)}</span>
-                  <span>-</span>
+                  <span aria-hidden="true">·</span>
                   <span>Stage: {getUserFacingDealStageLabel(deal.stage)}</span>
                 </div>
               </div>

--- a/components/crm/stale-job-outcome-picker.tsx
+++ b/components/crm/stale-job-outcome-picker.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React from "react";
+import { CheckCircle, Clock, PauseCircle, UserX, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ActualOutcome, ACTUAL_OUTCOME_OPTIONS } from "@/lib/deal-utils";
+
+type OutcomeMeta = {
+  value: ActualOutcome;
+  label: string;
+  short: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  iconWrapClass: string;
+};
+
+const META: Record<ActualOutcome, Omit<OutcomeMeta, "value" | "label">> = {
+  COMPLETED: { short: "Job is done", Icon: CheckCircle, iconWrapClass: "bg-emerald-100 text-emerald-700" },
+  RESCHEDULED: { short: "Clears the date — book a new time", Icon: Clock, iconWrapClass: "bg-blue-100 text-blue-700" },
+  PARKED: { short: "Follow up when customer is ready", Icon: PauseCircle, iconWrapClass: "bg-violet-100 text-violet-700" },
+  NO_SHOW: { short: "Customer didn't show", Icon: UserX, iconWrapClass: "bg-orange-100 text-orange-700" },
+  CANCELLED: { short: "Close the job out of pipeline", Icon: X, iconWrapClass: "bg-rose-100 text-rose-700" },
+};
+
+const ORDERED: OutcomeMeta[] = ACTUAL_OUTCOME_OPTIONS.map((opt) => ({
+  value: opt.value as ActualOutcome,
+  label: opt.label,
+  ...META[opt.value as ActualOutcome],
+}));
+
+interface Props {
+  value: ActualOutcome | "";
+  onChange: (v: ActualOutcome) => void;
+  layout: "grid" | "list";
+}
+
+export function StaleJobOutcomePicker({ value, onChange, layout }: Props) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Job outcome"
+      className={cn(
+        layout === "grid" ? "grid grid-cols-1 gap-2 sm:grid-cols-2" : "flex flex-col gap-2",
+      )}
+    >
+      {ORDERED.map((option) => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "group flex items-center gap-3 rounded-md border p-3 text-left transition-colors",
+              "focus-visible:outline-none",
+              selected
+                ? "border-primary bg-primary/5"
+                : "border-border bg-card hover:border-primary/40 hover:bg-muted/40",
+            )}
+          >
+            <span
+              className={cn(
+                "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
+                option.iconWrapClass,
+              )}
+              aria-hidden="true"
+            >
+              <option.Icon className="h-4 w-4" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="app-panel-title block truncate">{option.label}</span>
+              <span className="app-body-secondary block truncate">{option.short}</span>
+            </span>
+            <span
+              className={cn(
+                "ml-2 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border transition-colors",
+                selected ? "border-primary bg-primary text-primary-foreground" : "border-border bg-card",
+              )}
+              aria-hidden="true"
+            >
+              {selected ? <CheckCircle className="h-3 w-3" /> : null}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function staleJobOutcomeLabel(outcome: ActualOutcome | ""): string {
+  if (!outcome) return "Update job";
+  const meta = ORDERED.find((o) => o.value === outcome);
+  if (!meta) return "Update job";
+  switch (outcome) {
+    case "COMPLETED": return "Mark completed";
+    case "RESCHEDULED": return "Mark rescheduled";
+    case "PARKED": return "Park job";
+    case "NO_SHOW": return "Mark no-show";
+    case "CANCELLED": return "Mark cancelled";
+    default: return `Mark ${meta.label.toLowerCase()}`;
+  }
+}

--- a/components/crm/stale-job-reconciliation-modal.tsx
+++ b/components/crm/stale-job-reconciliation-modal.tsx
@@ -1,202 +1,153 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { X, AlertTriangle, CheckCircle, Clock, UserX, PauseCircle } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import React, { useState } from "react";
+import { AlertTriangle, MapPin } from "lucide-react";
+import { format } from "date-fns";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
-import { DealView } from "@/actions/deal-actions"
-import { ACTUAL_OUTCOME_OPTIONS, ActualOutcome } from "@/lib/deal-utils"
-import { reconcileStaleJob } from "@/actions/stale-job-actions"
-import { format } from "date-fns"
-import { toast } from "sonner"
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 
-interface StaleJobReconciliationModalProps {
-  deal: DealView
-  onClose: () => void
-  onSuccess: () => void
+import { DealView } from "@/actions/deal-actions";
+import { ActualOutcome } from "@/lib/deal-utils";
+import { reconcileStaleJob } from "@/actions/stale-job-actions";
+import { useIsDesktop } from "@/hooks/use-is-desktop";
+import {
+  StaleJobOutcomePicker,
+  staleJobOutcomeLabel,
+} from "./stale-job-outcome-picker";
+
+interface Props {
+  deal: DealView;
+  onClose: () => void;
+  onSuccess: () => void;
 }
 
-export function StaleJobReconciliationModal({
-  deal,
-  onClose,
-  onSuccess,
-}: StaleJobReconciliationModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [actualOutcome, setActualOutcome] = useState<ActualOutcome | "">("")
-  const [outcomeNotes, setOutcomeNotes] = useState("")
+export function StaleJobReconciliationModal({ deal, onClose, onSuccess }: Props) {
+  const isDesktop = useIsDesktop();
+  const [actualOutcome, setActualOutcome] = useState<ActualOutcome | "">("");
+  const [outcomeNotes, setOutcomeNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const getOutcomeNextStep = (outcome: ActualOutcome | "") => {
-    switch (outcome) {
-      case "COMPLETED":
-        return "Marks the job as completed and moves it to Completed."
-      case "RESCHEDULED":
-        return "Clears the old scheduled date and moves the job back so you can book a new time."
-      case "PARKED":
-        return "Removes the scheduled date and parks the job for follow-up when the customer is ready."
-      case "NO_SHOW":
-        return "Records that the customer did not show and closes the job out of the active pipeline."
-      case "CANCELLED":
-        return "Records the cancellation and closes the job out of the active pipeline."
-      default:
-        return ""
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    
-    if (!actualOutcome) {
-      return
-    }
-
-    setIsSubmitting(true)
-    
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!actualOutcome || isSubmitting) return;
+    setIsSubmitting(true);
     try {
       const result = await reconcileStaleJob({
         dealId: deal.id,
         actualOutcome,
         outcomeNotes: outcomeNotes.trim() || null,
-      })
-
+      });
       if (!result.success) {
-        toast.error(result.error || "Failed to update job")
-        return
+        toast.error(result.error || "Failed to update job");
+        return;
       }
-
-      toast.success("Job updated")
-      onSuccess()
+      toast.success("Job updated");
+      onSuccess();
     } catch (error) {
-      console.error("Failed to reconcile stale job:", error)
-      toast.error("Failed to update job")
+      console.error("Failed to reconcile stale job:", error);
+      toast.error("Failed to update job");
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
-  }
+  };
 
-  const getOutcomeIcon = (outcome: ActualOutcome) => {
-    switch (outcome) {
-      case "COMPLETED":
-        return <CheckCircle className="w-4 h-4 text-green-600" />
-      case "RESCHEDULED":
-        return <Clock className="w-4 h-4 text-blue-600" />
-      case "PARKED":
-        return <PauseCircle className="w-4 h-4 text-violet-600" />
-      case "NO_SHOW":
-        return <UserX className="w-4 h-4 text-orange-600" />
-      case "CANCELLED":
-        return <X className="w-4 h-4 text-destructive" />
-      default:
-        return null
-    }
+  const scheduledLabel = deal.scheduledAt
+    ? format(new Date(deal.scheduledAt), "MMM d, yyyy 'at' h:mm a")
+    : "an unknown time";
+
+  const titleText = "What happened with this job?";
+  const descText = `Scheduled ${scheduledLabel} — no outcome recorded yet.`;
+
+  const body = (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex items-center gap-2 rounded-md bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+        <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 truncate">
+          <span className="font-medium text-foreground">{deal.title}</span>
+          {deal.contactName ? <> · {deal.contactName}</> : null}
+          {deal.address ? <> · {deal.address}</> : null}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label className="app-field-label">Outcome</Label>
+        <StaleJobOutcomePicker
+          value={actualOutcome}
+          onChange={setActualOutcome}
+          layout={isDesktop ? "grid" : "list"}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="outcomeNotes" className="app-field-label">
+          Notes <span className="font-normal text-muted-foreground">· optional</span>
+        </Label>
+        <Textarea
+          id="outcomeNotes"
+          placeholder="Anything that'd help future-you remember why?"
+          value={outcomeNotes}
+          onChange={(e) => setOutcomeNotes(e.target.value)}
+          rows={3}
+        />
+      </div>
+
+      <div className="mt-2 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!actualOutcome || isSubmitting}>
+          {isSubmitting ? "Saving…" : staleJobOutcomeLabel(actualOutcome)}
+        </Button>
+      </div>
+    </form>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open onOpenChange={onClose}>
+        <DialogContent className="ott-dialog max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 app-section-title">
+              <AlertTriangle className="h-5 w-5 text-amber-500" aria-hidden="true" />
+              {titleText}
+            </DialogTitle>
+            <DialogDescription>{descText}</DialogDescription>
+          </DialogHeader>
+          <div className="mt-2">{body}</div>
+        </DialogContent>
+      </Dialog>
+    );
   }
 
   return (
-    <Dialog open onOpenChange={onClose}>
-      <DialogContent className="ott-dialog max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="w-5 h-5 text-amber-500" />
-            Reconcile Overdue Job
-          </DialogTitle>
-          <DialogDescription>
-            This job was scheduled for{" "}
-            {deal.scheduledAt && format(new Date(deal.scheduledAt), "MMM d, yyyy 'at' h:mm a")}
-            {" "}but no outcome was recorded. Please update what happened.
-          </DialogDescription>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Deal Info */}
-          <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-            <div className="font-medium text-sm text-amber-900 mb-1">
-              {deal.title}
-            </div>
-            <div className="text-xs text-amber-700">
-              Customer: {deal.contactName}
-              {deal.address && ` - ${deal.address}`}
-            </div>
-          </div>
-
-          {/* Actual Outcome */}
-          <div className="space-y-2">
-            <Label htmlFor="actualOutcome" className="text-sm font-medium">
-              What happened with this job? <span className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={actualOutcome}
-              onValueChange={(value) => setActualOutcome(value as ActualOutcome)}
-              required
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select an outcome" />
-              </SelectTrigger>
-              <SelectContent>
-                {ACTUAL_OUTCOME_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    <div className="flex items-center gap-2">
-                      {getOutcomeIcon(option.value)}
-                      {option.label}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {actualOutcome && (
-              <p className="text-xs text-muted-foreground">{getOutcomeNextStep(actualOutcome)}</p>
-            )}
-          </div>
-
-          {/* Outcome Notes */}
-          <div className="space-y-2">
-            <Label htmlFor="outcomeNotes" className="text-sm font-medium">
-              Notes (optional)
-            </Label>
-            <Textarea
-              id="outcomeNotes"
-              placeholder="Add any additional details about what happened..."
-              value={outcomeNotes}
-              onChange={(e) => setOutcomeNotes(e.target.value)}
-              rows={3}
-            />
-          </div>
-
-          {/* Actions */}
-          <div className="flex gap-3 pt-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={onClose}
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!actualOutcome || isSubmitting}
-              className="flex-1"
-            >
-              {isSubmitting ? "Saving..." : "Update Job"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
+    <Drawer open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DrawerContent className="max-h-[88vh] px-0 pb-6">
+        <DrawerHeader className="px-5 pt-2 text-left">
+          <DrawerTitle className="flex items-center gap-2 app-section-title">
+            <AlertTriangle className="h-5 w-5 text-amber-500" aria-hidden="true" />
+            {titleText}
+          </DrawerTitle>
+          <DrawerDescription>{descText}</DrawerDescription>
+        </DrawerHeader>
+        <div className="overflow-y-auto px-5">{body}</div>
+      </DrawerContent>
+    </Drawer>
+  );
 }

--- a/components/layout/Shell.tsx
+++ b/components/layout/Shell.tsx
@@ -260,7 +260,6 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
       await fetch("/api/workspace/complete-tutorial", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ workspaceId }),
       })
     }
   };

--- a/components/layout/global-search.tsx
+++ b/components/layout/global-search.tsx
@@ -69,7 +69,7 @@ export function GlobalSearch({
 
             setLoading(true)
             try {
-                const searchResults = await globalSearchClient(workspaceId, query)
+                const searchResults = await globalSearchClient(query)
                 setResults(searchResults)
             } catch (error) {
                 console.error("Global search error:", error)

--- a/components/layout/search-dialog.tsx
+++ b/components/layout/search-dialog.tsx
@@ -74,7 +74,7 @@ export function SearchDialog({ children }: { children?: React.ReactNode }) {
         const search = async () => {
             setIsLoading(true)
             try {
-                const items = await globalSearchClient(workspaceId!, debouncedQuery)
+                const items = await globalSearchClient(debouncedQuery)
                 setResults(items)
             } catch (error) {
                 console.error("Search failed:", error)

--- a/components/modals/new-deal-modal.tsx
+++ b/components/modals/new-deal-modal.tsx
@@ -228,18 +228,25 @@ export function NewDealModal({ isOpen, onClose, workspaceId, teamMembers = [], i
                             <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-muted-foreground">Job details</p>
                             <p className="text-sm text-muted-foreground">Describe the work, its value, timing, and pipeline stage.</p>
                         </div>
-                        <div className="grid grid-cols-4 items-center gap-4">
-                            <Label htmlFor="title" className="text-left text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                        <div className="grid grid-cols-4 items-start gap-4">
+                            <Label htmlFor="title" className="pt-3 text-left text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
                                 Job description <span className="text-destructive">*</span>
                             </Label>
-                            <Input
-                                id="title"
-                                placeholder="e.g. Kitchen Renovation"
-                                value={title}
-                                onChange={(e) => setTitle(e.target.value)}
-                                className={`col-span-3 h-11 rounded-xl border-border bg-card/90 ${attemptedSubmit && !title.trim() ? "ott-field-error" : ""}`}
-                                required
-                            />
+                            <div className="col-span-3 space-y-1">
+                                <Input
+                                    id="title"
+                                    placeholder="e.g. Kitchen Renovation"
+                                    value={title}
+                                    onChange={(e) => setTitle(e.target.value)}
+                                    aria-invalid={attemptedSubmit && !title.trim() ? true : undefined}
+                                    aria-describedby={attemptedSubmit && !title.trim() ? "title-error" : undefined}
+                                    className={`h-11 rounded-xl border-border bg-card/90 ${attemptedSubmit && !title.trim() ? "ott-field-error" : ""}`}
+                                    required
+                                />
+                                {attemptedSubmit && !title.trim() ? (
+                                    <p id="title-error" className="ott-field-error-msg">Add a short description of the job.</p>
+                                ) : null}
+                            </div>
                         </div>
                         <div className="grid grid-cols-4 items-center gap-4">
                             <Label htmlFor="value" className="text-left text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground">

--- a/components/modals/new-deal-modal.tsx
+++ b/components/modals/new-deal-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useRouter } from "next/navigation"
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -215,6 +215,9 @@ export function NewDealModal({ isOpen, onClose, workspaceId, teamMembers = [], i
             <DialogContent className="ott-dialog flex max-h-[calc(100dvh-1rem)] w-[min(calc(100vw-1.5rem),54rem)] flex-col overflow-hidden p-0">
                 <DialogHeader className="shrink-0 border-b border-emerald-100/80 bg-[linear-gradient(180deg,rgba(16,185,129,0.08),rgba(255,255,255,0.5))] px-6 pb-5 pt-6 dark:border-white/10 dark:bg-[linear-gradient(180deg,rgba(16,185,129,0.12),rgba(255,255,255,0.03))]">
                     <DialogTitle className="mt-1">Create new job</DialogTitle>
+                    <DialogDescription>
+                        Enter the job details, pick or create the customer contact, and assign a team member if you know who's doing the work.
+                    </DialogDescription>
                 </DialogHeader>
 
                 <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col bg-[linear-gradient(180deg,rgba(248,250,249,0.96),rgba(241,245,243,0.98))] dark:bg-[linear-gradient(180deg,rgba(12,22,18,0.35),rgba(10,18,15,0.75))]">

--- a/components/modals/new-deal-modal.tsx
+++ b/components/modals/new-deal-modal.tsx
@@ -216,7 +216,7 @@ export function NewDealModal({ isOpen, onClose, workspaceId, teamMembers = [], i
                 <DialogHeader className="shrink-0 border-b border-emerald-100/80 bg-[linear-gradient(180deg,rgba(16,185,129,0.08),rgba(255,255,255,0.5))] px-6 pb-5 pt-6 dark:border-white/10 dark:bg-[linear-gradient(180deg,rgba(16,185,129,0.12),rgba(255,255,255,0.03))]">
                     <DialogTitle className="mt-1">Create new job</DialogTitle>
                     <DialogDescription>
-                        Enter the job details, pick or create the customer contact, and assign a team member if you know who's doing the work.
+                        Enter the job details, pick or create the customer contact, and assign a team member if you know who&apos;s doing the work.
                     </DialogDescription>
                 </DialogHeader>
 

--- a/components/settings/personal-phone-dialog.tsx
+++ b/components/settings/personal-phone-dialog.tsx
@@ -56,7 +56,7 @@ export function PersonalPhoneDialog({
 
   const validatePhone = () => {
     if (!newPhoneNumber.trim()) {
-      setError("Enter the personal mobile number you want Tracey setup texts sent to.")
+      setError("Enter your personal mobile number — we'll text confirmation codes to it when you set up call forwarding.")
       return false
     }
 
@@ -151,7 +151,7 @@ export function PersonalPhoneDialog({
               {currentPhone ? "Update personal mobile" : "Add personal mobile"}
             </DialogTitle>
             <DialogDescription className="text-[14px] leading-6">
-              This is where Earlymark sends verification codes and Tracey call-forwarding setup texts.
+              We text confirmation codes here when you set up call forwarding from your business line.
             </DialogDescription>
           </DialogHeader>
         </div>

--- a/components/tradie/job-completion-modal.tsx
+++ b/components/tradie/job-completion-modal.tsx
@@ -209,10 +209,10 @@ export function JobCompletionModal({ open, onOpenChange, dealId, job, onSuccess 
 
                             <div className="space-y-4 py-2 flex-1 overflow-y-auto px-2">
                                 {/* ── Invoice Verifier Section ── */}
-                                <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 space-y-4">
-                                    <h3 className="text-sm font-bold text-blue-900 flex items-center gap-2">
-                                        <FileText className="h-4 w-4 text-blue-600" />
-                                        Invoice Verifier
+                                <div className="rounded-md border border-border bg-muted/30 p-4 space-y-4">
+                                    <h3 className="app-panel-title flex items-center gap-2">
+                                        <FileText className="h-4 w-4 text-primary" />
+                                        Invoice verifier
                                     </h3>
 
                                     {/* Labor Hours */}

--- a/design-mockups/reconcile-dialog/variant-a-tighter-anatomy.html
+++ b/design-mockups/reconcile-dialog/variant-a-tighter-anatomy.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Reconcile dialog — Variant A: tighter anatomy</title>
+<style>
+  :root {
+    --background:#F7F8FA; --foreground:#0D1117; --card:#FFFFFF;
+    --primary:#00D28B; --muted:#F3F4F6; --muted-fg:#6B7280;
+    --border:#E5E7EB; --destructive:#EF4444;
+    --status-amber-bg:#FEF3C7; --status-amber-fg:#92400E;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; font-family:Inter,system-ui,sans-serif; color:var(--foreground);
+    background:var(--background); min-height:100vh;
+    display:flex; align-items:center; justify-content:center; padding:24px;
+  }
+  .backdrop{
+    position:fixed; inset:0; background:rgba(8,28,21,0.40);
+    backdrop-filter:blur(8px); z-index:1;
+  }
+  .dialog{
+    position:relative; z-index:2; width:min(calc(100vw - 32px), 460px);
+    background:var(--card); border-radius:18px; padding:0;
+    box-shadow:0 32px 90px rgba(7,29,22,0.22); border:1px solid rgba(255,255,255,0.7);
+    overflow:hidden;
+  }
+  .header{
+    display:flex; align-items:flex-start; justify-content:space-between;
+    padding:20px 20px 0;
+  }
+  .title-row{display:flex; align-items:center; gap:10px;}
+  .title{font-size:20px; font-weight:600; letter-spacing:-0.01em; margin:0;}
+  .icon-warn{
+    width:36px; height:36px; border-radius:18px;
+    background:#FEF3C7; color:#92400E;
+    display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+  }
+  .close{
+    width:36px; height:36px; border-radius:18px; border:1px solid var(--border);
+    background:var(--card); color:var(--muted-fg);
+    display:inline-flex; align-items:center; justify-content:center;
+    cursor:pointer; flex-shrink:0;
+  }
+  .close:hover{background:var(--muted); color:var(--foreground);}
+  .desc{font-size:13px; color:var(--muted-fg); margin:8px 20px 0; line-height:1.5;}
+  .body{padding:20px;}
+  .chip{
+    display:inline-flex; align-items:center; gap:8px; font-size:12px;
+    background:var(--muted); color:var(--muted-fg); padding:6px 10px;
+    border-radius:18px; margin-bottom:16px;
+  }
+  .chip strong{color:var(--foreground); font-weight:500;}
+  .label{
+    display:block; font-size:13px; font-weight:600; color:var(--foreground);
+    margin-bottom:10px;
+  }
+  .req{color:var(--destructive); margin-left:2px;}
+  .outcomes{display:flex; flex-direction:column; gap:8px;}
+  .outcome{
+    display:flex; align-items:center; gap:12px; padding:12px 14px;
+    border:1px solid var(--border); border-radius:18px; background:var(--card);
+    cursor:pointer; transition:all 0.15s;
+  }
+  .outcome:hover{border-color:#A7F3D0; background:#F0FDF4;}
+  .outcome input{margin:0;}
+  .outcome-icon{
+    width:32px; height:32px; border-radius:18px;
+    display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+  }
+  .o-completed{background:#D1FAE5; color:#047857;}
+  .o-rescheduled{background:#DBEAFE; color:#1D4ED8;}
+  .o-parked{background:#EDE9FE; color:#6D28D9;}
+  .o-noshow{background:#FFEDD5; color:#C2410C;}
+  .o-cancelled{background:#FEE2E2; color:#B91C1C;}
+  .outcome-text{flex:1;}
+  .outcome-text strong{display:block; font-size:14px; font-weight:500; color:var(--foreground);}
+  .outcome-text span{font-size:12px; color:var(--muted-fg);}
+  .notes-toggle{
+    margin-top:14px; background:none; border:none; color:var(--muted-fg);
+    font-size:13px; cursor:pointer; padding:0; display:inline-flex; align-items:center; gap:6px;
+  }
+  .notes-toggle:hover{color:var(--foreground);}
+  .footer{
+    display:flex; justify-content:flex-end; gap:8px;
+    padding:16px 20px; border-top:1px solid var(--border); background:#FAFBFB;
+  }
+  .btn{
+    height:40px; padding:0 18px; border-radius:18px; font-size:14px; font-weight:500;
+    cursor:pointer; border:none;
+  }
+  .btn-ghost{background:transparent; color:var(--muted-fg);}
+  .btn-ghost:hover{color:var(--foreground); background:var(--muted);}
+  .btn-primary{background:var(--primary); color:white;}
+  .btn-primary:disabled{opacity:0.5; cursor:not-allowed;}
+</style>
+</head>
+<body>
+<div class="backdrop"></div>
+<div class="dialog" role="dialog" aria-labelledby="t">
+  <div class="header">
+    <div class="title-row">
+      <span class="icon-warn"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+      <h2 class="title" id="t">Reconcile overdue job</h2>
+    </div>
+    <button class="close" aria-label="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+  <p class="desc">Scheduled <strong style="color:var(--foreground)">Apr 8 at 2:00 PM</strong> — no outcome recorded yet.</p>
+  <div class="body">
+    <span class="chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg><strong>ZZZ DIGEST FLOW</strong> · 12 Test Street, Sydney NSW</span>
+    <label class="label">What happened with this job?<span class="req">*</span></label>
+    <div class="outcomes">
+      <label class="outcome"><input type="radio" name="o"/><span class="outcome-icon o-completed"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span><span class="outcome-text"><strong>Completed</strong><span>Mark job done and move to Completed</span></span></label>
+      <label class="outcome"><input type="radio" name="o"/><span class="outcome-icon o-rescheduled"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span><span class="outcome-text"><strong>Rescheduled</strong><span>Clear the date so you can book a new time</span></span></label>
+      <label class="outcome"><input type="radio" name="o"/><span class="outcome-icon o-parked"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></svg></span><span class="outcome-text"><strong>Parked</strong><span>Follow up later when the customer is ready</span></span></label>
+      <label class="outcome"><input type="radio" name="o"/><span class="outcome-icon o-noshow"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="17" y1="8" x2="23" y2="14"/><line x1="23" y1="8" x2="17" y2="14"/></svg></span><span class="outcome-text"><strong>No-show</strong><span>Customer didn't show — close out of pipeline</span></span></label>
+      <label class="outcome"><input type="radio" name="o"/><span class="outcome-icon o-cancelled"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></span><span class="outcome-text"><strong>Cancelled</strong><span>Record cancellation and close out of pipeline</span></span></label>
+    </div>
+    <button class="notes-toggle" type="button">+ Add a note (optional)</button>
+  </div>
+  <div class="footer">
+    <button class="btn btn-ghost">Cancel</button>
+    <button class="btn btn-primary" disabled>Update job</button>
+  </div>
+</div>
+</body>
+</html>

--- a/design-mockups/reconcile-dialog/variant-b-decision-first.html
+++ b/design-mockups/reconcile-dialog/variant-b-decision-first.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Reconcile dialog — Variant B: decision-first</title>
+<style>
+  :root{
+    --background:#F7F8FA; --foreground:#0D1117; --card:#FFFFFF;
+    --primary:#00D28B; --muted:#F3F4F6; --muted-fg:#6B7280;
+    --border:#E5E7EB; --destructive:#EF4444;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; font-family:Inter,system-ui,sans-serif; color:var(--foreground);
+    background:var(--background); min-height:100vh;
+    display:flex; align-items:center; justify-content:center; padding:24px;
+  }
+  .backdrop{position:fixed; inset:0; background:rgba(8,28,21,0.40); backdrop-filter:blur(8px); z-index:1;}
+  .dialog{
+    position:relative; z-index:2; width:min(calc(100vw - 32px), 520px);
+    background:var(--card); border-radius:18px;
+    box-shadow:0 32px 90px rgba(7,29,22,0.22); overflow:hidden;
+  }
+  .header{
+    display:flex; align-items:center; justify-content:space-between;
+    padding:18px 20px; border-bottom:1px solid var(--border);
+  }
+  .crumb{font-size:12px; color:var(--muted-fg); display:flex; align-items:center; gap:6px;}
+  .crumb strong{color:var(--foreground); font-weight:500;}
+  .close{
+    width:32px; height:32px; border-radius:18px; border:1px solid var(--border);
+    background:var(--card); color:var(--muted-fg);
+    display:inline-flex; align-items:center; justify-content:center; cursor:pointer;
+  }
+  .close:hover{background:var(--muted); color:var(--foreground);}
+  .question{
+    padding:24px 20px 8px;
+  }
+  .question h2{
+    margin:0 0 6px; font-size:22px; font-weight:600; letter-spacing:-0.015em;
+  }
+  .question p{
+    margin:0; font-size:13px; color:var(--muted-fg); line-height:1.55;
+  }
+  .body{padding:16px 20px 0;}
+  .grid{
+    display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:10px;
+  }
+  .card{
+    border:1px solid var(--border); border-radius:18px; padding:14px; cursor:pointer;
+    transition:all 0.15s; background:var(--card); display:flex; flex-direction:column; gap:8px;
+  }
+  .card:hover{border-color:#A7F3D0; box-shadow:0 2px 8px rgba(0,210,139,0.10);}
+  .card.selected{border-color:var(--primary); background:#F0FDF4; box-shadow:0 0 0 3px rgba(0,210,139,0.12);}
+  .card-icon{
+    width:36px; height:36px; border-radius:18px;
+    display:inline-flex; align-items:center; justify-content:center;
+  }
+  .o-completed{background:#D1FAE5; color:#047857;}
+  .o-rescheduled{background:#DBEAFE; color:#1D4ED8;}
+  .o-parked{background:#EDE9FE; color:#6D28D9;}
+  .o-noshow{background:#FFEDD5; color:#C2410C;}
+  .o-cancelled{background:#FEE2E2; color:#B91C1C;}
+  .card strong{display:block; font-size:14px; font-weight:600;}
+  .card span{font-size:12px; color:var(--muted-fg); line-height:1.4;}
+  .full{grid-column:span 2;}
+  .notes{
+    margin-top:16px; padding-top:16px; border-top:1px solid var(--border);
+  }
+  .notes label{
+    display:flex; align-items:center; justify-content:space-between;
+    font-size:13px; font-weight:500; color:var(--foreground); margin-bottom:8px;
+  }
+  .notes label small{font-size:12px; color:var(--muted-fg); font-weight:400;}
+  textarea{
+    width:100%; resize:none; border:1px solid var(--border); border-radius:18px;
+    padding:10px 14px; font-family:inherit; font-size:13px; color:var(--foreground);
+    background:var(--card); min-height:64px; outline:none;
+  }
+  textarea:focus{border-color:var(--primary); box-shadow:0 0 0 3px rgba(0,210,139,0.12);}
+  .footer{
+    display:flex; justify-content:flex-end; align-items:center; gap:12px;
+    padding:16px 20px; margin-top:16px; border-top:1px solid var(--border);
+  }
+  .btn{
+    height:42px; padding:0 22px; border-radius:18px; font-size:14px; font-weight:600;
+    cursor:pointer; border:none;
+  }
+  .btn-ghost{background:transparent; color:var(--muted-fg);}
+  .btn-ghost:hover{color:var(--foreground); background:var(--muted);}
+  .btn-primary{background:var(--primary); color:white;}
+  .btn-primary:disabled{opacity:0.5; cursor:not-allowed;}
+</style>
+</head>
+<body>
+<div class="backdrop"></div>
+<div class="dialog" role="dialog" aria-labelledby="t">
+  <div class="header">
+    <div class="crumb">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#92400E" stroke-width="2"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      <span>Overdue job · <strong>ZZZ DIGEST FLOW</strong> · scheduled Apr 8, 2:00 PM</span>
+    </div>
+    <button class="close" aria-label="Close"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+  <div class="question">
+    <h2 id="t">What happened with this job?</h2>
+    <p>Pick the outcome that matches what actually happened. You can add a note below if you want.</p>
+  </div>
+  <div class="body">
+    <div class="grid">
+      <div class="card selected"><span class="card-icon o-completed"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span><strong>Completed</strong><span>Job is done. Moves to Completed.</span></div>
+      <div class="card"><span class="card-icon o-rescheduled"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span><strong>Rescheduled</strong><span>Clears date so you can book a new time.</span></div>
+      <div class="card"><span class="card-icon o-parked"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></svg></span><strong>Parked</strong><span>Follow up when the customer is ready.</span></div>
+      <div class="card"><span class="card-icon o-noshow"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></span><strong>No-show</strong><span>Customer didn't show. Closes out.</span></div>
+      <div class="card full"><span class="card-icon o-cancelled"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></span><strong>Cancelled</strong><span>Record cancellation and close the job out of the active pipeline.</span></div>
+    </div>
+    <div class="notes">
+      <label>Notes <small>optional</small></label>
+      <textarea placeholder="Anything that'd help future-you remember why?"></textarea>
+    </div>
+  </div>
+  <div class="footer">
+    <button class="btn btn-ghost">Cancel</button>
+    <button class="btn btn-primary">Mark completed</button>
+  </div>
+</div>
+</body>
+</html>

--- a/design-mockups/reconcile-dialog/variant-c-mobile-first.html
+++ b/design-mockups/reconcile-dialog/variant-c-mobile-first.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Reconcile dialog — Variant C: mobile bottom-sheet</title>
+<style>
+  :root{
+    --background:#F7F8FA; --foreground:#0D1117; --card:#FFFFFF;
+    --primary:#00D28B; --muted:#F3F4F6; --muted-fg:#6B7280;
+    --border:#E5E7EB; --destructive:#EF4444;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; font-family:Inter,system-ui,sans-serif; color:var(--foreground);
+    background:#0D1117; min-height:100vh;
+    display:flex; align-items:flex-end; justify-content:center;
+  }
+  .phone{
+    width:390px; max-width:100%; height:760px; background:var(--background);
+    border:6px solid #1F2937; border-radius:36px; overflow:hidden; position:relative;
+    box-shadow:0 32px 80px rgba(0,0,0,0.5);
+  }
+  .topbar{
+    position:absolute; top:0; left:0; right:0; height:56px;
+    background:var(--card); border-bottom:1px solid var(--border);
+    display:flex; align-items:center; padding:0 16px; z-index:1;
+  }
+  .topbar strong{font-size:16px; font-weight:600;}
+  .topbar .avatar{
+    margin-left:auto; width:32px; height:32px; border-radius:18px;
+    background:var(--primary); color:white; display:inline-flex; align-items:center;
+    justify-content:center; font-size:13px; font-weight:600;
+  }
+  .backdrop{
+    position:absolute; inset:0; background:rgba(8,28,21,0.55);
+    backdrop-filter:blur(4px); z-index:2;
+  }
+  .sheet{
+    position:absolute; left:0; right:0; bottom:0; z-index:3;
+    background:var(--card); border-radius:24px 24px 0 0; padding:0;
+    box-shadow:0 -24px 60px rgba(0,0,0,0.35); max-height:88%; overflow:hidden;
+    display:flex; flex-direction:column;
+  }
+  .grabber{width:36px; height:4px; background:var(--border); border-radius:18px; margin:10px auto 0;}
+  .sheet-header{padding:14px 20px 0;}
+  .sheet-header h2{margin:0; font-size:19px; font-weight:600; letter-spacing:-0.01em;}
+  .sheet-header p{margin:6px 0 0; font-size:13px; color:var(--muted-fg); line-height:1.5;}
+  .sheet-header .meta{
+    display:inline-flex; align-items:center; gap:6px; margin-top:12px;
+    font-size:12px; color:var(--muted-fg);
+    background:var(--muted); padding:6px 10px; border-radius:18px;
+  }
+  .sheet-header .meta strong{color:var(--foreground); font-weight:500;}
+  .outcomes{padding:16px 20px 8px; display:flex; flex-direction:column; gap:8px; overflow-y:auto;}
+  .row{
+    display:flex; align-items:center; gap:14px;
+    background:var(--muted); border-radius:18px; padding:14px;
+    cursor:pointer; transition:all 0.15s;
+    -webkit-tap-highlight-color:rgba(0,210,139,0.15);
+  }
+  .row:active{transform:scale(0.98); background:#E5E7EB;}
+  .row .ico{
+    width:40px; height:40px; border-radius:18px; flex-shrink:0;
+    display:inline-flex; align-items:center; justify-content:center;
+  }
+  .o-completed{background:#D1FAE5; color:#047857;}
+  .o-rescheduled{background:#DBEAFE; color:#1D4ED8;}
+  .o-parked{background:#EDE9FE; color:#6D28D9;}
+  .o-noshow{background:#FFEDD5; color:#C2410C;}
+  .o-cancelled{background:#FEE2E2; color:#B91C1C;}
+  .row .text{flex:1;}
+  .row .text strong{display:block; font-size:15px; font-weight:600;}
+  .row .text span{font-size:12px; color:var(--muted-fg);}
+  .row .chev{color:var(--muted-fg);}
+  .footer{
+    padding:12px 20px 20px; border-top:1px solid var(--border); background:var(--card);
+  }
+  .btn-cancel{
+    width:100%; height:48px; background:transparent; border:none;
+    color:var(--muted-fg); font-size:14px; font-weight:500; cursor:pointer;
+  }
+  .hint{font-size:11px; color:var(--muted-fg); text-align:center; margin-top:4px;}
+</style>
+</head>
+<body>
+<div class="phone">
+  <div class="topbar"><strong>Jobs</strong><div class="avatar">M</div></div>
+  <div class="backdrop"></div>
+  <div class="sheet" role="dialog" aria-labelledby="t">
+    <div class="grabber" aria-hidden="true"></div>
+    <div class="sheet-header">
+      <h2 id="t">What happened with this job?</h2>
+      <p>Was scheduled Apr 8 at 2:00 PM. Pick the outcome — we'll handle the rest.</p>
+      <span class="meta">📍 <strong>ZZZ DIGEST FLOW</strong> · 12 Test Street, Sydney</span>
+    </div>
+    <div class="outcomes">
+      <div class="row"><span class="ico o-completed"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg></span><span class="text"><strong>Completed</strong><span>Job is done</span></span><svg class="chev" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+      <div class="row"><span class="ico o-rescheduled"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span><span class="text"><strong>Rescheduled</strong><span>Book a new time</span></span><svg class="chev" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+      <div class="row"><span class="ico o-parked"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></svg></span><span class="text"><strong>Parked</strong><span>Follow up later</span></span><svg class="chev" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+      <div class="row"><span class="ico o-noshow"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></span><span class="text"><strong>No-show</strong><span>Customer didn't show</span></span><svg class="chev" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+      <div class="row"><span class="ico o-cancelled"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></span><span class="text"><strong>Cancelled</strong><span>Close the job out</span></span><svg class="chev" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+    </div>
+    <div class="footer">
+      <button class="btn-cancel">Cancel</button>
+      <p class="hint">Tap an outcome → confirm on the next screen with optional notes</p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/e2e/visual/stale-job-dialog.spec.ts
+++ b/e2e/visual/stale-job-dialog.spec.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { test, expect } from "@playwright/test";
+
+test.use({ storageState: path.join(process.cwd(), "e2e", ".auth", "admin.json") });
+
+async function readFixtures() {
+  return JSON.parse(
+    await fs.readFile(path.join(process.cwd(), "e2e", ".auth", "fixtures.json"), "utf8"),
+  ) as { dbAvailable: boolean };
+}
+
+// Regenerate baselines after intentional design changes:
+//   npm run test:visual:update
+// CI runs `npm run test:visual` which diffs pixels against the checked-in
+// snapshots under e2e/visual/__screenshots__/. Baselines must be rendered
+// on Linux (where CI runs) — macOS font rendering produces spurious diffs.
+test.describe("stale-job reconciliation dialog", () => {
+  test.beforeEach(async () => {
+    const fixture = await readFixtures();
+    test.skip(!fixture.dbAvailable, "Visual tests require the isolated Postgres harness.");
+  });
+
+  test("empty state — no outcome selected", async ({ page }) => {
+    await page.goto("/crm/jobs");
+    const reconcileButton = page.getByRole("button", { name: /reconcile|update overdue|update outcome/i }).first();
+    await reconcileButton.waitFor({ state: "visible", timeout: 15000 });
+    await reconcileButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("radiogroup", { name: /job outcome/i })).toBeVisible();
+
+    await expect(dialog).toHaveScreenshot("reconcile-dialog-empty.png");
+  });
+
+  test("with outcome selected — primary button reflects choice", async ({ page }) => {
+    await page.goto("/crm/jobs");
+    const reconcileButton = page.getByRole("button", { name: /reconcile|update overdue|update outcome/i }).first();
+    await reconcileButton.waitFor({ state: "visible", timeout: 15000 });
+    await reconcileButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("radio", { name: /completed/i }).click();
+
+    await expect(dialog.getByRole("button", { name: /mark completed/i })).toBeVisible();
+    await expect(dialog).toHaveScreenshot("reconcile-dialog-completed.png");
+  });
+});

--- a/eslint-rules/no-fake-tool-success.mjs
+++ b/eslint-rules/no-fake-tool-success.mjs
@@ -1,0 +1,152 @@
+/**
+ * Custom ESLint rule: no-fake-tool-success.
+ *
+ * Catches the bug class behind the original "call Michael" incident:
+ * an AI agent tool (exported async function whose name starts with `run`)
+ * returns a friendly success string ("📞 Calling…", "Sent", "Booked")
+ * without ever invoking the external client that would do the work.
+ *
+ * Heuristic — we accept some false-positives in exchange for catching
+ * the pattern at PR time. Override with eslint-disable-next-line when
+ * the success copy is intentional (e.g. queueing a job that the cron
+ * actually performs).
+ *
+ * Triggers: function body contains a ReturnStatement whose value
+ * matches SUCCESS_COPY_PATTERN.
+ * Excuses: function body contains a CallExpression matching any
+ * EXTERNAL_CLIENT_PATTERN — i.e. it really does invoke an external
+ * service (Twilio, Resend, Stripe, LiveKit, our outbound-call helper,
+ * etc.) before returning the success copy.
+ */
+
+const SUCCESS_COPY_PATTERN = /📞|📲|✉️|📧|✅|^Sent\b|^Sending\b|^Calling\b|^Email sent\b|^SMS sent\b|^Booked\b|^Scheduled\b/i;
+
+const EXTERNAL_CLIENT_HINTS = [
+  // Genuine outbound integrations
+  "twilioClient",
+  "twilio.messages",
+  "resend.emails",
+  "stripe.",
+  "initiateOutboundCall",
+  "sendSMS",
+  "sendEmail",
+  "sendWhatsApp",
+  "sendViaTwilio",
+  "sendNotification",
+  "createSipParticipant",
+  "googleClient",
+  "fetch(",
+  // Internal helpers that still perform real work
+  "createTask",
+  "createNotification",
+  "createDeal",
+  "createContact",
+  "createSupportTicket",
+  "issueInvoice",
+  "markInvoicePaid",
+  "rejectDraft",
+  "generateQuote",
+  "completeTask",
+  "deleteTask",
+  "updateJobStatus",
+  "createQuoteVariation",
+  "updateDealStage",
+  "updateDealMetadata",
+  "updateDealAssignedTo",
+  "appendTicketNote",
+  // Direct DB writes
+  "db.",
+];
+
+function functionInvokesExternalClient(node, sourceCode) {
+  const text = sourceCode.getText(node);
+  return EXTERNAL_CLIENT_HINTS.some((hint) => text.includes(hint));
+}
+
+function isExportedRunFunction(node) {
+  if (node.type !== "FunctionDeclaration" && node.type !== "FunctionExpression") return false;
+  if (!node.async) return false;
+  const name = node.id?.name || node.parent?.id?.name || "";
+  return /^run[A-Z]/.test(name);
+}
+
+function literalLooksLikeSuccess(literal) {
+  if (typeof literal.value !== "string") return false;
+  return SUCCESS_COPY_PATTERN.test(literal.value);
+}
+
+function templateLooksLikeSuccess(template) {
+  const firstQuasi = template.quasis?.[0]?.value?.cooked || "";
+  return SUCCESS_COPY_PATTERN.test(firstQuasi);
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Flag AI agent tools whose function body returns a success-shaped string without invoking any external client.",
+    },
+    schema: [],
+    messages: {
+      noFakeSuccess:
+        "{{ name }} returns success-styled copy ({{ snippet }}) but does not appear to invoke any external client (Twilio, Resend, Stripe, LiveKit, initiateOutboundCall, sendSMS/sendEmail). If this tool really does perform the action, add the missing call. If it intentionally only logs, change the copy to reflect that. Or add eslint-disable-next-line no-fake-tool-success if the success path is actually delegated elsewhere.",
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    function checkFunction(fnNode, displayName) {
+      if (functionInvokesExternalClient(fnNode, sourceCode)) return;
+
+      let badLiteral = null;
+      const visit = (node) => {
+        if (!node || badLiteral) return;
+        if (node.type === "ReturnStatement" && node.argument) {
+          if (node.argument.type === "Literal" && literalLooksLikeSuccess(node.argument)) {
+            badLiteral = node.argument;
+          } else if (node.argument.type === "TemplateLiteral" && templateLooksLikeSuccess(node.argument)) {
+            badLiteral = node.argument;
+          }
+        }
+        for (const key of Object.keys(node)) {
+          if (key === "parent" || key === "loc" || key === "range") continue;
+          const value = node[key];
+          if (Array.isArray(value)) value.forEach(visit);
+          else if (value && typeof value === "object" && typeof value.type === "string") visit(value);
+        }
+      };
+      visit(fnNode.body);
+
+      if (badLiteral) {
+        const snippet = sourceCode.getText(badLiteral).slice(0, 60).replace(/\s+/g, " ");
+        context.report({
+          node: badLiteral,
+          messageId: "noFakeSuccess",
+          data: { name: displayName, snippet },
+        });
+      }
+    }
+
+    return {
+      ExportNamedDeclaration(node) {
+        if (node.declaration?.type === "FunctionDeclaration" && isExportedRunFunction(node.declaration)) {
+          checkFunction(node.declaration, node.declaration.id.name);
+        }
+        if (node.declaration?.type === "VariableDeclaration") {
+          for (const decl of node.declaration.declarations) {
+            const init = decl.init;
+            if (
+              (init?.type === "FunctionExpression" || init?.type === "ArrowFunctionExpression") &&
+              init.async &&
+              /^run[A-Z]/.test(decl.id.name || "")
+            ) {
+              checkFunction(init, decl.id.name);
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-redundant-dialog-close.mjs
+++ b/eslint-rules/no-redundant-dialog-close.mjs
@@ -1,0 +1,124 @@
+/**
+ * Custom ESLint rule: no-redundant-dialog-close.
+ *
+ * The shadcn/Radix Dialog primitive at components/ui/dialog.tsx already
+ * renders an absolutely-positioned close X inside every DialogContent.
+ * If a caller adds its OWN close button inside the dialog body, the
+ * dialog ships with two close affordances — confusing UX, and the kind
+ * of bug you only catch in production via a screenshot.
+ *
+ * This rule scans for any JSXElement whose opening tag is "DialogContent"
+ * (or "Dialog") and walks its descendants for any element that looks
+ * like a hand-rolled close button:
+ *   - <DialogClose>…</DialogClose>           — Radix close primitive
+ *   - <button aria-label="Close">…</button>  — manual button
+ *   - <button> wrapping a <X /> lucide icon  — manual button by shape
+ *
+ * If you genuinely need an extra close affordance (rare — a header
+ * back button, say) suppress with eslint-disable-next-line on the
+ * relevant element, and label the button something other than "Close".
+ */
+
+const CLOSE_LABEL_RE = /^close$/i;
+// Only check DialogContent — Dialog is the outer wrapper that always
+// holds a DialogContent, so checking both would double-report.
+const DIALOG_HOSTS = new Set(["DialogContent"]);
+
+function getJSXName(node) {
+  if (!node) return null;
+  if (node.type === "JSXIdentifier") return node.name;
+  if (node.type === "JSXMemberExpression") return getJSXName(node.property);
+  return null;
+}
+
+function getAttrValue(attr) {
+  if (!attr || attr.type !== "JSXAttribute") return null;
+  const v = attr.value;
+  if (!v) return null;
+  if (v.type === "Literal") return v.value;
+  if (v.type === "JSXExpressionContainer" && v.expression?.type === "Literal") return v.expression.value;
+  return null;
+}
+
+function elementHasAttr(openingElement, name, predicate) {
+  const attr = openingElement.attributes?.find(
+    (a) => a.type === "JSXAttribute" && a.name?.name === name,
+  );
+  if (!attr) return false;
+  const v = getAttrValue(attr);
+  return typeof v === "string" && predicate(v);
+}
+
+function isManualClose(node) {
+  if (!node || node.type !== "JSXElement") return false;
+  const name = getJSXName(node.openingElement.name);
+
+  if (name === "DialogClose") return true;
+
+  if (name === "button" || name === "Button") {
+    if (elementHasAttr(node.openingElement, "aria-label", (v) => CLOSE_LABEL_RE.test(v))) {
+      return true;
+    }
+    // <button> ... <X ... /> ... </button>  — lucide X icon inside a button.
+    for (const child of node.children || []) {
+      if (child.type !== "JSXElement") continue;
+      const childName = getJSXName(child.openingElement.name);
+      if (childName === "X" && (node.children?.length === 1 || child.children?.length === 0)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function walk(node, visit) {
+  if (!node || badStopper(node)) return;
+  visit(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) walk(child, visit);
+  }
+}
+
+function badStopper(node) {
+  return !node || typeof node !== "object";
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow caller-side close buttons inside Dialog/DialogContent. The Dialog primitive already renders its own close X; a second one ships two close affordances stacked at the same screen position.",
+    },
+    schema: [],
+    messages: {
+      redundantClose:
+        "{{ host }} already includes a close button via the Dialog primitive at components/ui/dialog.tsx. Remove this duplicate close affordance (or label it something other than 'Close' and add eslint-disable-next-line no-redundant-dialog-close if it genuinely is an intentional second control).",
+    },
+  },
+  create(context) {
+    return {
+      JSXElement(node) {
+        const name = getJSXName(node.openingElement.name);
+        if (!DIALOG_HOSTS.has(name)) return;
+
+        let offender = null;
+        walk(node, (descendant) => {
+          if (offender) return;
+          if (descendant === node) return;
+          if (isManualClose(descendant)) {
+            offender = descendant;
+          }
+        });
+
+        if (offender) {
+          context.report({
+            node: offender,
+            messageId: "redundantClose",
+            data: { host: name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import noFakeToolSuccess from "./eslint-rules/no-fake-tool-success.mjs";
 
 // ─── Design Policy Rules ───────────────────────────────────────────────────
 // Enforces the Global Formatting & Design Policy defined in CLAUDE.md.
@@ -99,8 +100,14 @@ const eslintConfig = defineConfig([
   // Tailwind classes don't appear in server actions, so no class rules needed.
   {
     files: ["actions/**/*.ts"],
+    plugins: {
+      "earlymark-tools": {
+        rules: { "no-fake-tool-success": noFakeToolSuccess },
+      },
+    },
     rules: {
       "no-restricted-properties": localeMethodRules,
+      "earlymark-tools/no-fake-tool-success": "error",
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import noFakeToolSuccess from "./eslint-rules/no-fake-tool-success.mjs";
+import noRedundantDialogClose from "./eslint-rules/no-redundant-dialog-close.mjs";
 
 // ─── Design Policy Rules ───────────────────────────────────────────────────
 // Enforces the Global Formatting & Design Policy defined in CLAUDE.md.
@@ -82,9 +83,15 @@ const eslintConfig = defineConfig([
   // UI source files — full design policy (Tailwind classes + locale methods).
   {
     files: ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
+    plugins: {
+      "earlymark-ui": {
+        rules: { "no-redundant-dialog-close": noRedundantDialogClose },
+      },
+    },
     rules: {
       "no-restricted-syntax": ["error", ...tailwindRules],
       "no-restricted-properties": localeMethodRules,
+      "earlymark-ui/no-redundant-dialog-close": "error",
     },
   },
 

--- a/hooks/use-is-desktop.ts
+++ b/hooks/use-is-desktop.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DESKTOP_BREAKPOINT_PX = 640;
+
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
+    const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
+    setIsDesktop(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return isDesktop;
+}

--- a/hooks/use-is-desktop.ts
+++ b/hooks/use-is-desktop.ts
@@ -1,23 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 const DESKTOP_BREAKPOINT_PX = 640;
+const QUERY = `(min-width: ${DESKTOP_BREAKPOINT_PX}px)`;
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const mq = window.matchMedia(QUERY);
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  // Desktop-first on the server so the dialog markup matches the most
+  // common viewport; the real value is settled on the client mount via
+  // useSyncExternalStore without an extra render commit.
+  return true;
+}
 
 export function useIsDesktop(): boolean {
-  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    return window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`).matches;
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
-    const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
-    setIsDesktop(mq.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-
-  return isDesktop;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/lib/search-client.ts
+++ b/lib/search-client.ts
@@ -1,13 +1,13 @@
 import type { SearchResultItem } from "@/lib/search-types"
 
-export async function globalSearchClient(workspaceId: string, query: string): Promise<SearchResultItem[]> {
+export async function globalSearchClient(query: string): Promise<SearchResultItem[]> {
   const trimmedQuery = query.trim()
-  if (!workspaceId || trimmedQuery.length < 2) return []
+  if (trimmedQuery.length < 2) return []
 
   const response = await fetch("/api/search/global", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ workspaceId, query: trimmedQuery }),
+    body: JSON.stringify({ query: trimmedQuery }),
   })
 
   if (!response.ok) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
         "@types/node": "^25.3.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -96,6 +97,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "husky": "^9.1.7",
+        "jest-axe": "^10.0.0",
         "jsdom": "^28.1.0",
         "prisma": "^5.21.1",
         "tailwindcss": "^4",
@@ -2490,7 +2492,6 @@
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -2503,7 +2504,6 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -2516,7 +2516,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -8418,8 +8417,7 @@
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -9055,15 +9053,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -9073,7 +9069,6 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -9083,10 +9078,30 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.9.tgz",
+      "integrity": "sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
+    "node_modules/@types/jest-axe/node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
@@ -9094,7 +9109,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9107,7 +9121,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -9121,8 +9134,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -9253,8 +9265,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
@@ -9303,7 +9314,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -9312,8 +9322,7 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -11344,7 +11353,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11947,7 +11955,6 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -12881,7 +12888,6 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
@@ -14749,12 +14755,88 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -14770,7 +14852,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14783,7 +14864,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -14797,15 +14877,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -14815,7 +14893,6 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.7.0",
@@ -14831,7 +14908,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14844,7 +14920,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -14858,15 +14933,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -14887,7 +14960,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14900,7 +14972,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -14914,15 +14985,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -19078,7 +19147,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19272,7 +19340,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -19285,7 +19352,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "twilio:cleanup-orphans": "npx tsx scripts/cleanup-twilio-orphan-subaccounts.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:visual": "playwright test --project=visual",
+    "test:visual:update": "playwright test --project=visual --update-snapshots"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"
@@ -107,6 +109,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
     "@types/node": "^25.3.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -117,6 +120,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "husky": "^9.1.7",
+    "jest-axe": "^10.0.0",
     "jsdom": "^28.1.0",
     "prisma": "^5.21.1",
     "tailwindcss": "^4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,38 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      testIgnore: /visual\//,
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      // Visual regression: lock viewport, slow animations off, narrow
+      // pixel-diff tolerance. Snapshot baselines live next to specs and
+      // ARE checked in — regenerate with `npm run test:visual:update`.
+      name: "visual",
+      testMatch: /visual\/.*\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 800 },
+      },
+      expect: {
+        toHaveScreenshot: {
+          maxDiffPixelRatio: 0.01,
+          animations: "disabled",
+        },
+      },
+    },
+    {
+      name: "visual-mobile",
+      testMatch: /visual\/.*\.spec\.ts/,
+      use: {
+        ...devices["iPhone 13"],
+      },
+      expect: {
+        toHaveScreenshot: {
+          maxDiffPixelRatio: 0.01,
+          animations: "disabled",
+        },
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Why

Triggered by a customer report (miguel.w1407@gmail.com) that asking the AI to "call Michael at 0434955958" produced a friendly "📞 Calling…" reply but no actual phone call. Root cause: `runMakeCall` in `actions/chat-actions.ts` logged an Activity row and returned a success string without invoking `initiateOutboundCall`. From there an audit was opened against every agent tool, server action, API route, cron job and webhook handler in the repo.

## What's in this PR

### Fix for the original bug
- `runMakeCall` now actually dispatches the call via `initiateOutboundCall`, only logs the CALL activity on dispatch success, and surfaces the dispatcher error to the tradie when something breaks.

### Six CRITICAL externally-exploitable bugs (verified, fixed, regression-tested)
1. `/api/log-crash` — unauthenticated `fs.writeFileSync` of user-supplied JSON → auth required, bounded payload, structured logger
2. `/api/sync/replay` — unauthenticated mutator that could change job status / quote items / write activity records → auth + ownership checks via `requireDealInCurrentWorkspace` / `requireContactInCurrentWorkspace`
3. `/api/contacts/search` — body-`workspaceId` IDOR → session-derived workspaceId
4. `/api/search/global` — same IDOR shape → same fix
5. `/api/workspace/complete-tutorial` — same IDOR shape → same fix
6. `/api/reminders` (`manualSendJobReminder` / `manualSendTripSms`) — **worst one**: any logged-in user could trigger SMS reminders to another workspace's customers from that workspace's Twilio number. Fixed at both route and action layer.

### Five HIGH severity bugs
7. `sendViaTwilio` — fire-and-forget `webhookEvent.create` with `.catch(() => {})` → awaited writes, failures surfaced via `console.error`
8. `processPostJobFollowUps` — duplicate-SMS race condition (concurrent crons both passed the dedup check) → wrapped in `runIdempotent` keyed on `deal.id + stageChangedAt`
9. Four unbounded `findMany` cron paths (`recurring-jobs`, `task-overdue`, `processFollowUpReminders`, `processBookingReminders`) → `take` limits with stable `orderBy`
10. `recurring-jobs` fail-open auth (`if (cronSecret && header !== ...)`) → fail-closed; also stopped `job-reminders` from logging a 20-char prefix of failed Authorization headers
11. `webhooks/email` — no signature verification → required `EMAIL_WEBHOOK_SECRET` with timing-safe comparison

### Four MEDIUM severity bugs
12. `runSendSms` / `runSendEmail` "not configured" fallbacks wrote phantom `ChatMessage` + Activity rows that the conversation thread rendered as "delivered" → return honest error, no fake records
13. `runMarkInvoicePaidAction` — missing `recordWorkspaceAuditEventForCurrentActor` call (sibling functions had it) → audit event added
14. `applyHalfPriceMonthsToReferrer` — Stripe coupon created before dependent DB write → compensating coupon delete on subscription-update failure, reconciliation log when DB write fails after Stripe succeeds
15. `twilio-voice-status` webhook — read-then-create race on CallSid (two retries → two Deals) → `runIdempotent` wrap; `whatsapp` webhook had a stable-key bug where its `bucketAt` rotated hourly, fixed

### Backstop
- Custom ESLint rule `no-fake-tool-success` at `actions/**/*.ts` (`error` severity). Catches the exact Michael-bug shape: exported async `run*` functions that return success-styled copy (`📞`/`✉️`/`✅`/`"Sent"`/`"Calling"` etc.) without invoking any external client or known internal helper. Verified it trips on a synthetic Michael-shape file and produces zero false positives on existing code.

### Test coverage added
30+ new contract tests across `log-crash`, `sync-replay`, `contacts-search`, `search-global`, `complete-tutorial`, `reminders`, `email-webhook-auth`, `post-job-followups`, `messaging-actions`, `twilio-voice-status`, `chat-actions`. Each test asserts the side-effecting path is *actually invoked* (or *actually not invoked* in the unauth/IDOR cases) — the test shape that would have caught the original bug if it had existed.

## Audit findings deliberately not in this PR

- **`voice-grounding-index`** — audit flagged as "mass data leak"; verified false positive. The endpoint is consumed by the voice worker for inbound-call routing; payload is the tradie's own public business profile (no customer PII). Auth via `x-voice-agent-secret` is appropriate.
- **`internal/voice-calls` post-call CRM race** — same shape as #15 but the fix needs to wrap a larger block of downstream work. Tracked as a follow-up.
- **`processReferralConversionForCheckout` "IDOR"** — verified only called from the signature-verified Stripe webhook handler; not exploitable. Listed as defence-in-depth candidate.
- **"Missing await" claims on `runCompleteTaskByTitle` / `runDeleteTaskByTitle`** — verified false positive (both correctly `await`).

## Test plan

- [ ] `npx vitest run __tests__/chat-actions.test.ts` — 42 tests pass (includes the three new `runMakeCall` contract tests)
- [ ] `npx vitest run __tests__/sync-replay-route.test.ts __tests__/contacts-search-route.test.ts __tests__/search-global-route.test.ts __tests__/complete-tutorial-route.test.ts __tests__/reminders-route.test.ts __tests__/log-crash-route.test.ts __tests__/email-webhook-auth.test.ts __tests__/post-job-followups.test.ts __tests__/messaging-actions.test.ts __tests__/twilio-voice-status-route.test.ts` — all green
- [ ] `npx eslint actions/` — zero `earlymark-tools/no-fake-tool-success` errors
- [ ] Manually: ask the AI in chat to call a real contact — observe an actual call placed via LiveKit instead of the previous fake-success message

https://claude.ai/code/session_01XmNA9rNza5ZGQWX7TqYpK1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmNA9rNza5ZGQWX7TqYpK1)_