### PR TITLE
Add support ticket workflow with status, SLA & admin view

### DIFF
--- a/app/admin/customer-usage/page.tsx
+++ b/app/admin/customer-usage/page.tsx
@@ -961,6 +961,12 @@ export default async function CustomerUsagePage({
             {label}
           </Link>
         ))}
+        <Link
+          href="/admin/support"
+          className="inline-flex h-10 items-center rounded-full px-4 text-sm font-medium border border-border text-foreground"
+        >
+          Support tickets
+        </Link>
       </div>
 
       {filters.tab === "overview" ? (

--- a/app/admin/support/page.tsx
+++ b/app/admin/support/page.tsx
@@ -1,0 +1,54 @@
+import { requireInternalAdminAccess } from "@/lib/internal-admin";
+import { db } from "@/lib/db";
+import { SupportTicketAdminTable } from "@/components/admin/support-ticket-table";
+
+export const dynamic = "force-dynamic";
+
+export default async function SupportAdminPage() {
+  await requireInternalAdminAccess();
+
+  const raw = await db.supportTicket.findMany({
+    include: {
+      workspace: { select: { id: true, name: true } },
+      user: { select: { email: true, name: true } },
+      notes: {
+        orderBy: { createdAt: "asc" },
+        select: { id: true, content: true, createdAt: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 500,
+  });
+
+  const tickets = raw.map((t) => ({
+    id: t.id,
+    ref: t.ref,
+    subject: t.subject,
+    message: t.message,
+    priority: t.priority,
+    status: t.status,
+    source: t.source,
+    slaDeadline: t.slaDeadline.toISOString(),
+    resolvedAt: t.resolvedAt?.toISOString() ?? null,
+    createdAt: t.createdAt.toISOString(),
+    workspace: t.workspace,
+    user: t.user,
+    notes: t.notes.map((n) => ({ ...n, createdAt: n.createdAt.toISOString() })),
+  }));
+
+  const openCount = tickets.filter((t) => t.status === "OPEN").length;
+
+  return (
+    <div className="mx-auto max-w-[1600px] space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          Support tickets
+        </h1>
+        <p className="app-body-secondary">
+          {tickets.length} total · {openCount} open
+        </p>
+      </div>
+      <SupportTicketAdminTable tickets={tickets} />
+    </div>
+  );
+}

--- a/app/api/admin/support-tickets/[id]/route.ts
+++ b/app/api/admin/support-tickets/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { isInternalAdminEmail } from "@/lib/internal-admin";
+import { db } from "@/lib/db";
+
+const VALID_STATUSES = ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED"] as const;
+type TicketStatus = (typeof VALID_STATUSES)[number];
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authUser = await getAuthUser();
+  if (!authUser || !isInternalAdminEmail(authUser.email)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  const status = body.status as TicketStatus;
+
+  if (!VALID_STATUSES.includes(status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  try {
+    const ticket = await db.supportTicket.update({
+      where: { id },
+      data: {
+        status,
+        resolvedAt: status === "RESOLVED" || status === "CLOSED" ? new Date() : null,
+      },
+    });
+    return NextResponse.json({ ticket });
+  } catch {
+    return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+  }
+}

--- a/app/api/support/tickets/[id]/route.ts
+++ b/app/api/support/tickets/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
+import { updateSupportTicketStatus } from "@/lib/support-tickets";
+
+const VALID_STATUSES = ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED"] as const;
+type TicketStatus = (typeof VALID_STATUSES)[number];
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireCurrentWorkspaceAccess();
+    const { id } = await params;
+    const body = await request.json();
+    const status = body.status as TicketStatus;
+
+    if (!VALID_STATUSES.includes(status)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+
+    const ticket = await updateSupportTicketStatus(id, actor.workspaceId, status);
+    return NextResponse.json({ ticket });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === "Unauthorized" || error.message === "Workspace access not found")
+    ) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Failed to update ticket" }, { status: 500 });
+  }
+}

--- a/app/api/support/tickets/route.ts
+++ b/app/api/support/tickets/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { requireCurrentWorkspaceAccess } from "@/lib/workspace-access";
+import { getSupportTickets } from "@/lib/support-tickets";
+
+export async function GET() {
+  try {
+    const actor = await requireCurrentWorkspaceAccess();
+    const tickets = await getSupportTickets(actor.workspaceId, actor.id);
+    return NextResponse.json({ tickets });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === "Unauthorized" || error.message === "Workspace access not found")
+    ) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Failed to fetch tickets" }, { status: 500 });
+  }
+}

--- a/components/admin/support-ticket-table.tsx
+++ b/components/admin/support-ticket-table.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { formatShortDate } from "@/lib/format";
+
+type Note = { id: string; content: string; createdAt: string };
+type Ticket = {
+  id: string; ref: string; subject: string; message: string;
+  priority: string; status: string; source: string;
+  slaDeadline: string; resolvedAt: string | null; createdAt: string;
+  workspace: { id: string; name: string };
+  user: { email: string; name: string | null };
+  notes: Note[];
+};
+
+const STATUS_OPTIONS = ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED"] as const;
+type Status = (typeof STATUS_OPTIONS)[number];
+const STATUS_LABELS: Record<Status, string> = { OPEN: "Open", IN_PROGRESS: "In progress", RESOLVED: "Resolved", CLOSED: "Closed" };
+const PRIORITY_VARIANT: Record<string, "destructive" | "default" | "secondary" | "outline"> = {
+  urgent: "destructive", high: "default", medium: "secondary", low: "outline",
+};
+
+function slaLabel(t: Ticket) {
+  if (t.status === "RESOLVED" || t.status === "CLOSED") return "—";
+  const h = Math.round((new Date(t.slaDeadline).getTime() - Date.now()) / 3_600_000);
+  return h < 0 ? "Overdue" : h < 1 ? "< 1 hr" : `${h}h`;
+}
+
+function slaClass(t: Ticket) {
+  if (t.status === "RESOLVED" || t.status === "CLOSED") return "text-muted-foreground";
+  const h = (new Date(t.slaDeadline).getTime() - Date.now()) / 3_600_000;
+  return h < 0 ? "text-destructive font-medium" : h < 4 ? "text-amber-600 font-medium" : "text-muted-foreground";
+}
+
+export function SupportTicketAdminTable({ tickets: initial }: { tickets: Ticket[] }) {
+  const [tickets, setTickets] = useState(initial);
+  const [filter, setFilter] = useState<Status | "ALL">("ALL");
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  const visible = filter === "ALL" ? tickets : tickets.filter((t) => t.status === filter);
+  const counts = Object.fromEntries(STATUS_OPTIONS.map((s) => [s, tickets.filter((t) => t.status === s).length]));
+
+  async function updateStatus(id: string, status: Status) {
+    setUpdating(id);
+    try {
+      const res = await fetch(`/api/admin/support-tickets/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (res.ok) setTickets((prev) => prev.map((t) => (t.id === id ? { ...t, status } : t)));
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {(["ALL", ...STATUS_OPTIONS] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => setFilter(s)}
+            className={`inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-sm font-medium transition-colors ${filter === s ? "bg-foreground text-background" : "border border-border text-muted-foreground hover:text-foreground"}`}
+          >
+            {s === "ALL" ? "All" : STATUS_LABELS[s]}
+            <span className="text-xs opacity-60">{s === "ALL" ? tickets.length : counts[s]}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-md border border-border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-28">Ref</TableHead>
+              <TableHead>Subject</TableHead>
+              <TableHead className="w-20">Priority</TableHead>
+              <TableHead className="w-36">Status</TableHead>
+              <TableHead className="w-20">SLA</TableHead>
+              <TableHead className="w-40">Workspace</TableHead>
+              <TableHead className="w-48">User</TableHead>
+              <TableHead className="w-24">Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visible.length === 0 && (
+              <TableRow><TableCell colSpan={8} className="text-center text-muted-foreground py-8">No tickets</TableCell></TableRow>
+            )}
+            {visible.map((t) => (
+              <>
+                <TableRow
+                  key={t.id}
+                  className="cursor-pointer hover:bg-muted/40"
+                  onClick={() => setExpanded(expanded === t.id ? null : t.id)}
+                >
+                  <TableCell className="font-mono text-xs">{t.ref}</TableCell>
+                  <TableCell className="font-medium max-w-xs truncate">{t.subject}</TableCell>
+                  <TableCell><Badge variant={PRIORITY_VARIANT[t.priority] ?? "outline"}>{t.priority}</Badge></TableCell>
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    <select
+                      value={t.status}
+                      disabled={updating === t.id}
+                      onChange={(e) => updateStatus(t.id, e.target.value as Status)}
+                      className="text-sm rounded border border-border bg-background px-2 py-1"
+                    >
+                      {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{STATUS_LABELS[s]}</option>)}
+                    </select>
+                  </TableCell>
+                  <TableCell className={slaClass(t)}>{slaLabel(t)}</TableCell>
+                  <TableCell className="text-sm truncate max-w-[160px]">{t.workspace.name}</TableCell>
+                  <TableCell className="text-sm text-muted-foreground truncate max-w-[192px]">{t.user.email}</TableCell>
+                  <TableCell className="text-sm text-muted-foreground">{formatShortDate(new Date(t.createdAt))}</TableCell>
+                </TableRow>
+                {expanded === t.id && (
+                  <TableRow key={`${t.id}-detail`} className="bg-muted/20">
+                    <TableCell colSpan={8} className="py-4 px-6">
+                      <div className="space-y-3 text-sm">
+                        <div>
+                          <p className="app-field-label mb-1">Message</p>
+                          <p className="whitespace-pre-wrap text-foreground">{t.message}</p>
+                        </div>
+                        {t.notes.length > 0 && (
+                          <div>
+                            <p className="app-field-label mb-1">Notes ({t.notes.length})</p>
+                            <div className="space-y-2">
+                              {t.notes.map((n) => (
+                                <div key={n.id} className="rounded border border-border bg-card px-3 py-2">
+                                  <p className="whitespace-pre-wrap">{n.content}</p>
+                                  <p className="text-xs text-muted-foreground mt-1">{formatShortDate(new Date(n.createdAt))}</p>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/support-request-panel.tsx
+++ b/components/settings/support-request-panel.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { SupportTicketList } from "@/components/settings/support-ticket-list"
 
 export function SupportRequestPanel() {
   const [loading, setLoading] = useState(false)
@@ -67,6 +68,7 @@ export function SupportRequestPanel() {
 
   return (
     <div className="space-y-6">
+      <SupportTicketList />
       <Card id="support-request">
         <CardHeader>
           <CardTitle>Support request</CardTitle>

--- a/components/settings/support-ticket-list.tsx
+++ b/components/settings/support-ticket-list.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { CheckCircle } from "lucide-react"
+
+type Ticket = {
+  id: string
+  ref: string
+  subject: string
+  priority: string
+  status: string
+  slaDeadline: string
+  resolvedAt: string | null
+  createdAt: string
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  OPEN: "Open",
+  IN_PROGRESS: "In progress",
+  RESOLVED: "Resolved",
+  CLOSED: "Closed",
+}
+
+const PRIORITY_LABELS: Record<string, string> = {
+  urgent: "Urgent",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+}
+
+function slaLabel(ticket: Ticket): string {
+  if (ticket.status === "RESOLVED" || ticket.status === "CLOSED") return "Resolved"
+  const deadline = new Date(ticket.slaDeadline)
+  const hoursLeft = Math.round((deadline.getTime() - Date.now()) / 3_600_000)
+  if (hoursLeft < 0) return "Overdue"
+  if (hoursLeft < 1) return "< 1 hr"
+  return `${hoursLeft}h remaining`
+}
+
+export function SupportTicketList() {
+  const [tickets, setTickets] = useState<Ticket[]>([])
+  const [loading, setLoading] = useState(true)
+  const [closing, setClosing] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch("/api/support/tickets")
+      .then((r) => r.json())
+      .then((d) => setTickets(d.tickets ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function closeTicket(id: string) {
+    setClosing(id)
+    try {
+      const res = await fetch(`/api/support/tickets/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "CLOSED" }),
+      })
+      if (res.ok) {
+        setTickets((prev) =>
+          prev.map((t) => (t.id === id ? { ...t, status: "CLOSED" } : t)),
+        )
+      }
+    } finally {
+      setClosing(null)
+    }
+  }
+
+  const open = tickets.filter((t) => t.status !== "CLOSED")
+  if (loading || open.length === 0) return null
+
+  return (
+    <div className="space-y-2">
+      <p className="app-field-label">Your open tickets</p>
+      {open.map((ticket) => (
+        <div
+          key={ticket.id}
+          className="flex items-start justify-between gap-3 rounded-md border border-border bg-card px-4 py-3"
+        >
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="app-body-primary font-medium truncate">{ticket.subject}</span>
+              <Badge variant="outline" className="text-xs shrink-0">{ticket.ref}</Badge>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
+              <span>{STATUS_LABELS[ticket.status] ?? ticket.status}</span>
+              <span>·</span>
+              <span>{PRIORITY_LABELS[ticket.priority] ?? ticket.priority}</span>
+              <span>·</span>
+              <span>{slaLabel(ticket)}</span>
+            </div>
+          </div>
+          {ticket.status !== "RESOLVED" && ticket.status !== "CLOSED" && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="shrink-0 text-xs h-7 px-2"
+              disabled={closing === ticket.id}
+              onClick={() => closeTicket(ticket.id)}
+            >
+              <CheckCircle className="h-3 w-3 mr-1" />
+              Close
+            </Button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/support-tickets.ts
+++ b/lib/support-tickets.ts
@@ -1,33 +1,26 @@
 import "server-only";
 
+import { randomBytes } from "crypto";
 import { db } from "@/lib/db";
 import { createNotification } from "@/actions/notification-actions";
 
 type SupportPriority = "low" | "medium" | "high" | "urgent";
 
 function normalizePriority(value: string | null | undefined): SupportPriority {
-  const normalized = (value || "").trim().toLowerCase();
-  if (normalized === "low" || normalized === "medium" || normalized === "high" || normalized === "urgent") {
-    return normalized;
-  }
+  const p = (value || "").trim().toLowerCase();
+  if (p === "low" || p === "medium" || p === "high" || p === "urgent") return p;
   return "medium";
 }
 
-function getSlaHours(priority: SupportPriority) {
-  switch (priority) {
-    case "urgent":
-      return 4;
-    case "high":
-      return 12;
-    case "low":
-      return 48;
-    default:
-      return 24;
-  }
+function getSlaHours(priority: SupportPriority): number {
+  if (priority === "urgent") return 4;
+  if (priority === "high") return 12;
+  if (priority === "low") return 48;
+  return 24;
 }
 
-export function buildSupportTicketReference(ticketId: string) {
-  return `SUP-${ticketId.slice(-6).toUpperCase()}`;
+export function buildSupportTicketReference(): string {
+  return `SUP-${randomBytes(3).toString("hex").toUpperCase()}`;
 }
 
 export async function createSupportTicket(input: {
@@ -46,45 +39,26 @@ export async function createSupportTicket(input: {
 }) {
   const priority = normalizePriority(input.priority);
   const slaHours = getSlaHours(priority);
+  const slaDeadline = new Date(Date.now() + slaHours * 60 * 60 * 1000);
+  const ref = buildSupportTicketReference();
 
-  const activity = await db.activity.create({
+  const ticket = await db.supportTicket.create({
     data: {
-      type: "NOTE",
-      title: `${input.source === "chatbot" ? "Chatbot Support Request" : "Support Request"}: ${input.subject}`,
-      content: [
-        `Priority: ${priority}`,
-        `Source: ${input.source}`,
-        "",
-        input.message,
-        "",
-        `User: ${input.requesterEmail || "Unknown user"}`,
-        `Workspace: ${input.workspaceName || "Unknown workspace"}`,
-        `Tracey number: ${input.traceyNumber || "Not configured"}`,
-      ].join("\n"),
-      userId: input.userId,
-    },
-  });
-
-  await db.activityLog.create({
-    data: {
+      ref,
       workspaceId: input.workspaceId,
       userId: input.userId,
-      action: "support.ticket.created",
-      entityType: "support_ticket",
-      entityId: activity.id,
+      subject: input.subject,
+      message: input.message,
+      priority,
+      source: input.source,
+      slaDeadline,
       metadata: {
-        ticketId: activity.id,
-        ticketRef: buildSupportTicketReference(activity.id),
-        status: "open",
-        priority,
-        source: input.source,
-        slaHours,
-        requesterName: input.requesterName || null,
-        requesterEmail: input.requesterEmail || null,
-        requesterPhone: input.requesterPhone || null,
-        workspaceName: input.workspaceName || null,
-        workspaceType: input.workspaceType || null,
-        traceyNumber: input.traceyNumber || null,
+        requesterName: input.requesterName ?? null,
+        requesterEmail: input.requesterEmail ?? null,
+        requesterPhone: input.requesterPhone ?? null,
+        workspaceName: input.workspaceName ?? null,
+        workspaceType: input.workspaceType ?? null,
+        traceyNumber: input.traceyNumber ?? null,
       },
     },
   });
@@ -92,24 +66,14 @@ export async function createSupportTicket(input: {
   await createNotification({
     userId: input.userId,
     title: `Support ticket created: ${input.subject}`,
-    message: `${buildSupportTicketReference(activity.id)} is open with ${priority} priority.`,
+    message: `${ref} is open with ${priority} priority.`,
     type: priority === "urgent" || priority === "high" ? "WARNING" : "INFO",
     link: "/crm/settings/help#support-request",
     actionType: "VIEW_SUPPORT_TICKET",
-    actionPayload: {
-      ticketId: activity.id,
-      ticketRef: buildSupportTicketReference(activity.id),
-      status: "open",
-      priority,
-    },
+    actionPayload: { ticketId: ticket.id, ticketRef: ref, status: "OPEN", priority },
   });
 
-  return {
-    ticketId: activity.id,
-    ticketRef: buildSupportTicketReference(activity.id),
-    priority,
-    slaHours,
-  };
+  return { ticketId: ticket.id, ticketRef: ref, priority, slaHours };
 }
 
 export async function appendSupportTicketNote(input: {
@@ -118,61 +82,39 @@ export async function appendSupportTicketNote(input: {
   noteContent: string;
   userId?: string | null;
 }) {
-  const ticket = await db.activity.findFirst({
-    where: {
-      id: input.ticketId,
-      userId: input.userId ?? undefined,
-      title: { startsWith: "Support Request:" },
-    },
-    select: {
-      id: true,
-      title: true,
-      userId: true,
-    },
+  const ticket = await db.supportTicket.findFirst({
+    where: { id: input.ticketId, workspaceId: input.workspaceId },
+    select: { id: true, ref: true },
   });
 
-  const chatbotTicket =
-    ticket ||
-    (await db.activity.findFirst({
-      where: {
-        id: input.ticketId,
-        userId: input.userId ?? undefined,
-        title: { startsWith: "Chatbot Support Request:" },
-      },
-      select: {
-        id: true,
-        title: true,
-        userId: true,
-      },
-    }));
+  if (!ticket) throw new Error("Ticket not found.");
 
-  if (!chatbotTicket) {
-    throw new Error("Ticket not found.");
-  }
+  await db.supportTicketNote.create({
+    data: { ticketId: ticket.id, content: input.noteContent },
+  });
 
-  await db.activity.create({
+  return `Note added to ticket ${ticket.ref}.`;
+}
+
+export async function getSupportTickets(workspaceId: string, userId: string) {
+  return db.supportTicket.findMany({
+    where: { workspaceId, userId },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    include: { notes: { orderBy: { createdAt: "asc" } } },
+  });
+}
+
+export async function updateSupportTicketStatus(
+  ticketId: string,
+  workspaceId: string,
+  status: "OPEN" | "IN_PROGRESS" | "RESOLVED" | "CLOSED",
+) {
+  return db.supportTicket.update({
+    where: { id: ticketId, workspaceId },
     data: {
-      type: "NOTE",
-      title: `Support ticket note: ${buildSupportTicketReference(chatbotTicket.id)}`,
-      content: input.noteContent,
-      userId: chatbotTicket.userId ?? undefined,
+      status,
+      resolvedAt: status === "RESOLVED" || status === "CLOSED" ? new Date() : null,
     },
   });
-
-  await db.activityLog.create({
-    data: {
-      workspaceId: input.workspaceId,
-      userId: input.userId ?? undefined,
-      action: "support.ticket.note_added",
-      entityType: "support_ticket",
-      entityId: chatbotTicket.id,
-      metadata: {
-        ticketId: chatbotTicket.id,
-        ticketRef: buildSupportTicketReference(chatbotTicket.id),
-        note: input.noteContent,
-      },
-    },
-  });
-
-  return `Note added to ticket ${buildSupportTicketReference(chatbotTicket.id)}.`;
 }

--- a/prisma/migrations/20260524_support_ticket_model/migration.sql
+++ b/prisma/migrations/20260524_support_ticket_model/migration.sql
@@ -1,0 +1,56 @@
+-- Support ticket workflow: dedicated model with status, SLA deadline, and notes
+
+CREATE TYPE "SupportTicketStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+CREATE TABLE "support_tickets" (
+  "id"          TEXT                   NOT NULL,
+  "ref"         TEXT                   NOT NULL,
+  "workspaceId" TEXT                   NOT NULL,
+  "userId"      TEXT                   NOT NULL,
+  "subject"     TEXT                   NOT NULL,
+  "message"     TEXT                   NOT NULL,
+  "priority"    TEXT                   NOT NULL DEFAULT 'medium',
+  "status"      "SupportTicketStatus"  NOT NULL DEFAULT 'OPEN',
+  "source"      TEXT                   NOT NULL DEFAULT 'settings_form',
+  "slaDeadline" TIMESTAMP(3)           NOT NULL,
+  "resolvedAt"  TIMESTAMP(3),
+  "metadata"    JSONB                  DEFAULT '{}',
+  "createdAt"   TIMESTAMP(3)           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3)           NOT NULL,
+  CONSTRAINT "support_tickets_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "support_tickets_ref_key"
+  ON "support_tickets"("ref");
+
+CREATE INDEX "support_tickets_workspaceId_status_createdAt_idx"
+  ON "support_tickets"("workspaceId", "status", "createdAt");
+
+CREATE INDEX "support_tickets_userId_status_idx"
+  ON "support_tickets"("userId", "status");
+
+ALTER TABLE "support_tickets"
+  ADD CONSTRAINT "support_tickets_workspaceId_fkey"
+  FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "support_tickets"
+  ADD CONSTRAINT "support_tickets_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE TABLE "support_ticket_notes" (
+  "id"        TEXT         NOT NULL,
+  "ticketId"  TEXT         NOT NULL,
+  "content"   TEXT         NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "support_ticket_notes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "support_ticket_notes_ticketId_createdAt_idx"
+  ON "support_ticket_notes"("ticketId", "createdAt");
+
+ALTER TABLE "support_ticket_notes"
+  ADD CONSTRAINT "support_ticket_notes_ticketId_fkey"
+  FOREIGN KEY ("ticketId") REFERENCES "support_tickets"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model Workspace {
   activityLogs     ActivityLog[]
   calendarIntegrations WorkspaceCalendarIntegration[]
   syncIssues       SyncIssue[]
+  supportTickets   SupportTicket[]
 
   // Self-Learning & NLP Behavioral State
   aiPreferences      String? @db.Text
@@ -182,7 +183,8 @@ model User {
   // Referral System
   referrals Referral[]
 
-  channelPrefs NotificationChannelPref[]
+  channelPrefs   NotificationChannelPref[]
+  supportTickets SupportTicket[]
 }
 
 model NotificationChannelPref {
@@ -1069,4 +1071,48 @@ model DemoLead {
   @@index([phone, createdAt])
   @@index([callStatus, createdAt])
   @@index([createdAt])
+}
+
+// ─── Support Ticket Workflow ─────────────────────────────────────────────────
+
+enum SupportTicketStatus {
+  OPEN
+  IN_PROGRESS
+  RESOLVED
+  CLOSED
+}
+
+model SupportTicket {
+  id          String              @id @default(cuid())
+  ref         String              @unique
+  workspaceId String
+  workspace   Workspace           @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  userId      String
+  user        User                @relation(fields: [userId], references: [id])
+  subject     String
+  message     String              @db.Text
+  priority    String              @default("medium")
+  status      SupportTicketStatus @default(OPEN)
+  source      String              @default("settings_form")
+  slaDeadline DateTime
+  resolvedAt  DateTime?
+  metadata    Json?               @default("{}")
+  notes       SupportTicketNote[]
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+
+  @@index([workspaceId, status, createdAt])
+  @@index([userId, status])
+  @@map("support_tickets")
+}
+
+model SupportTicketNote {
+  id        String        @id @default(cuid())
+  ticketId  String
+  ticket    SupportTicket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  content   String        @db.Text
+  createdAt DateTime      @default(now())
+
+  @@index([ticketId, createdAt])
+  @@map("support_ticket_notes")
 }


### PR DESCRIPTION
## Summary

Replaces the fragile `ActivityLog`-based support approach with a dedicated `SupportTicket` model and admin view.

### Prisma model
- New `SupportTicket` + `SupportTicketNote` models with `SupportTicketStatus` enum (`OPEN → IN_PROGRESS → RESOLVED → CLOSED`)
- SLA deadline timestamps and structured follow-up notes — ends title-prefix string matching
- Migration: `prisma/migrations/20260524_support_ticket_model/migration.sql`

### Backend
- `lib/support-tickets.ts` — rewritten to use new model; `getSupportTickets` and `updateSupportTicketStatus`
- `app/api/support/tickets/route.ts` — GET endpoint (list caller's tickets)
- `app/api/support/tickets/[id]/route.ts` — PATCH endpoint (update ticket status)
- `app/api/admin/support-tickets/[id]/route.ts` — admin PATCH gated on `isInternalAdminEmail`, stamps `resolvedAt`

### UI
- `components/settings/support-ticket-list.tsx` — open tickets with SLA countdown and close action
- `components/settings/support-request-panel.tsx` — wires in `SupportTicketList` above submission form
- `app/admin/support/page.tsx` — internal admin view at `/admin/support`: filter tabs (All/Open/In Progress/Resolved/Closed), SLA countdown, inline status select, click-to-expand message + notes
- `app/admin/customer-usage/page.tsx` — adds "Support tickets" nav link

## Test plan
- [ ] Run `npm test` — existing suite should stay green
- [ ] Verify `/admin/support` loads and shows tickets across workspaces
- [ ] Verify status updates stamp `resolvedAt` on RESOLVED/CLOSED transitions
- [ ] Verify SLA countdown shows correctly in settings panel

https://claude.ai/code/session_01T5Uz96WvGaQnHG2Q2qmDtw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5Uz96WvGaQnHG2Q2qmDtw)_