### PR TITLE
Mobile-native shell, bottom nav, and full page coverage

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { redirect } from 'next/navigation';
-import { Shell } from '@/components/layout/Shell';
+import { ShellHost } from '@/components/layout/shell-host';
 import { OnboardingModal } from "@/components/dashboard/onboarding-modal";
 import { DeferredChatInterface } from "@/components/chatbot/deferred-chat-interface";
 import { ShellInitializer } from "@/components/layout/shell-initializer";
@@ -66,10 +66,10 @@ export default async function DashboardLayout({
         workspaceIndustryType={workspaceIndustryType}
       />
       <Suspense fallback={<div className="h-screen w-full bg-background flex items-center justify-center"><div className="animate-pulse text-muted-foreground">Loading...</div></div>}>
-        <Shell chatbot={<DeferredChatInterface workspaceId={workspaceId} />}>
+        <ShellHost chatbot={<DeferredChatInterface workspaceId={workspaceId} />}>
           <OnboardingModal />
           {children}
-        </Shell>
+        </ShellHost>
       </Suspense>
       <Toaster />
       <DashboardClientChrome />

--- a/app/(dashboard)/tradie/estimator/page.tsx
+++ b/app/(dashboard)/tradie/estimator/page.tsx
@@ -2,6 +2,7 @@ import { getDeals } from "@/actions/deal-actions";
 import { EstimatorForm } from "@/components/tradie/estimator-form";
 import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
 import { redirect } from "next/navigation";
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header";
 
 export const dynamic = "force-dynamic";
 
@@ -21,9 +22,11 @@ export default async function TradieEstimatorPage() {
     .map((deal) => ({ id: deal.id, title: deal.title }));
 
   return (
+    <>
+    <MobileHeader pageTitle="Estimator" />
     <div className="min-h-[calc(100vh-4rem)] bg-muted/30 px-4 py-6 md:px-6">
       <div className="mx-auto max-w-3xl space-y-4">
-        <div className="space-y-2">
+        <div className="hidden md:block space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Tradie Tools</p>
           <h1 className="text-3xl font-bold text-foreground">Estimator</h1>
           <p className="max-w-2xl text-sm text-muted-foreground">
@@ -43,5 +46,6 @@ export default async function TradieEstimatorPage() {
         )}
       </div>
     </div>
+    </>
   );
 }

--- a/app/(dashboard)/tradie/map/page.tsx
+++ b/app/(dashboard)/tradie/map/page.tsx
@@ -1,8 +1,9 @@
 import { getTradieJobs } from "@/actions/tradie-actions"
 import { getOrCreateWorkspace } from "@/actions/workspace-actions"
 import { getAuthUserId } from "@/lib/auth"
-import MapView from "@/components/map/map-view-client"
+import { MapPageClient } from "@/components/map/map-page-client"
 import { redirect } from "next/navigation"
+import type { Job } from "@/components/map/map-view"
 
 export const dynamic = "force-dynamic"
 
@@ -37,8 +38,8 @@ export default async function TradieMapPage() {
     }
 
     return (
-        <div className="h-[calc(100vh-4rem)] w-full">
-            <MapView jobs={jobs} />
+        <div className="h-full w-full">
+            <MapPageClient jobs={jobs as Job[]} />
         </div>
     )
 }

--- a/app/(dashboard)/tradie/schedule/page.tsx
+++ b/app/(dashboard)/tradie/schedule/page.tsx
@@ -3,6 +3,7 @@ import { getOrCreateWorkspace } from "@/actions/workspace-actions"
 import { getAuthUserId } from "@/lib/auth"
 import SchedulerView from "@/components/scheduler/scheduler-view"
 import { redirect } from "next/navigation"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 
 export const dynamic = "force-dynamic"
 
@@ -36,8 +37,11 @@ export default async function SchedulerPage() {
     }
 
     return (
+        <>
+        <MobileHeader pageTitle="Schedule" />
         <div className="h-[calc(100vh-4rem)]">
             <SchedulerView initialJobs={jobs} />
         </div>
+        </>
     )
 }

--- a/app/crm/analytics/page.tsx
+++ b/app/crm/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 import { TrendingUp, TrendingDown, DollarSign, Users, Star, CheckCircle, LayoutList, Printer } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -285,6 +286,7 @@ export default function AnalyticsPage() {
 
   return (
     <div className="h-full min-h-0 flex flex-col overflow-hidden">
+      <MobileHeader pageTitle="Analytics" />
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-6">
           <div className="flex items-center justify-between">

--- a/app/crm/contacts/[id]/edit/page.tsx
+++ b/app/crm/contacts/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { db } from "@/lib/db";
 import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
 import { ContactForm } from "@/components/crm/contact-form";
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header";
 
 export const dynamic = "force-dynamic";
 
@@ -41,12 +42,15 @@ export default async function EditContactPage({ params }: PageProps) {
   }
 
   return (
-    <ContactForm
-      mode="edit"
-      contact={{
-        ...contact,
-        metadata: (contact.metadata as Record<string, unknown> | null) ?? undefined,
-      }}
-    />
+    <>
+      <MobileHeader pageTitle="Edit Contact" />
+      <ContactForm
+        mode="edit"
+        contact={{
+          ...contact,
+          metadata: (contact.metadata as Record<string, unknown> | null) ?? undefined,
+        }}
+      />
+    </>
   );
 }

--- a/app/crm/contacts/[id]/page.tsx
+++ b/app/crm/contacts/[id]/page.tsx
@@ -10,6 +10,7 @@ import { format } from "date-fns"
 import { PRISMA_STAGE_LABELS } from "@/lib/deal-utils"
 import { formatCurrency, formatShortDate } from "@/lib/format"
 import { getActivities } from "@/actions/activity-actions"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 
 export const dynamic = "force-dynamic"
 
@@ -71,8 +72,21 @@ export default async function ContactDetailPage({ params }: PageProps) {
     : rawActivities
 
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)] p-4 md:p-6 gap-4 overflow-hidden">
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-muted-foreground">
+    <>
+    <MobileHeader
+      pageTitle={contact.name}
+      rightSlot={
+        <Link
+          href={`/crm/contacts/${id}/edit`}
+          aria-label="Edit contact"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-700/60 text-white"
+        >
+          <Edit className="h-4 w-4" />
+        </Link>
+      }
+    />
+    <div className="flex flex-col md:h-[calc(100vh-4rem)] p-4 md:p-6 gap-4 md:overflow-hidden">
+      <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1 text-sm text-muted-foreground">
         <Link href="/crm/dashboard" className="inline-flex items-center gap-1 hover:text-foreground transition-colors">
           <Home className="h-4 w-4" />
           Dashboard
@@ -83,7 +97,7 @@ export default async function ContactDetailPage({ params }: PageProps) {
         <span className="font-medium text-foreground">{contact.name}</span>
       </nav>
 
-      <div className="flex items-center justify-between shrink-0">
+      <div className="hidden md:flex items-center justify-between shrink-0">
         <div className="flex items-center gap-4">
           <Link
             href="/crm/dashboard"
@@ -130,7 +144,7 @@ export default async function ContactDetailPage({ params }: PageProps) {
         Recent notes and jobs stay on this page. Open the customer timeline for the full SMS, email, and call correspondence.
       </div>
 
-      <div className="flex-1 grid grid-cols-1 lg:grid-cols-3 gap-4 min-h-0 overflow-y-auto">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-3 gap-4 min-h-0 md:overflow-y-auto">
         {/* Left: Contact/Business details + Current job */}
         <div className="lg:col-span-1 flex flex-col gap-4">
           {contactType === "BUSINESS" ? (
@@ -410,5 +424,6 @@ export default async function ContactDetailPage({ params }: PageProps) {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/app/crm/contacts/new/page.tsx
+++ b/app/crm/contacts/new/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
 import { ContactForm } from "@/components/crm/contact-form";
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header";
 
 export const dynamic = "force-dynamic";
 
@@ -16,5 +17,10 @@ export default async function NewContactPage() {
     redirect("/crm/dashboard");
   }
 
-  return <ContactForm mode="create" workspaceId={actor.workspaceId} />;
+  return (
+    <>
+      <MobileHeader pageTitle="New Contact" />
+      <ContactForm mode="create" workspaceId={actor.workspaceId} />
+    </>
+  );
 }

--- a/app/crm/deals/[id]/edit/page.tsx
+++ b/app/crm/deals/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import { DealEditForm } from "./deal-edit-form"
 import { PRISMA_STAGE_TO_UI_STAGE, STAGE_OPTIONS } from "@/lib/deal-utils"
 import { getDealRecurrence } from "@/actions/deal-actions"
 import { resolveWorkspaceTimezone, toDateTimeLocalValue } from "@/lib/timezone"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 
 interface PageProps {
   params: Promise<{ id: string }>
@@ -48,8 +49,10 @@ export default async function DealEditPage({ params }: PageProps) {
   const stage = PRISMA_STAGE_TO_UI_STAGE[deal.stage] ?? "new_request"
 
   return (
+    <>
+    <MobileHeader pageTitle="Edit Job" />
     <div className="flex flex-col max-w-2xl mx-auto p-4 md:p-6 gap-6 min-h-0 overflow-y-auto">
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-muted-foreground">
+      <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1 text-sm text-muted-foreground">
         <Link href="/crm/dashboard" className="inline-flex items-center gap-1 hover:text-foreground transition-colors">
           <Home className="h-4 w-4" />
           Dashboard
@@ -62,7 +65,7 @@ export default async function DealEditPage({ params }: PageProps) {
         <span className="font-medium text-foreground">Edit</span>
       </nav>
 
-      <div className="flex items-center gap-4">
+      <div className="hidden md:flex items-center gap-4">
         <Link
           href={`/crm/deals/${id}`}
           className="h-10 w-10 inline-flex items-center justify-center rounded-lg hover:bg-muted text-foreground transition-colors"
@@ -89,5 +92,6 @@ export default async function DealEditPage({ params }: PageProps) {
         initialRecurrence={recurrence}
       />
     </div>
+    </>
   )
 }

--- a/app/crm/deals/[id]/page.tsx
+++ b/app/crm/deals/[id]/page.tsx
@@ -3,6 +3,7 @@ import { requireDealInCurrentWorkspace } from "@/lib/workspace-access"
 import { notFound } from "next/navigation"
 import Link from "next/link"
 import { ChevronLeft, ChevronRight, Edit, MessageSquare, FileText, MapPin, Briefcase, ImageIcon, Home, DollarSign, AlertTriangle, Navigation, Phone } from "lucide-react"
+import { DealHeaderMobile } from "@/components/mobile/deals/deal-header-mobile"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -87,6 +88,7 @@ export default async function DealDetailPage({ params }: PageProps) {
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-y-auto p-4 pb-24 md:p-6 md:pb-24">
+      <DealHeaderMobile title={deal.title} stageLabel={stageLabel} dealId={id} />
       <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1 text-sm text-muted-foreground">
         <Link href="/crm/dashboard" className="inline-flex items-center gap-1 hover:text-foreground transition-colors">
           <Home className="h-4 w-4" />
@@ -98,8 +100,8 @@ export default async function DealDetailPage({ params }: PageProps) {
         <span className="font-medium text-foreground">{deal.title}</span>
       </nav>
 
-      {/* Header */}
-      <div className="flex items-center justify-between shrink-0">
+      {/* Header — desktop only; mobile uses DealHeaderMobile above */}
+      <div className="hidden md:flex items-center justify-between shrink-0">
         <div className="flex items-center gap-4">
           <Link
             href="/crm/dashboard"

--- a/app/crm/deals/[id]/page.tsx
+++ b/app/crm/deals/[id]/page.tsx
@@ -87,7 +87,7 @@ export default async function DealDetailPage({ params }: PageProps) {
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-y-auto p-4 pb-24 md:p-6 md:pb-24">
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-muted-foreground">
+      <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1 text-sm text-muted-foreground">
         <Link href="/crm/dashboard" className="inline-flex items-center gap-1 hover:text-foreground transition-colors">
           <Home className="h-4 w-4" />
           Dashboard

--- a/app/crm/deals/new/page.tsx
+++ b/app/crm/deals/new/page.tsx
@@ -1,6 +1,7 @@
 import { NewDealModalStandalone } from "@/components/modals/new-deal-modal-standalone";
 import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
 import { redirect } from "next/navigation";
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header";
 
 export const dynamic = "force-dynamic";
 
@@ -13,9 +14,11 @@ export default async function NewDealPage() {
   }
 
   return (
+    <>
+    <MobileHeader pageTitle="New Booking" />
     <div className="h-full overflow-y-auto bg-muted/30 px-4 py-6 pb-24 md:px-6">
       <div className="mx-auto max-w-3xl space-y-4">
-        <div className="space-y-2">
+        <div className="hidden md:block space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">CRM Jobs</p>
           <h1 className="text-3xl font-bold text-foreground">New Booking</h1>
           <p className="max-w-2xl text-sm text-muted-foreground">
@@ -25,5 +28,6 @@ export default async function NewDealPage() {
         <NewDealModalStandalone workspaceId={actor.workspaceId} />
       </div>
     </div>
+    </>
   );
 }

--- a/app/crm/estimator/page.tsx
+++ b/app/crm/estimator/page.tsx
@@ -2,6 +2,7 @@ import { getDeals } from "@/actions/deal-actions";
 import { EstimatorForm } from "@/components/tradie/estimator-form";
 import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
 import { redirect } from "next/navigation";
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header";
 
 export const dynamic = "force-dynamic";
 
@@ -21,8 +22,10 @@ export default async function CrmEstimatorPage() {
     .map((deal) => ({ id: deal.id, title: deal.title }));
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
+    <>
+    <MobileHeader pageTitle="Estimator" />
+    <div className="space-y-6 px-4 py-4 md:px-0 md:py-0">
+      <div className="hidden md:block space-y-2">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">CRM Billing</p>
         <h1 className="text-3xl font-bold text-foreground">Estimator</h1>
         <p className="max-w-2xl text-sm text-muted-foreground">
@@ -41,5 +44,6 @@ export default async function CrmEstimatorPage() {
         <EstimatorForm deals={visibleDeals as never[]} workspaceId={actor.workspaceId} />
       )}
     </div>
+    </>
   );
 }

--- a/app/crm/inbox/[contactId]/page.tsx
+++ b/app/crm/inbox/[contactId]/page.tsx
@@ -1,0 +1,41 @@
+import { redirect } from "next/navigation"
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access"
+import { getActivities } from "@/actions/activity-actions"
+import { getContact } from "@/actions/contact-actions"
+import { InboxThreadMobile } from "@/components/mobile/inbox/inbox-thread-mobile"
+
+export const dynamic = "force-dynamic"
+
+export default async function InboxThreadPage({
+  params,
+}: {
+  params: Promise<{ contactId: string }>
+}) {
+  let actor: Awaited<ReturnType<typeof requireCurrentWorkspaceAccess>>
+  try {
+    actor = await requireCurrentWorkspaceAccess()
+  } catch {
+    redirect("/login")
+  }
+
+  if (actor.role === "TEAM_MEMBER") redirect("/crm/dashboard")
+
+  const { contactId } = await params
+
+  const [contact, activities] = await Promise.all([
+    getContact(contactId),
+    getActivities({ workspaceId: actor.workspaceId, contactId, limit: 100 }),
+  ])
+
+  if (!contact) redirect("/crm/inbox")
+
+  return (
+    <InboxThreadMobile
+      contactId={contactId}
+      contactName={contact.name}
+      contactPhone={contact.phone}
+      activities={activities}
+      workspaceId={actor.workspaceId}
+    />
+  )
+}

--- a/app/crm/schedule/schedule-calendar.tsx
+++ b/app/crm/schedule/schedule-calendar.tsx
@@ -5,6 +5,8 @@ import { startOfMonth, endOfMonth, eachDayOfInterval, isSameMonth, isSameDay, ad
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { DealView } from "@/actions/deal-actions"
+import { useIsMobile } from "@/hooks/use-is-mobile"
+import { ScheduleMobile } from "@/components/mobile/schedule/schedule-mobile"
 import { cn } from "@/lib/utils"
 import { DealDetailModal } from "@/components/crm/deal-detail-modal"
 import { ChevronLeft, ChevronRight } from "lucide-react"
@@ -45,6 +47,10 @@ interface ScheduleCalendarProps {
 const DAY_HOURS = Array.from({ length: 15 }, (_, index) => index + 6)
 
 export function ScheduleCalendar({ deals, teamMembers, workspaceTimezone, initialDate }: ScheduleCalendarProps) {
+  const isMobile = useIsMobile()
+  if (isMobile) {
+    return <ScheduleMobile deals={deals} />
+  }
   const router = useRouter()
   const [current, setCurrent] = useState(() => initialDate ?? new Date())
   const [view, setView] = useState<ViewMode>("month")

--- a/app/crm/settings/layout.tsx
+++ b/app/crm/settings/layout.tsx
@@ -7,6 +7,9 @@ import { cn } from "@/lib/utils"
 import { useShellStore } from "@/lib/store"
 import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
+import { useIsMobile } from "@/hooks/use-is-mobile"
+import { SettingsIndexMobile } from "@/components/mobile/settings/settings-index-mobile"
+import { SettingsSubMobile } from "@/components/mobile/settings/settings-sub-mobile"
 
 interface SettingsLayoutProps {
     children: React.ReactNode
@@ -137,6 +140,14 @@ function SidebarNav({ className, ...props }: { className?: string } & React.HTML
 }
 
 export default function SettingsLayout({ children }: SettingsLayoutProps) {
+    const isMobile = useIsMobile()
+    const pathname = usePathname()
+    if (isMobile) {
+        if (pathname === "/crm/settings") {
+            return <SettingsIndexMobile />
+        }
+        return <SettingsSubMobile>{children}</SettingsSubMobile>
+    }
     return (
         <div className="min-h-full flex-1 space-y-6 p-4 pl-6 pb-16 md:p-8 md:pl-10 lg:p-10 lg:pl-14 max-w-6xl mx-auto w-full">
             <div className="space-y-1.5">

--- a/app/crm/team/page.tsx
+++ b/app/crm/team/page.tsx
@@ -37,6 +37,7 @@ import { getTeamMembers, getWorkspaceInvites, createInvite, revokeInvite, remove
 import { toast } from "sonner"
 import { useShellStore } from "@/lib/store"
 import { formatDate } from "@/lib/format"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 
 interface TeamMember {
     id: string
@@ -207,6 +208,8 @@ export default function TeamPage() {
     }
 
     return (
+        <>
+        <MobileHeader pageTitle="Team" />
         <div className="mx-auto w-full max-w-6xl space-y-8 px-6 py-8">
             <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
                 <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground">
@@ -513,5 +516,6 @@ export default function TeamPage() {
                 )}
             </div>
         </div>
+        </>
     )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -524,3 +524,19 @@
 .scrollbar-hide::-webkit-scrollbar-track {
   background: transparent !important;
 }
+
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --mobile-nav-h: 64px;
+}
+
+.pt-safe { padding-top: var(--safe-top); }
+.pb-safe { padding-bottom: var(--safe-bottom); }
+.pl-safe { padding-left: var(--safe-left); }
+.pr-safe { padding-right: var(--safe-right); }
+.pb-mobile-nav { padding-bottom: calc(var(--mobile-nav-h) + var(--safe-bottom)); }
+.h-mobile-nav { height: calc(var(--mobile-nav-h) + var(--safe-bottom)); }
+.bottom-mobile-nav { bottom: calc(var(--mobile-nav-h) + var(--safe-bottom)); }

--- a/components/crm/contacts-client.tsx
+++ b/components/crm/contacts-client.tsx
@@ -5,6 +5,8 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { ChevronDown, Filter, Mail, MessageSquare, Phone, Search, X } from "lucide-react"
 import { toast } from "sonner"
+import { useIsMobile } from "@/hooks/use-is-mobile"
+import { ContactsMobile } from "@/components/mobile/contacts/contacts-mobile"
 
 import { ContactView, deleteContacts } from "@/actions/contact-actions"
 import { Badge } from "@/components/ui/badge"
@@ -89,6 +91,10 @@ function formatLastContact(date: Date | null): string {
 }
 
 export function ContactsClient({ contacts, pagination }: ContactsClientProps) {
+  const isMobile = useIsMobile()
+  if (isMobile) {
+    return <ContactsMobile contacts={contacts} />
+  }
   const router = useRouter()
   const [search, setSearch] = useState("")
   const allStageIds = useMemo(() => new Set(KANBAN_STAGES.map((stage) => stage.id)), [])

--- a/components/crm/inbox-view.tsx
+++ b/components/crm/inbox-view.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import type { ActivityView } from "@/actions/activity-actions"
 import { useShellStore } from "@/lib/store"
+import { useIsMobile } from "@/hooks/use-is-mobile"
+import { InboxMobile } from "@/components/mobile/inbox/inbox-mobile"
 import { TUTORIAL_STEPS } from "@/components/tutorial/tutorial-steps"
 import { cn } from "@/lib/utils"
 import {
@@ -177,6 +179,10 @@ export function InboxView({
   workspaceId,
   initialContactId = null,
 }: InboxViewProps) {
+  const isMobile = useIsMobile()
+  if (isMobile) {
+    return <InboxMobile interactions={initialInteractions} contactSegment={contactSegment} />
+  }
   const router = useRouter()
   const { viewMode, tutorialStepIndex } = useShellStore()
   const isTutorialInboxStep = viewMode === "TUTORIAL" && TUTORIAL_STEPS[tutorialStepIndex]?.id === "nav-inbox"

--- a/components/dashboard/dashboard-client.tsx
+++ b/components/dashboard/dashboard-client.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useMemo, useCallback } from "react"
 import { KanbanBoard } from "@/components/crm/kanban-board"
 import { DashboardKpiCards } from "@/components/dashboard/dashboard-kpi-cards"
+import { PipelineMobile } from "@/components/mobile/pipeline/pipeline-mobile"
+import { useIsMobile } from "@/hooks/use-is-mobile"
 import { DealView } from "@/actions/deal-actions"
 import { WorkspaceView } from "@/actions/workspace-actions"
 import { ensureDailyNotifications } from "@/actions/notification-actions"
@@ -55,7 +57,11 @@ interface DashboardClientProps {
     userId: string
 }
 
-export function DashboardClient({ workspace, deals, teamMembers }: DashboardClientProps) {
+export function DashboardClient({ workspace, deals, teamMembers, userName }: DashboardClientProps) {
+    const isMobile = useIsMobile()
+    if (isMobile) {
+        return <PipelineMobile workspace={workspace} deals={deals} userName={userName} />
+    }
     const FILTER_ALL = "__all__"
     const FILTER_UNASSIGNED = "__unassigned__"
     const PRESETS_KEY = `kanban-filter-presets:${workspace.id}`

--- a/components/layout/Shell.tsx
+++ b/components/layout/Shell.tsx
@@ -9,9 +9,8 @@ import { TutorialOverlay } from "@/components/tutorial/tutorial-overlay"
 import { Sidebar } from "@/components/core/sidebar"
 import { MobileSidebar } from "@/components/layout/mobile-sidebar"
 // Switch import removed — using segmented control buttons instead
-import { Layers, MessageSquare, Menu } from "lucide-react"
+import { Layers, MessageSquare } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import type { ImperativePanelGroupHandle, ImperativePanelHandle } from "react-resizable-panels"
 import { DashboardMainChrome } from "@/components/dashboard/dashboard-main-chrome"
 
@@ -68,7 +67,6 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
   const assistantResizeFrameRef = useRef<number | null>(null)
   const pendingAssistantSizeRef = useRef<number | null>(null)
   const [assistantHandleDragging, setAssistantHandleDragging] = useState(false)
-  const [mobileChatOpen, setMobileChatOpen] = useState(false)
   const recentAssistantDragRef = useRef(false)
   const recentAssistantDragTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const assistantPillDragRef = useRef<{
@@ -497,22 +495,6 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
             </div>
           </div>
 
-          {/* Mobile: floating nav + chat buttons */}
-          <div className="md:hidden fixed bottom-5 right-5 z-[10000] flex flex-col gap-2 items-end">
-            {/* Chat FAB - opens a sheet on mobile */}
-            {chatbot && (
-              <button
-                type="button"
-                onClick={() => setMobileChatOpen(true)}
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary shadow-lg hover:bg-primary/90 hover:shadow-xl transition-all focus:outline-none animate-bounce-gentle"
-                title="Open chat"
-                aria-label="Open chat"
-              >
-                <MessageSquare className="h-5 w-5 text-white" />
-              </button>
-            )}
-          </div>
-
           {/* Desktop: chat FAB when panel is collapsed */}
           {chatbot && !chatbotExpanded && (
             <button
@@ -530,32 +512,6 @@ export function Shell({ children, chatbot }: { children: React.ReactNode; chatbo
               <MessageSquare className="h-5 w-5 text-white" />
             </button>
           )}
-
-          {/* Mobile: hamburger menu - fixed bottom-left for navigation on non-dashboard pages */}
-          <button
-            type="button"
-            onClick={() => useShellStore.getState().setMobileMenuOpen(true)}
-            className="md:hidden fixed bottom-5 left-5 z-[10000] flex h-12 w-12 items-center justify-center rounded-full bg-primary shadow-lg hover:bg-primary/90 hover:shadow-xl transition-all focus:outline-none"
-            title="Open navigation"
-            aria-label="Open navigation menu"
-          >
-            <Menu className="h-5 w-5 text-white" />
-          </button>
-
-          {/* Mobile Chat Sheet */}
-          <Sheet open={mobileChatOpen} onOpenChange={setMobileChatOpen}>
-            <SheetContent side="bottom" className="h-[85dvh] p-0 flex flex-col">
-              <SheetHeader className="shrink-0 flex flex-row items-center px-4 py-3 border-b border-border/50">
-                <SheetTitle className="flex items-center gap-2 text-sm font-semibold">
-                  <MessageSquare className="h-4 w-4 text-primary" />
-                  AI Assistant
-                </SheetTitle>
-              </SheetHeader>
-              <div id="mobile-assistant-pane" className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                {!isDesktop && mobileChatOpen ? chatbot : null}
-              </div>
-            </SheetContent>
-          </Sheet>
         </div>
       )}
     </div>

--- a/components/layout/shell-host.tsx
+++ b/components/layout/shell-host.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { useSyncExternalStore } from "react"
+import { usePathname } from "next/navigation"
 import { Shell } from "@/components/layout/Shell"
+import { MobileShell } from "@/components/mobile/_primitives/mobile-shell"
+import { useIsMobile } from "@/hooks/use-is-mobile"
 
 export function ShellHost({ children, chatbot }: { children: React.ReactNode; chatbot?: React.ReactNode }) {
   const mounted = useSyncExternalStore(
@@ -9,6 +12,8 @@ export function ShellHost({ children, chatbot }: { children: React.ReactNode; ch
     () => true,
     () => false,
   )
+  const isMobile = useIsMobile()
+  const pathname = usePathname()
 
   if (!mounted) {
     return (
@@ -20,6 +25,9 @@ export function ShellHost({ children, chatbot }: { children: React.ReactNode; ch
     )
   }
 
+  if (isMobile && pathname.startsWith("/crm")) {
+    return <MobileShell chatbot={chatbot}>{children}</MobileShell>
+  }
+
   return <Shell chatbot={chatbot}>{children}</Shell>
 }
-

--- a/components/layout/shell-host.tsx
+++ b/components/layout/shell-host.tsx
@@ -32,7 +32,10 @@ export function ShellHost({ children, chatbot }: { children: React.ReactNode; ch
     pathname.startsWith("/contacts") ||
     pathname.startsWith("/jobs")
 
-  if (isMobile && isAppRoute) {
+  // Full-bleed routes that manage their own layout (no bottom nav / scroll wrapper)
+  const isFullBleed = /^\/crm\/inbox\/[^/]+$/.test(pathname)
+
+  if (isMobile && isAppRoute && !isFullBleed) {
     return <MobileShell chatbot={chatbot}>{children}</MobileShell>
   }
 

--- a/components/layout/shell-host.tsx
+++ b/components/layout/shell-host.tsx
@@ -25,7 +25,14 @@ export function ShellHost({ children, chatbot }: { children: React.ReactNode; ch
     )
   }
 
-  if (isMobile && pathname.startsWith("/crm")) {
+  const isAppRoute =
+    pathname.startsWith("/crm") ||
+    pathname.startsWith("/tradie") ||
+    pathname.startsWith("/agent") ||
+    pathname.startsWith("/contacts") ||
+    pathname.startsWith("/jobs")
+
+  if (isMobile && isAppRoute) {
     return <MobileShell chatbot={chatbot}>{children}</MobileShell>
   }
 

--- a/components/map/map-page-client.tsx
+++ b/components/map/map-page-client.tsx
@@ -6,6 +6,8 @@ import Link from "next/link"
 import { AlertCircle, MapPinned } from "lucide-react"
 import { GoogleMapView } from "@/components/map/google-map-view"
 import type { Job } from "@/components/map/map-view"
+import { useIsMobile } from "@/hooks/use-is-mobile"
+import { MapMobile } from "@/components/mobile/map/map-mobile"
 
 const LeafletMapView = dynamic(() => import("@/components/map/map-view"), {
   ssr: false,
@@ -17,9 +19,12 @@ const LeafletMapView = dynamic(() => import("@/components/map/map-view"), {
 })
 
 export function MapPageClient({ jobs }: { jobs: Job[] }) {
+  const isMobile = useIsMobile()
   const hasGoogleKey = !!(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "").trim()
   const [useGoogleMaps, setUseGoogleMaps] = useState(hasGoogleKey)
   const [fellBackToLeaflet, setFellBackToLeaflet] = useState(false)
+
+  if (isMobile) return <MapMobile jobs={jobs} />
 
   if (jobs.length === 0) {
     return (

--- a/components/mobile/_primitives/bottom-nav.tsx
+++ b/components/mobile/_primitives/bottom-nav.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { LayoutDashboard, Inbox, CalendarDays, MoreHorizontal } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type TabItem = {
+  href: string
+  label: string
+  icon: typeof LayoutDashboard
+  match: (pathname: string) => boolean
+}
+
+const TABS: TabItem[] = [
+  {
+    href: "/crm/dashboard",
+    label: "Pipeline",
+    icon: LayoutDashboard,
+    match: (p) => p === "/crm/dashboard" || p.startsWith("/crm/deals"),
+  },
+  {
+    href: "/crm/inbox",
+    label: "Inbox",
+    icon: Inbox,
+    match: (p) => p.startsWith("/crm/inbox"),
+  },
+  {
+    href: "/crm/schedule",
+    label: "Schedule",
+    icon: CalendarDays,
+    match: (p) => p.startsWith("/crm/schedule"),
+  },
+]
+
+interface BottomNavProps {
+  onTraceyClick: () => void
+  onMoreClick: () => void
+  hasNotifications?: boolean
+}
+
+export function BottomNav({ onTraceyClick, onMoreClick, hasNotifications }: BottomNavProps) {
+  const pathname = usePathname()
+
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-40 h-mobile-nav pb-safe border-t border-border/60 bg-card/95 backdrop-blur-md md:hidden"
+    >
+      <div className="relative mx-auto flex h-[64px] max-w-md items-stretch justify-around px-2">
+        <TabButton tab={TABS[0]} active={TABS[0].match(pathname)} />
+        <TabButton tab={TABS[1]} active={TABS[1].match(pathname)} />
+        <TraceyTab onClick={onTraceyClick} hasDot={hasNotifications} />
+        <TabButton tab={TABS[2]} active={TABS[2].match(pathname)} />
+        <MoreTab onClick={onMoreClick} />
+      </div>
+    </nav>
+  )
+}
+
+function TabButton({ tab, active }: { tab: TabItem; active: boolean }) {
+  const Icon = tab.icon
+  return (
+    <Link
+      href={tab.href}
+      aria-label={tab.label}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex flex-1 flex-col items-center justify-center gap-1 text-[11px] font-medium transition-colors",
+        active ? "text-foreground" : "text-muted-foreground"
+      )}
+    >
+      <Icon className="h-5 w-5" strokeWidth={active ? 2.25 : 1.75} />
+      <span>{tab.label}</span>
+    </Link>
+  )
+}
+
+function TraceyTab({ onClick, hasDot }: { onClick: () => void; hasDot?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Open Tracey assistant"
+      className="flex flex-1 flex-col items-center justify-end gap-1 text-[11px] font-medium text-foreground"
+    >
+      <span className="relative -mt-6 flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 ring-4 ring-card">
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground">
+          T
+        </span>
+        {hasDot && (
+          <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-destructive" />
+        )}
+      </span>
+      <span>Tracey</span>
+    </button>
+  )
+}
+
+function MoreTab({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="More"
+      className="flex flex-1 flex-col items-center justify-center gap-1 text-[11px] font-medium text-muted-foreground"
+    >
+      <MoreHorizontal className="h-5 w-5" strokeWidth={1.75} />
+      <span>More</span>
+    </button>
+  )
+}

--- a/components/mobile/_primitives/mobile-header.tsx
+++ b/components/mobile/_primitives/mobile-header.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+
+interface MobileHeaderProps {
+  pageTitle: string
+  userName?: string
+  workspaceInitial?: string
+  hasNotifications?: boolean
+  onProfileClick?: () => void
+  onWorkspaceClick?: () => void
+  /** Override the displayed date (defaults to today, formatted en-AU) */
+  dateLabel?: string
+  /** Optional right-side element (e.g. action button) shown in place of profile dot */
+  rightSlot?: React.ReactNode
+}
+
+export function MobileHeader({
+  pageTitle,
+  userName,
+  workspaceInitial,
+  hasNotifications,
+  onProfileClick,
+  onWorkspaceClick,
+  dateLabel,
+  rightSlot,
+}: MobileHeaderProps) {
+  const today = useMemo(() => {
+    if (dateLabel) return dateLabel
+    return new Date().toLocaleDateString("en-AU", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    })
+  }, [dateLabel])
+
+  const userInitial = (userName?.trim()?.[0] || "U").toUpperCase()
+  const wsInitial = (workspaceInitial?.trim()?.[0] || userInitial).toLowerCase()
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-30 md:hidden",
+        "bg-emerald-900 text-white pt-safe"
+      )}
+    >
+      <div className="flex items-center gap-3 px-4 pb-4 pt-3">
+        <button
+          type="button"
+          onClick={onWorkspaceClick}
+          aria-label="Workspace"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-base font-semibold text-white"
+        >
+          {wsInitial}
+        </button>
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] leading-tight text-emerald-100/90">{today}</p>
+          <h1 className="truncate text-xl font-bold leading-tight text-white">{pageTitle}</h1>
+        </div>
+        {rightSlot ?? (
+          <button
+            type="button"
+            onClick={onProfileClick}
+            aria-label="Profile and notifications"
+            className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-base font-semibold text-white"
+          >
+            {userInitial}
+            {hasNotifications && (
+              <span className="absolute right-0 top-0 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-emerald-900" />
+            )}
+          </button>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/components/mobile/_primitives/mobile-shell.tsx
+++ b/components/mobile/_primitives/mobile-shell.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState, type ReactNode } from "react"
+import { BottomNav } from "./bottom-nav"
+import { TraceySheet } from "./tracey-sheet"
+import { MoreSheet } from "./more-sheet"
+
+interface MobileShellProps {
+  /** Page-specific header rendered above the scroll area (use <MobileHeader/> or any custom node). */
+  header?: ReactNode
+  /** Main scrollable content. */
+  children: ReactNode
+  /** Chatbot node to render inside the Tracey sheet (same node passed to desktop Shell). */
+  chatbot?: ReactNode
+  /** Hide the bottom navigation (e.g. for full-screen flows like onboarding). */
+  hideBottomNav?: boolean
+  /** Notification dot on the Tracey tab. */
+  hasNotifications?: boolean
+}
+
+export function MobileShell({
+  header,
+  children,
+  chatbot,
+  hideBottomNav,
+  hasNotifications,
+}: MobileShellProps) {
+  const [traceyOpen, setTraceyOpen] = useState(false)
+  const [moreOpen, setMoreOpen] = useState(false)
+
+  return (
+    <div className="md:hidden flex h-dvh min-h-0 w-full flex-col bg-background">
+      {header}
+      <main
+        className={
+          "flex-1 min-h-0 overflow-y-auto overflow-x-hidden " +
+          (hideBottomNav ? "" : "pb-mobile-nav")
+        }
+      >
+        {children}
+      </main>
+
+      {!hideBottomNav && (
+        <BottomNav
+          onTraceyClick={() => setTraceyOpen(true)}
+          onMoreClick={() => setMoreOpen(true)}
+          hasNotifications={hasNotifications}
+        />
+      )}
+
+      {chatbot && (
+        <TraceySheet open={traceyOpen} onOpenChange={setTraceyOpen}>
+          {chatbot}
+        </TraceySheet>
+      )}
+
+      <MoreSheet open={moreOpen} onOpenChange={setMoreOpen} />
+    </div>
+  )
+}

--- a/components/mobile/_primitives/more-sheet.tsx
+++ b/components/mobile/_primitives/more-sheet.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  Users,
+  UsersRound,
+  Map as MapIcon,
+  BarChart2,
+  Settings2,
+  LifeBuoy,
+  LogOut,
+} from "lucide-react"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { useShellStore } from "@/lib/store"
+import { createClient } from "@/lib/supabase/client"
+
+interface MoreSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type MoreItem = {
+  href?: string
+  label: string
+  icon: typeof Users
+  managerOnly?: boolean
+  onClick?: () => void
+  destructive?: boolean
+}
+
+export function MoreSheet({ open, onOpenChange }: MoreSheetProps) {
+  const { userRole } = useShellStore()
+  const router = useRouter()
+  const isManager = userRole === "OWNER" || userRole === "MANAGER"
+
+  const handleSignOut = async () => {
+    const supabase = createClient()
+    await supabase.auth.signOut()
+    onOpenChange(false)
+    router.push("/login")
+  }
+
+  const items: MoreItem[] = [
+    { href: "/crm/contacts", label: "Contacts", icon: Users, managerOnly: true },
+    { href: "/crm/team", label: "Team", icon: UsersRound },
+    { href: "/crm/map", label: "Map", icon: MapIcon },
+    { href: "/crm/analytics", label: "Analytics", icon: BarChart2, managerOnly: true },
+    { href: "/crm/settings/account", label: "Settings", icon: Settings2 },
+    { href: "/crm/settings/help", label: "Help & support", icon: LifeBuoy },
+    { label: "Sign out", icon: LogOut, onClick: handleSignOut, destructive: true },
+  ].filter((i) => !i.managerOnly || isManager)
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="p-0 rounded-t-3xl pb-safe">
+        <SheetHeader className="px-5 pt-5 pb-3 border-b border-border/40">
+          <SheetTitle className="text-base font-semibold">More</SheetTitle>
+        </SheetHeader>
+        <ul className="flex flex-col py-2">
+          {items.map((item) => {
+            const Icon = item.icon
+            const content = (
+              <span
+                className={
+                  "flex items-center gap-3 px-5 py-3.5 text-[15px] " +
+                  (item.destructive ? "text-destructive" : "text-foreground")
+                }
+              >
+                <Icon className="h-5 w-5 opacity-80" />
+                <span className="flex-1">{item.label}</span>
+              </span>
+            )
+            return (
+              <li key={item.label} className="border-b border-border/30 last:border-b-0">
+                {item.href ? (
+                  <Link href={item.href} onClick={() => onOpenChange(false)}>
+                    {content}
+                  </Link>
+                ) : (
+                  <button type="button" onClick={item.onClick} className="w-full text-left">
+                    {content}
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/mobile/_primitives/tracey-sheet.tsx
+++ b/components/mobile/_primitives/tracey-sheet.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { MessageSquare } from "lucide-react"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+
+interface TraceySheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+export function TraceySheet({ open, onOpenChange, children }: TraceySheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="h-[92dvh] p-0 flex flex-col rounded-t-3xl"
+      >
+        <SheetHeader className="shrink-0 flex flex-row items-center px-4 py-3 border-b border-border/50">
+          <SheetTitle className="flex items-center gap-2 text-sm font-semibold">
+            <MessageSquare className="h-4 w-4 text-primary" />
+            Ask Tracey
+          </SheetTitle>
+        </SheetHeader>
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          {open ? children : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/mobile/contacts/contacts-mobile.tsx
+++ b/components/mobile/contacts/contacts-mobile.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { Search, UserPlus, Phone, Mail } from "lucide-react"
+import { ContactView } from "@/actions/contact-actions"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
+import { formatShortDate } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+interface ContactsMobileProps {
+  contacts: ContactView[]
+}
+
+type Filter = "all" | "lead" | "customer"
+
+const LEAD_STAGES = new Set(["NEW", "CONTACTED", "NEGOTIATION", "PIPELINE"])
+const CUSTOMER_STAGES = new Set(["SCHEDULED", "INVOICED", "WON"])
+
+function classify(stage: string | null): Filter {
+  if (!stage) return "lead"
+  if (CUSTOMER_STAGES.has(stage)) return "customer"
+  if (LEAD_STAGES.has(stage)) return "lead"
+  return "lead"
+}
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}
+
+export function ContactsMobile({ contacts }: ContactsMobileProps) {
+  const [query, setQuery] = useState("")
+  const [filter, setFilter] = useState<Filter>("all")
+
+  const filtered = useMemo(() => {
+    return contacts.filter((c) => {
+      if (filter !== "all" && classify(c.primaryDealStage) !== filter) return false
+      if (!query) return true
+      const q = query.toLowerCase()
+      return (
+        c.name.toLowerCase().includes(q) ||
+        (c.email || "").toLowerCase().includes(q) ||
+        (c.phone || "").toLowerCase().includes(q)
+      )
+    })
+  }, [contacts, query, filter])
+
+  return (
+    <>
+      <MobileHeader
+        pageTitle="Contacts"
+        rightSlot={
+          <Link
+            href="/crm/contacts/new"
+            aria-label="Add contact"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-white"
+          >
+            <UserPlus className="h-4 w-4" />
+          </Link>
+        }
+      />
+      <div className="px-4 pt-4">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search contacts"
+            className="w-full rounded-md border border-border bg-card py-3 pl-10 pr-3 text-[15px] focus-visible:outline-none"
+          />
+        </div>
+      </div>
+      <div className="flex gap-2 overflow-x-auto scrollbar-hide px-4 py-3">
+        {(["all", "lead", "customer"] as Filter[]).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={cn(
+              "rounded-full border px-4 py-1.5 text-[13px] font-medium capitalize whitespace-nowrap",
+              filter === f
+                ? "border-foreground bg-foreground text-background"
+                : "border-border bg-card text-muted-foreground"
+            )}
+          >
+            {f === "all" ? "All" : f === "lead" ? "Leads" : "Customers"}
+          </button>
+        ))}
+      </div>
+      <ul className="flex flex-col divide-y divide-border/40 border-y border-border/40">
+        {filtered.length === 0 && (
+          <li className="px-4 py-12">
+            <div className="ott-empty-state">
+              <p className="ott-empty-state-title">No contacts</p>
+              <p className="ott-empty-state-body">Add a contact to get started.</p>
+            </div>
+          </li>
+        )}
+        {filtered.map((c) => (
+          <li key={c.id}>
+            <Link href={`/crm/contacts/${c.id}`} className="flex items-center gap-3 px-4 py-3.5 active:bg-muted/40">
+              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-muted text-[13px] font-semibold text-foreground">
+                {initials(c.name) || "?"}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[15px] font-semibold text-foreground">{c.name}</p>
+                <p className="truncate text-[12px] text-muted-foreground flex items-center gap-1">
+                  {c.phone ? (
+                    <>
+                      <Phone className="h-3 w-3 shrink-0" /> {c.phone}
+                    </>
+                  ) : c.email ? (
+                    <>
+                      <Mail className="h-3 w-3 shrink-0" /> {c.email}
+                    </>
+                  ) : (
+                    "No contact info"
+                  )}
+                </p>
+              </div>
+              {c.lastActivityDate && (
+                <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                  {formatShortDate(c.lastActivityDate)}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/components/mobile/deals/deal-header-mobile.tsx
+++ b/components/mobile/deals/deal-header-mobile.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import Link from "next/link"
+import { ChevronLeft, Edit } from "lucide-react"
+
+interface DealHeaderMobileProps {
+  title: string
+  stageLabel: string
+  dealId: string
+}
+
+export function DealHeaderMobile({ title, stageLabel, dealId }: DealHeaderMobileProps) {
+  return (
+    <header className="md:hidden sticky top-0 z-30 bg-emerald-900 pt-safe text-white">
+      <div className="flex items-center gap-2 px-2 pb-3 pt-2">
+        <Link
+          href="/crm/dashboard"
+          aria-label="Back to pipeline"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-white"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-bold leading-tight">{title}</p>
+          <p className="text-[12px] text-emerald-200/80">{stageLabel}</p>
+        </div>
+        <Link
+          href={`/crm/deals/${dealId}/edit`}
+          aria-label="Edit deal"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-700/60 text-white"
+        >
+          <Edit className="h-4 w-4" />
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/components/mobile/inbox/inbox-mobile.tsx
+++ b/components/mobile/inbox/inbox-mobile.tsx
@@ -108,7 +108,7 @@ export function InboxMobile({ interactions, contactSegment, userName }: InboxMob
         )}
         {threads.map((a) => {
           const Icon = activityIcon(a.type)
-          const href = a.contactId ? `/crm/inbox?contact=${a.contactId}` : "#"
+          const href = a.contactId ? `/crm/inbox/${a.contactId}` : "#"
           return (
             <li key={a.id}>
               <Link href={href} className="flex items-start gap-3 px-4 py-4 active:bg-muted/40">

--- a/components/mobile/inbox/inbox-mobile.tsx
+++ b/components/mobile/inbox/inbox-mobile.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { Search, MessageSquare, Phone, Mail, StickyNote } from "lucide-react"
+import { ActivityView } from "@/actions/activity-actions"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
+import { formatShortDate, formatTime } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+interface InboxMobileProps {
+  interactions: ActivityView[]
+  contactSegment?: Record<string, "lead" | "existing">
+  userName?: string
+}
+
+type FilterKey = "all" | "lead" | "existing"
+
+const FILTERS: { id: FilterKey; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "lead", label: "Leads" },
+  { id: "existing", label: "Customers" },
+]
+
+function activityIcon(type: string) {
+  const t = type.toUpperCase()
+  if (t === "CALL") return Phone
+  if (t === "EMAIL") return Mail
+  if (t === "NOTE") return StickyNote
+  return MessageSquare
+}
+
+function groupByContact(activities: ActivityView[]): ActivityView[] {
+  const seen = new Set<string>()
+  const result: ActivityView[] = []
+  for (const a of activities) {
+    const key = a.contactId || a.id
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(a)
+  }
+  return result
+}
+
+export function InboxMobile({ interactions, contactSegment, userName }: InboxMobileProps) {
+  const [filter, setFilter] = useState<FilterKey>("all")
+  const [query, setQuery] = useState("")
+
+  const threads = useMemo(() => {
+    const grouped = groupByContact(interactions)
+    return grouped.filter((a) => {
+      if (filter !== "all") {
+        const seg = a.contactId ? contactSegment?.[a.contactId] : "lead"
+        if (seg !== filter) return false
+      }
+      if (query) {
+        const q = query.toLowerCase()
+        return (
+          (a.contactName || "").toLowerCase().includes(q) ||
+          (a.title || "").toLowerCase().includes(q) ||
+          (a.description || "").toLowerCase().includes(q)
+        )
+      }
+      return true
+    })
+  }, [interactions, filter, query, contactSegment])
+
+  return (
+    <>
+      <MobileHeader pageTitle="Inbox" userName={userName} />
+      <div className="px-4 pt-4">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search conversations"
+            className="w-full rounded-md border border-border bg-card py-3 pl-10 pr-3 text-[15px] focus-visible:outline-none"
+          />
+        </div>
+      </div>
+      <div className="flex gap-2 overflow-x-auto scrollbar-hide px-4 py-3">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => setFilter(f.id)}
+            className={cn(
+              "rounded-full border px-4 py-1.5 text-[13px] font-medium whitespace-nowrap",
+              filter === f.id
+                ? "border-foreground bg-foreground text-background"
+                : "border-border bg-card text-muted-foreground"
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+      <ul className="flex flex-col divide-y divide-border/40 border-y border-border/40">
+        {threads.length === 0 && (
+          <li className="px-4 py-12">
+            <div className="ott-empty-state">
+              <p className="ott-empty-state-title">No conversations</p>
+              <p className="ott-empty-state-body">New messages will appear here.</p>
+            </div>
+          </li>
+        )}
+        {threads.map((a) => {
+          const Icon = activityIcon(a.type)
+          const href = a.contactId ? `/crm/inbox?contact=${a.contactId}` : "#"
+          return (
+            <li key={a.id}>
+              <Link href={href} className="flex items-start gap-3 px-4 py-4 active:bg-muted/40">
+                <span className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <Icon className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <p className="truncate text-[15px] font-semibold text-foreground">
+                      {a.contactName || a.title || "Unknown"}
+                    </p>
+                    <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                      {formatShortDate(a.createdAt)} {formatTime(a.createdAt)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 line-clamp-2 text-[13px] text-muted-foreground break-words">
+                    {a.description || a.title}
+                  </p>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}

--- a/components/mobile/inbox/inbox-thread-mobile.tsx
+++ b/components/mobile/inbox/inbox-thread-mobile.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { ChevronLeft, Send, MessageSquare, Bot } from "lucide-react"
+import { ActivityView } from "@/actions/activity-actions"
+import { sendSMS } from "@/actions/messaging-actions"
+import { formatTime, formatShortDate } from "@/lib/format"
+import { cn } from "@/lib/utils"
+import { toast } from "sonner"
+
+type MessageMode = "direct" | "tracey"
+
+interface InboxThreadMobileProps {
+  contactId: string
+  contactName: string
+  contactPhone: string | null
+  activities: ActivityView[]
+  workspaceId: string
+}
+
+function isSameDay(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+}
+
+export function InboxThreadMobile({
+  contactId,
+  contactName,
+  contactPhone,
+  activities,
+  workspaceId,
+}: InboxThreadMobileProps) {
+  const router = useRouter()
+  const [text, setText] = useState("")
+  const [mode, setMode] = useState<MessageMode>("direct")
+  const [sending, setSending] = useState(false)
+  const [optimistic, setOptimistic] = useState<ActivityView[]>([])
+
+  const all = [...activities, ...optimistic].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  )
+
+  const handleSend = async () => {
+    const body = text.trim()
+    if (!body) return
+    setSending(true)
+    setText("")
+
+    if (mode === "direct") {
+      if (!contactPhone) {
+        toast.error("No phone number on file for this contact")
+        setSending(false)
+        return
+      }
+      const temp: ActivityView = {
+        id: `temp-${Date.now()}`,
+        type: "EMAIL",
+        title: "SMS",
+        description: body,
+        body,
+        createdAt: new Date(),
+        contactId,
+        contactName,
+      }
+      setOptimistic((prev) => [...prev, temp])
+      const result = await sendSMS(contactId, body)
+      if (!result.success) toast.error(result.error || "Failed to send")
+    } else {
+      const temp: ActivityView = {
+        id: `temp-${Date.now()}`,
+        type: "NOTE",
+        title: "Tracey",
+        description: body,
+        body,
+        createdAt: new Date(),
+        contactId,
+        contactName,
+      }
+      setOptimistic((prev) => [...prev, temp])
+      await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          workspaceId,
+          messages: [{ role: "user", content: `Contact: ${contactName} (${contactPhone || "no phone"}) — ${body}` }],
+        }),
+      })
+    }
+    setSending(false)
+  }
+
+  return (
+    <div className="flex h-dvh flex-col bg-background pt-safe">
+      <header className="shrink-0 bg-emerald-900 pb-3 pt-2 text-white">
+        <div className="flex items-center gap-2 px-2">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-white"
+            aria-label="Back"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-base font-bold">{contactName}</p>
+            {contactPhone && <p className="text-[12px] text-emerald-200/80">{contactPhone}</p>}
+          </div>
+        </div>
+      </header>
+
+      <ul className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        {all.map((a, i) => {
+          const prev = all[i - 1]
+          const showDate = !prev || !isSameDay(new Date(prev.createdAt), new Date(a.createdAt))
+          const outbound = a.type === "EMAIL" || a.type === "NOTE"
+          return (
+            <li key={a.id}>
+              {showDate && (
+                <p className="text-center text-[11px] text-muted-foreground py-1">
+                  {formatShortDate(a.createdAt)}
+                </p>
+              )}
+              <div className={cn("flex", outbound ? "justify-end" : "justify-start")}>
+                <div className={cn(
+                  "max-w-[78%] rounded-2xl px-3.5 py-2.5 text-[14px]",
+                  outbound
+                    ? "bg-primary text-primary-foreground rounded-br-sm"
+                    : "bg-muted text-foreground rounded-bl-sm"
+                )}>
+                  <p className="break-words">{a.description || a.title}</p>
+                  <p className={cn("mt-1 text-[11px] tabular-nums", outbound ? "text-primary-foreground/60" : "text-muted-foreground")}>
+                    {formatTime(a.createdAt)}
+                  </p>
+                </div>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      <div className="shrink-0 border-t border-border/60 bg-card pb-safe px-3 pt-2">
+        <div className="flex items-center gap-1 mb-2">
+          {(["direct", "tracey"] as MessageMode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-3 py-1 text-[12px] font-medium transition-colors",
+                mode === m ? "bg-foreground text-background" : "text-muted-foreground"
+              )}
+            >
+              {m === "direct" ? <MessageSquare className="h-3 w-3" /> : <Bot className="h-3 w-3" />}
+              {m === "direct" ? "Direct" : "Tell Tracey"}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-end gap-2">
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend() } }}
+            rows={1}
+            placeholder={mode === "direct" ? "Send a message…" : "Ask Tracey to do something…"}
+            className="flex-1 resize-none rounded-2xl border border-border bg-muted/30 px-4 py-2.5 text-[15px] focus-visible:outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={sending || !text.trim()}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground disabled:opacity-40"
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/mobile/map/map-mobile-inner.tsx
+++ b/components/mobile/map/map-mobile-inner.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { MapContainer, TileLayer, Marker, CircleMarker, useMap } from "react-leaflet"
+import "leaflet/dist/leaflet.css"
+import L from "leaflet"
+import { useEffect, useMemo } from "react"
+import type { Job } from "@/components/map/map-view"
+
+const TILE_URL = "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+const TILE_ATTR =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+const DEFAULT_CENTER: [number, number] = [-33.8688, 151.2093]
+
+function getPos(job: Job): [number, number] {
+  if (job.lat != null && job.lng != null) return [job.lat, job.lng]
+  const offset = (job.id.charCodeAt(0) % 10 - 5) * 0.004
+  return [DEFAULT_CENTER[0] + offset, DEFAULT_CENTER[1] + offset]
+}
+
+function makePinIcon(isToday: boolean) {
+  const color = isToday ? "#059669" : "#64748B"
+  const svg = `<svg width="28" height="28" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" fill="${color}"/>
+    <circle cx="12" cy="9" r="2.5" fill="white"/>
+  </svg>`
+  return L.divIcon({
+    html: svg,
+    className: "custom-marker",
+    iconSize: [28, 28],
+    iconAnchor: [14, 28],
+    popupAnchor: [0, -28],
+  })
+}
+
+function FitBounds({ positions }: { positions: [number, number][] }) {
+  const map = useMap()
+  useEffect(() => {
+    if (!positions.length) return
+    map.fitBounds(L.latLngBounds(positions), { padding: [60, 60], maxZoom: 14 })
+  }, [map, positions])
+  return null
+}
+
+function FlyTo({ position }: { position: [number, number] | null }) {
+  const map = useMap()
+  useEffect(() => {
+    if (position) map.flyTo(position, 15, { duration: 0.6 })
+  }, [map, position])
+  return null
+}
+
+interface Props {
+  jobs: Job[]
+  selectedJobId: string | null
+  userPosition: [number, number] | null
+  onSelectJob: (job: Job) => void
+}
+
+export function MapMobileInner({ jobs, selectedJobId, userPosition, onSelectJob }: Props) {
+  const todaySet = useMemo(() => {
+    const s = new Set<string>()
+    const today = new Date().toDateString()
+    jobs.forEach((j) => {
+      if (j.scheduledAt && new Date(j.scheduledAt).toDateString() === today) s.add(j.id)
+    })
+    return s
+  }, [jobs])
+
+  const positions = useMemo(() => jobs.map(getPos), [jobs])
+  const flyTarget = useMemo(() => {
+    const j = jobs.find((x) => x.id === selectedJobId)
+    return j ? getPos(j) : null
+  }, [jobs, selectedJobId])
+
+  return (
+    <MapContainer
+      center={userPosition ?? DEFAULT_CENTER}
+      zoom={12}
+      scrollWheelZoom
+      style={{ height: "100%", width: "100%" }}
+    >
+      <TileLayer attribution={TILE_ATTR} url={TILE_URL} />
+      {!selectedJobId && <FitBounds positions={positions} />}
+      <FlyTo position={flyTarget} />
+      {userPosition && (
+        <CircleMarker
+          center={userPosition}
+          radius={7}
+          pathOptions={{ color: "#4285F4", weight: 2, fillOpacity: 0.2 }}
+        />
+      )}
+      {jobs.map((job) => (
+        <Marker
+          key={job.id}
+          position={getPos(job)}
+          icon={makePinIcon(todaySet.has(job.id))}
+          eventHandlers={{ click: () => onSelectJob(job) }}
+        />
+      ))}
+    </MapContainer>
+  )
+}

--- a/components/mobile/map/map-mobile.tsx
+++ b/components/mobile/map/map-mobile.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useState, useCallback, useEffect } from "react"
+import dynamic from "next/dynamic"
+import { ChevronLeft, LocateFixed, MapPin } from "lucide-react"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import type { Job } from "@/components/map/map-view"
+import { MapPinSheet } from "./map-pin-sheet"
+
+const MapMobileInner = dynamic(
+  () => import("./map-mobile-inner").then((m) => m.MapMobileInner),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full w-full items-center justify-center bg-muted text-sm text-muted-foreground">
+        Loading map…
+      </div>
+    ),
+  },
+)
+
+export function MapMobile({ jobs }: { jobs: Job[] }) {
+  const [selectedJob, setSelectedJob] = useState<Job | null>(null)
+  const [userPosition, setUserPosition] = useState<[number, number] | null>(null)
+  const [locating, setLocating] = useState(false)
+
+  const locateMe = useCallback(() => {
+    if (!navigator.geolocation) return
+    setLocating(true)
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        setUserPosition([coords.latitude, coords.longitude])
+        setLocating(false)
+      },
+      () => setLocating(false),
+      { enableHighAccuracy: true, timeout: 10000 },
+    )
+  }, [])
+
+  useEffect(() => {
+    const nav = navigator as Navigator & { permissions?: Permissions }
+    nav.permissions
+      ?.query({ name: "geolocation" as PermissionName })
+      .then((s) => { if (s.state === "granted") locateMe() })
+      .catch(() => {})
+  }, [locateMe])
+
+  const todayCount = jobs.filter((j) => {
+    const d = j.scheduledAt ? new Date(j.scheduledAt) : null
+    return d && d.toDateString() === new Date().toDateString()
+  }).length
+
+  return (
+    <div className="fixed inset-0 z-[200] flex flex-col md:hidden">
+      {/* Green header */}
+      <div className="shrink-0 bg-emerald-900 pt-safe text-white">
+        <div className="flex items-center gap-2 px-2 pb-3 pt-2">
+          <Link
+            href="/crm/dashboard"
+            aria-label="Back to pipeline"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-white"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <div className="min-w-0 flex-1">
+            <p className="text-base font-bold leading-tight">Map</p>
+            <p className="text-[12px] text-emerald-200/80">
+              {todayCount > 0 ? `${todayCount} job${todayCount === 1 ? "" : "s"} today` : "No jobs today"}
+            </p>
+          </div>
+          {jobs.length > 0 && (
+            <span className="flex items-center gap-1 rounded-full bg-emerald-700/60 px-2.5 py-1 text-[12px] font-semibold">
+              <MapPin className="h-3 w-3" />
+              {jobs.length}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Full-bleed map */}
+      <div className="relative min-h-0 flex-1">
+        <MapMobileInner
+          jobs={jobs}
+          selectedJobId={selectedJob?.id ?? null}
+          userPosition={userPosition}
+          onSelectJob={setSelectedJob}
+        />
+
+        {/* Locate-me overlay */}
+        <button
+          type="button"
+          onClick={locateMe}
+          disabled={locating}
+          aria-label={locating ? "Locating…" : "My location"}
+          className={cn(
+            "absolute right-4 top-4 z-[1000] flex items-center gap-2 rounded-md border border-border bg-card/95 px-3 py-2 shadow-lg",
+            locating && "opacity-50",
+          )}
+        >
+          <LocateFixed className={cn("h-4 w-4 text-blue-600", locating && "animate-spin")} />
+          <span className="text-xs font-semibold text-muted-foreground">{locating ? "Locating…" : "My Location"}</span>
+        </button>
+      </div>
+
+      <MapPinSheet
+        job={selectedJob}
+        open={!!selectedJob}
+        onOpenChange={(open) => { if (!open) setSelectedJob(null) }}
+      />
+    </div>
+  )
+}

--- a/components/mobile/map/map-pin-sheet.tsx
+++ b/components/mobile/map/map-pin-sheet.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Clock, ExternalLink, MapPin, Navigation } from "lucide-react"
+import Link from "next/link"
+import { formatDate, formatTime } from "@/lib/format"
+import type { Job } from "@/components/map/map-view"
+
+interface MapPinSheetProps {
+  job: Job | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function MapPinSheet({ job, open, onOpenChange }: MapPinSheetProps) {
+  if (!job) return null
+
+  function openNav() {
+    window.open(
+      `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(job!.address)}&travelmode=driving`,
+      "_blank",
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="rounded-t-2xl pb-safe px-0 max-h-[55dvh]">
+        <div className="px-4 pb-4 pt-2">
+          <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-muted-foreground/20" />
+
+          <h2 className="app-section-title mb-0.5 truncate min-w-0">{job.clientName}</h2>
+          <p className="app-body-secondary truncate min-w-0">{job.title}</p>
+
+          <div className="mt-4 space-y-2 rounded-md bg-muted/30 p-3">
+            <div className="flex items-start gap-2">
+              <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="app-body-secondary break-words min-w-0">{job.address}</span>
+            </div>
+            {job.scheduledAt && (
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="app-body-secondary">
+                  {formatDate(job.scheduledAt)} · {formatTime(job.scheduledAt)}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-4 flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={openNav}
+              className="flex w-full items-center justify-center gap-2 rounded-md bg-primary py-3 text-sm font-semibold text-primary-foreground"
+            >
+              <Navigation className="h-4 w-4" />
+              Navigate
+            </button>
+            <Link
+              href={`/crm/deals/${job.id}`}
+              className="flex w-full items-center justify-center gap-2 rounded-md border border-border bg-card py-3 text-sm font-semibold text-foreground"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View Job
+            </Link>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/mobile/pipeline/pipeline-deal-list.tsx
+++ b/components/mobile/pipeline/pipeline-deal-list.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import Link from "next/link"
+import { MapPin, User } from "lucide-react"
+import { DealView } from "@/actions/deal-actions"
+import { formatCurrency } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+interface PipelineDealListProps {
+  deals: DealView[]
+}
+
+const STATUS_BADGES: Record<string, { label: string; className: string }> = {
+  urgent: { label: "URGENT", className: "bg-destructive text-destructive-foreground" },
+  sent: { label: "SENT", className: "bg-amber-100 text-amber-800" },
+  scheduled: { label: "BOOKED", className: "bg-emerald-100 text-emerald-800" },
+  paid: { label: "PAID", className: "bg-emerald-600 text-white" },
+}
+
+function inferBadge(deal: DealView) {
+  if (deal.agentFlags?.includes("urgent")) return STATUS_BADGES.urgent
+  if ((deal.health || "").toLowerCase() === "critical") return STATUS_BADGES.urgent
+  if (deal.stage === "quote_sent") return STATUS_BADGES.sent
+  if (deal.stage === "scheduled") return STATUS_BADGES.scheduled
+  if (deal.stage === "completed") return STATUS_BADGES.paid
+  return null
+}
+
+export function PipelineDealList({ deals }: PipelineDealListProps) {
+  if (deals.length === 0) {
+    return (
+      <div className="px-4 pt-6">
+        <div className="ott-empty-state">
+          <p className="ott-empty-state-title">No jobs in this stage</p>
+          <p className="ott-empty-state-body">New leads will appear here as they come in.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-3 px-4 pt-3 pb-6">
+      {deals.map((deal) => {
+        const badge = inferBadge(deal)
+        return (
+          <li key={deal.id}>
+            <Link
+              href={`/crm/deals/${deal.id}`}
+              className="block overflow-hidden rounded-md border border-border bg-card shadow-sm active:opacity-80"
+            >
+              <div className="px-4 pt-4 pb-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="app-panel-title truncate">{deal.contactName || deal.company}</p>
+                    <p className="app-body-primary mt-0.5 truncate">{deal.title}</p>
+                  </div>
+                  {deal.metadata && typeof (deal.metadata as Record<string, unknown>).hint === "string" && (
+                    <span className="app-body-secondary shrink-0 text-right text-[12px] max-w-[6.5rem]">
+                      {(deal.metadata as Record<string, string>).hint}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 flex items-center gap-3 text-[12px] text-muted-foreground">
+                  {deal.address && (
+                    <span className="flex items-center gap-1 truncate min-w-0">
+                      <MapPin className="h-3.5 w-3.5 text-rose-500 shrink-0" />
+                      <span className="truncate">{deal.address.split(",")[0]}</span>
+                    </span>
+                  )}
+                  {deal.assignedToName && (
+                    <span className="flex items-center gap-1 truncate min-w-0">
+                      <User className="h-3.5 w-3.5 text-violet-500 shrink-0" />
+                      <span className="truncate">{deal.assignedToName.split(" ")[0]}</span>
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center justify-between border-t border-border/60 px-4 py-2.5">
+                <span className="text-[15px] font-semibold tabular-nums text-foreground">
+                  {formatCurrency(deal.value || 0)}
+                </span>
+                {badge && (
+                  <span
+                    className={cn(
+                      "rounded-md px-2.5 py-1 text-[11px] font-bold tracking-wider",
+                      badge.className
+                    )}
+                  >
+                    {badge.label}
+                  </span>
+                )}
+              </div>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/mobile/pipeline/pipeline-mobile.tsx
+++ b/components/mobile/pipeline/pipeline-mobile.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import Link from "next/link"
 import { Plus } from "lucide-react"
-import { DealView, WorkspaceView } from "@/actions/deal-actions"
+import { DealView } from "@/actions/deal-actions"
+import { WorkspaceView } from "@/actions/workspace-actions"
 import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
 import { DashboardKpiCards } from "@/components/dashboard/dashboard-kpi-cards"
 import { PipelineStageChips, PIPELINE_STAGES } from "./pipeline-stage-chips"
@@ -14,10 +16,9 @@ interface PipelineMobileProps {
   workspace: WorkspaceView
   deals: DealView[]
   userName: string
-  onAddDeal?: () => void
 }
 
-export function PipelineMobile({ workspace, deals, userName, onAddDeal }: PipelineMobileProps) {
+export function PipelineMobile({ workspace, deals, userName }: PipelineMobileProps) {
   const [activeStage, setActiveStage] = useState<string>(PIPELINE_STAGES[0].id)
 
   const dealsByStage = useMemo(() => {
@@ -78,14 +79,13 @@ export function PipelineMobile({ workspace, deals, userName, onAddDeal }: Pipeli
               </span>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={onAddDeal}
+          <Link
+            href="/crm/deals/new"
             aria-label="Add deal"
             className="flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-md"
           >
             <Plus className="h-5 w-5" />
-          </button>
+          </Link>
         </div>
       </div>
 

--- a/components/mobile/pipeline/pipeline-mobile.tsx
+++ b/components/mobile/pipeline/pipeline-mobile.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Plus } from "lucide-react"
+import { DealView, WorkspaceView } from "@/actions/deal-actions"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
+import { DashboardKpiCards } from "@/components/dashboard/dashboard-kpi-cards"
+import { PipelineStageChips, PIPELINE_STAGES } from "./pipeline-stage-chips"
+import { PipelineDealList } from "./pipeline-deal-list"
+import { formatCurrency } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+interface PipelineMobileProps {
+  workspace: WorkspaceView
+  deals: DealView[]
+  userName: string
+  onAddDeal?: () => void
+}
+
+export function PipelineMobile({ workspace, deals, userName, onAddDeal }: PipelineMobileProps) {
+  const [activeStage, setActiveStage] = useState<string>(PIPELINE_STAGES[0].id)
+
+  const dealsByStage = useMemo(() => {
+    const map = new Map<string, DealView[]>()
+    for (const stage of PIPELINE_STAGES) map.set(stage.id, [])
+    for (const deal of deals) {
+      const key = (deal.stage || "new_request").toLowerCase()
+      const list = map.get(key)
+      if (list) list.push(deal)
+    }
+    return map
+  }, [deals])
+
+  const stageCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const [id, list] of dealsByStage) counts[id] = list.length
+    return counts
+  }, [dealsByStage])
+
+  const activeStageMeta = PIPELINE_STAGES.find((s) => s.id === activeStage) ?? PIPELINE_STAGES[0]
+  const activeDeals = dealsByStage.get(activeStage) ?? []
+  const activeTotal = activeDeals.reduce((sum, d) => sum + (d.value || 0), 0)
+
+  return (
+    <>
+      <MobileHeader
+        pageTitle="Dashboard"
+        userName={userName}
+        workspaceInitial={workspace.name?.[0] ?? userName?.[0]}
+      />
+
+      <div className="px-4 pt-4 pb-2">
+        <DashboardKpiCards deals={deals} />
+      </div>
+
+      <PipelineStageChips
+        activeId={activeStage}
+        counts={stageCounts}
+        onSelect={setActiveStage}
+      />
+
+      <div className="px-4 pt-2">
+        <div
+          className={cn(
+            "rounded-md border border-border bg-card p-4 shadow-sm",
+            "flex items-center justify-between gap-3"
+          )}
+          style={{ borderLeft: `4px solid ${activeStageMeta.accent}` }}
+        >
+          <div className="min-w-0 flex-1">
+            <p className="app-micro-label text-muted-foreground">{activeStageMeta.label}</p>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold tabular-nums text-foreground">
+                {formatCurrency(activeTotal)}
+              </span>
+              <span className="app-body-secondary">
+                {activeDeals.length} {activeDeals.length === 1 ? "job" : "jobs"}
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onAddDeal}
+            aria-label="Add deal"
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-md"
+          >
+            <Plus className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      <PipelineDealList deals={activeDeals} />
+    </>
+  )
+}

--- a/components/mobile/pipeline/pipeline-stage-chips.tsx
+++ b/components/mobile/pipeline/pipeline-stage-chips.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+export const PIPELINE_STAGES: { id: string; label: string; accent: string }[] = [
+  { id: "new_request", label: "New request", accent: "rgb(59 130 246)" },
+  { id: "quote_sent", label: "Quote sent", accent: "rgb(245 158 11)" },
+  { id: "scheduled", label: "Scheduled", accent: "rgb(16 185 129)" },
+  { id: "ready_to_invoice", label: "Awaiting", accent: "rgb(168 85 247)" },
+  { id: "completed", label: "Complete", accent: "rgb(100 116 139)" },
+]
+
+interface PipelineStageChipsProps {
+  activeId: string
+  counts: Record<string, number>
+  onSelect: (id: string) => void
+}
+
+export function PipelineStageChips({ activeId, counts, onSelect }: PipelineStageChipsProps) {
+  return (
+    <div className="overflow-x-auto scrollbar-hide px-4 py-3">
+      <div className="flex w-max items-center gap-2">
+        {PIPELINE_STAGES.map((stage) => {
+          const active = stage.id === activeId
+          const count = counts[stage.id] ?? 0
+          return (
+            <button
+              key={stage.id}
+              type="button"
+              onClick={() => onSelect(stage.id)}
+              aria-pressed={active}
+              className={cn(
+                "flex items-center gap-2 rounded-full border px-3.5 py-2 text-[13px] font-medium transition-colors whitespace-nowrap",
+                active
+                  ? "border-border bg-card text-foreground shadow-sm"
+                  : "border-transparent bg-muted/40 text-muted-foreground"
+              )}
+            >
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: stage.accent }}
+                aria-hidden
+              />
+              <span>{stage.label}</span>
+              <span
+                className={cn(
+                  "tabular-nums text-[12px]",
+                  active ? "text-muted-foreground" : "text-muted-foreground/70"
+                )}
+              >
+                {count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/mobile/schedule/schedule-mobile.tsx
+++ b/components/mobile/schedule/schedule-mobile.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { ChevronLeft, ChevronRight, MapPin } from "lucide-react"
+import { DealView } from "@/actions/deal-actions"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
+import { formatTime, formatShortDate } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+interface ScheduleMobileProps {
+  deals: DealView[]
+  userName?: string
+}
+
+function startOfDay(d: Date) {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+function addDays(d: Date, n: number) {
+  const x = new Date(d)
+  x.setDate(x.getDate() + n)
+  return x
+}
+
+function sameDay(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+}
+
+export function ScheduleMobile({ deals, userName }: ScheduleMobileProps) {
+  const [cursor, setCursor] = useState<Date>(() => startOfDay(new Date()))
+
+  const days = useMemo(() => {
+    const start = addDays(cursor, -3)
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i))
+  }, [cursor])
+
+  const dayDeals = useMemo(() => {
+    return deals
+      .filter((d) => d.scheduledAt && sameDay(new Date(d.scheduledAt), cursor))
+      .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
+  }, [deals, cursor])
+
+  const unscheduledCount = deals.filter((d) => !d.scheduledAt && d.stage !== "completed").length
+
+  return (
+    <>
+      <MobileHeader pageTitle="Schedule" userName={userName} dateLabel={formatShortDate(cursor)} />
+
+      <div className="flex items-center justify-between px-4 pt-4">
+        <button
+          type="button"
+          onClick={() => setCursor(addDays(cursor, -1))}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/50 text-muted-foreground"
+          aria-label="Previous day"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setCursor(startOfDay(new Date()))}
+          className="text-[13px] font-medium text-muted-foreground"
+        >
+          Today
+        </button>
+        <button
+          type="button"
+          onClick={() => setCursor(addDays(cursor, 1))}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/50 text-muted-foreground"
+          aria-label="Next day"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="overflow-x-auto scrollbar-hide px-4 py-4">
+        <div className="flex gap-2">
+          {days.map((d) => {
+            const active = sameDay(d, cursor)
+            const isToday = sameDay(d, new Date())
+            return (
+              <button
+                key={d.toISOString()}
+                type="button"
+                onClick={() => setCursor(d)}
+                className={cn(
+                  "flex h-16 w-12 shrink-0 flex-col items-center justify-center rounded-md border",
+                  active ? "border-foreground bg-foreground text-background" : "border-border bg-card text-foreground"
+                )}
+              >
+                <span className={cn("text-[10px] uppercase tracking-wide", active ? "text-background/70" : "text-muted-foreground")}>
+                  {d.toLocaleDateString("en-AU", { weekday: "short" }).slice(0, 3)}
+                </span>
+                <span className="text-lg font-bold tabular-nums leading-tight">{d.getDate()}</span>
+                {isToday && !active && <span className="mt-0.5 h-1 w-1 rounded-full bg-primary" />}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="px-4">
+        {dayDeals.length === 0 ? (
+          <div className="ott-empty-state">
+            <p className="ott-empty-state-title">Nothing scheduled</p>
+            <p className="ott-empty-state-body">
+              {unscheduledCount > 0
+                ? `${unscheduledCount} job${unscheduledCount === 1 ? "" : "s"} waiting to be booked.`
+                : "Enjoy the day."}
+            </p>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-3 pb-6">
+            {dayDeals.map((deal) => (
+              <li key={deal.id}>
+                <Link
+                  href={`/crm/deals/${deal.id}`}
+                  className="flex items-stretch gap-3 rounded-md border border-border bg-card p-3 shadow-sm active:opacity-80"
+                >
+                  <span className="flex w-16 shrink-0 flex-col items-center justify-center rounded-md bg-muted/40 text-foreground">
+                    <span className="text-[15px] font-bold tabular-nums">{formatTime(deal.scheduledAt!)}</span>
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[15px] font-semibold text-foreground">
+                      {deal.contactName || deal.company}
+                    </p>
+                    <p className="truncate text-[13px] text-muted-foreground">{deal.title}</p>
+                    {deal.address && (
+                      <p className="mt-1 flex items-center gap-1 truncate text-[12px] text-muted-foreground">
+                        <MapPin className="h-3 w-3 text-rose-500 shrink-0" />
+                        <span className="truncate">{deal.address.split(",")[0]}</span>
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}

--- a/components/mobile/settings/settings-index-mobile.tsx
+++ b/components/mobile/settings/settings-index-mobile.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import Link from "next/link"
+import { ChevronRight, User, Building2, Phone, Bot, Plug, Bell, CreditCard, Palette, ShieldCheck, LifeBuoy } from "lucide-react"
+import { useShellStore } from "@/lib/store"
+import { MobileHeader } from "@/components/mobile/_primitives/mobile-header"
+
+type SettingsItem = {
+  title: string
+  href: string
+  icon: typeof User
+  subtitle?: string
+  managerOnly?: boolean
+}
+
+const ITEMS: SettingsItem[] = [
+  { title: "Account", href: "/crm/settings", icon: User, subtitle: "Profile and security" },
+  { title: "My business", href: "/crm/settings/my-business", icon: Building2, subtitle: "Trading name, hours, location" },
+  { title: "Calls & texting", href: "/crm/settings/call-settings", icon: Phone, subtitle: "Number, routing, hours" },
+  { title: "AI Assistant", href: "/crm/settings/agent", icon: Bot, subtitle: "Tracey behaviour and rules" },
+  { title: "Integrations", href: "/crm/settings/integrations", icon: Plug, subtitle: "Connect external tools", managerOnly: true },
+  { title: "Notifications", href: "/crm/settings/notifications", icon: Bell },
+  { title: "Billing", href: "/crm/settings/billing", icon: CreditCard, subtitle: "Plan and invoices", managerOnly: true },
+  { title: "Display", href: "/crm/settings/display", icon: Palette },
+  { title: "Data & privacy", href: "/crm/settings/privacy", icon: ShieldCheck },
+  { title: "Help", href: "/crm/settings/help", icon: LifeBuoy },
+]
+
+export function SettingsIndexMobile() {
+  const userRole = useShellStore((s) => s.userRole)
+  const isManager = userRole === "OWNER" || userRole === "MANAGER"
+  const items = ITEMS.filter((i) => !i.managerOnly || isManager)
+
+  return (
+    <>
+      <MobileHeader pageTitle="Settings" />
+      <ul className="flex flex-col divide-y divide-border/40 border-y border-border/40">
+        {items.map((item) => {
+          const Icon = item.icon
+          return (
+            <li key={item.href}>
+              <Link href={item.href} className="flex items-center gap-3 px-4 py-4 active:bg-muted/40">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <Icon className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[15px] font-semibold text-foreground">{item.title}</p>
+                  {item.subtitle && (
+                    <p className="truncate text-[12px] text-muted-foreground">{item.subtitle}</p>
+                  )}
+                </div>
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}

--- a/components/mobile/settings/settings-sub-mobile.tsx
+++ b/components/mobile/settings/settings-sub-mobile.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { ChevronLeft } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const TITLES: Record<string, string> = {
+  "/crm/settings": "Account",
+  "/crm/settings/account": "Account",
+  "/crm/settings/my-business": "My business",
+  "/crm/settings/call-settings": "Calls & texting",
+  "/crm/settings/phone-settings": "Phone",
+  "/crm/settings/agent": "AI Assistant",
+  "/crm/settings/ai-voice": "AI Voice",
+  "/crm/settings/after-hours": "After hours",
+  "/crm/settings/integrations": "Integrations",
+  "/crm/settings/automations": "Automations",
+  "/crm/settings/notifications": "Notifications",
+  "/crm/settings/billing": "Billing",
+  "/crm/settings/display": "Display",
+  "/crm/settings/appearance": "Appearance",
+  "/crm/settings/privacy": "Data & privacy",
+  "/crm/settings/data-privacy": "Data & privacy",
+  "/crm/settings/help": "Help",
+  "/crm/settings/support": "Support",
+  "/crm/settings/training": "Training",
+  "/crm/settings/knowledge": "Knowledge",
+  "/crm/settings/workspace": "Workspace",
+  "/crm/settings/sms-templates": "SMS templates",
+}
+
+export function SettingsSubMobile({ children, className }: { children: React.ReactNode; className?: string }) {
+  const pathname = usePathname()
+  const title = TITLES[pathname] || "Settings"
+
+  return (
+    <div className="md:hidden">
+      <header className="sticky top-0 z-30 bg-emerald-900 pt-safe text-white">
+        <div className="flex items-center gap-2 px-2 pb-3 pt-2">
+          <Link
+            href="/crm/settings"
+            aria-label="Back to settings"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-white"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="truncate text-lg font-bold">{title}</h1>
+        </div>
+      </header>
+      <div className={cn("px-4 pt-4 pb-6", className)}>{children}</div>
+    </div>
+  )
+}

--- a/hooks/use-is-mobile.ts
+++ b/hooks/use-is-mobile.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+const MOBILE_QUERY = "(max-width: 767px)"
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false
+    return window.matchMedia(MOBILE_QUERY).matches
+  })
+
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY)
+    const handler = (event: MediaQueryListEvent) => setIsMobile(event.matches)
+    setIsMobile(mq.matches)
+    mq.addEventListener("change", handler)
+    return () => mq.removeEventListener("change", handler)
+  }, [])
+
+  return isMobile
+}


### PR DESCRIPTION
## Summary

7 commits adding a complete mobile-native layer to the app. Desktop UI is untouched — each page branches on `useIsMobile()`.

- **Mobile primitives**: `MobileShell`, bottom tab bar (Pipeline · Inbox · Tracey · Schedule · More), branded `MobileHeader`, More sheet with manager-only gating, safe-area CSS tokens
- **ShellHost routing**: `/crm/*`, `/tradie/*`, `/agent/*` on mobile viewports use `MobileShell` instead of the desktop `Shell`
- **Pipeline mobile**: KPI cards, stage chips, single-stage summary, vertical deal list; "+ Add" wired to `/crm/deals/new`
- **Inbox, Schedule, Contacts, Settings**: full mobile views with drill-in patterns, day-focused agenda, card lists
- **Mobile inbox thread**: full-screen route `/crm/inbox/[contactId]` with sticky composer (SMS / Tell Tracey toggle)
- **Deal header**: sticky green `DealHeaderMobile` on deal detail pages
- **Full-bleed map**: fixed `inset-0` mobile map with pin bottom sheet (Navigate + View Job), auto-locate on permission grant
- **Remaining pages**: `MobileHeader` injected into Analytics, Team, Estimator, Estimator, Contacts detail/new/edit, Deals new/edit

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4QCxJJVmMSGpwuuKahAjR)_