### PR TITLE
Switch chatbot/SMS to DeepSeek V4 Flash; fix latency status false alarm

### DIFF
--- a/lib/ai-models.ts
+++ b/lib/ai-models.ts
@@ -32,9 +32,9 @@ const google = createGoogleGenerativeAI({
 export const contextModel = google("gemini-2.0-flash-lite-preview-02-05");
 
 /**
- * Logic Model — DeepSeek V3 (via DeepInfra)
+ * Logic Model — DeepSeek V4 Flash (via DeepInfra)
  *
  * Use for: Drafting emails, formatting CRM JSON, and complex business logic.
- * GPT-4o-class intelligence at ~$0.14/M tokens.
+ * Smarter than V3 at $0.14/$0.28 per M in/out tokens.
  */
-export const logicModel = deepinfra("deepseek-ai/DeepSeek-V3");
+export const logicModel = deepinfra("deepseek-ai/DeepSeek-V4-Flash");

--- a/lib/ai/sms-agent.ts
+++ b/lib/ai/sms-agent.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { logicModel } from "@/lib/ai-models";
 import { tool } from "ai";
 import { z } from "zod";
 import { db } from "@/lib/db";
@@ -20,8 +20,6 @@ import {
     runCreateDeal,
     runAddAgentFlag,
 } from "@/actions/chat-actions";
-
-const CHAT_MODEL_ID = "gemini-2.0-flash-lite";
 
 export type GeneratedSmsResponse = {
     text: string;
@@ -165,19 +163,6 @@ export async function generateSMSResponse(
 ): Promise<GeneratedSmsResponse> {
     const requestStartedAt = nowMs();
 
-    const apiKey =
-        process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-
-    if (!apiKey) {
-        console.error("Missing GEMINI_API_KEY for SMS agent");
-        const policyOutcome = enforceCustomerFacingResponsePolicy({
-            modeRaw: undefined,
-            text: "Thanks for your message! Someone will get back to you shortly.",
-            channel: "sms",
-        });
-        return { text: policyOutcome.finalText, policyOutcome };
-    }
-
     try {
         const preprocessingStartedAt = nowMs();
 
@@ -243,8 +228,6 @@ export async function generateSMSResponse(
             ],
         });
 
-        const google = createGoogleGenerativeAI({ apiKey });
-
         let toolCallsMs = 0;
         const tools = instrumentToolsWithLatency(
             getSmsCustomerTools(workspaceId, settings),
@@ -256,7 +239,7 @@ export async function generateSMSResponse(
 
         const llmStartedAt = nowMs();
         const result = await generateText({
-            model: google(CHAT_MODEL_ID as "gemini-2.0-flash-lite"),
+            model: logicModel,
             system: systemPrompt,
             messages: conversationHistory.length > 0
                 ? [...conversationHistory, { role: "user" as const, content: userMessage }]

--- a/lib/services/ai-agent.ts
+++ b/lib/services/ai-agent.ts
@@ -1,13 +1,11 @@
 import { generateText } from "ai";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { logicModel } from "@/lib/ai-models";
 import { db } from "@/lib/db";
 import { buildAgentContext, fetchMemoryContext } from "@/lib/ai/context";
 import { buildCrmChatSystemPrompt } from "@/lib/ai/prompt-contract";
 import { getAgentTools } from "@/lib/ai/tools";
 import { saveUserMessage } from "@/actions/chat-actions";
 import { instrumentToolsWithLatency, nowMs, recordLatencyMetric } from "@/lib/telemetry/latency";
-
-const CHAT_MODEL_ID = "gemini-2.0-flash-lite";
 
 function shouldIncludeHistoricalPricing(text: string): boolean {
   return /\b(price|pricing|quote|quoted|cost|how much|rate|fee|invoice)\b/i.test(text) || /\$/.test(text);
@@ -119,14 +117,6 @@ export async function processAgentCommand(userId: string, message: string): Prom
       roleGuardBlock: "OWNER and MANAGER users may confirm data changes through the existing confirmation flow. TEAM_MEMBER users cannot make restricted data changes and should be told to ask their manager.",
     });
 
-    const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    if (!apiKey) {
-      console.error("Missing Gemini API Key");
-      return "Internal Error: AI service configuration is missing.";
-    }
-
-    const google = createGoogleGenerativeAI({ apiKey });
-
     let toolCallsMs = 0;
     const tools = instrumentToolsWithLatency(
       getAgentTools(workspaceId, settings, userId),
@@ -137,7 +127,7 @@ export async function processAgentCommand(userId: string, message: string): Prom
     );
     const llmStartedAt = nowMs();
     const result = await generateText({
-      model: google(CHAT_MODEL_ID as "gemini-2.0-flash-lite"),
+      model: logicModel,
       system: systemPrompt,
       prompt: message,
       tools,

--- a/lib/voice-agent-health-monitor.ts
+++ b/lib/voice-agent-health-monitor.ts
@@ -2,7 +2,7 @@ import { auditTwilioVoiceRouting } from "@/lib/twilio-drift";
 import { getVoiceBusinessInvariantHealth } from "@/lib/voice-business-invariants";
 import { getVoiceFleetHealth, getVoiceSurfaceSaturationHealth, type RuntimeStatus } from "@/lib/voice-fleet";
 import { getTwilioVoiceCallHealth } from "@/lib/twilio-voice-call-health";
-import { getVoiceLatencyHealth } from "@/lib/voice-call-latency-health";
+import { getVoiceLatencyHealth, type VoiceLatencyHealth } from "@/lib/voice-call-latency-health";
 import { reconcileVoiceIncidents } from "@/lib/voice-incidents";
 import { getLivekitSipHealth } from "@/lib/livekit-sip-health";
 import { getDemoCallHealth } from "@/lib/demo-call-health";
@@ -19,6 +19,21 @@ import {
   buildSaturationIncidentObservations,
   combineVoiceStatuses,
 } from "@/lib/voice-monitoring";
+
+/**
+ * A latency degradation caused purely by no recent calls (sampleCount = 0) is a
+ * proof gap, not a performance problem. Treat it as healthy for rollup so the
+ * combined status stays green and CI doesn't fire false-alarm emails.
+ * The detailed latency object still shows degraded — this only affects the rollup.
+ */
+function resolveEffectiveLatencyStatus(latency: VoiceLatencyHealth): RuntimeStatus {
+  if (latency.status !== "degraded") return latency.status;
+  const degradedScopes = latency.scopes.filter((s) => s.status !== "healthy");
+  const allProofGap = degradedScopes.every(
+    (s) => s.sampleCount === 0 && s.syntheticProbeSampleCount === 0,
+  );
+  return allProofGap ? "healthy" : latency.status;
+}
 
 export type VoiceAgentHealthMonitorResult = {
   status: RuntimeStatus;
@@ -184,7 +199,7 @@ export async function runVoiceAgentHealthMonitor(
     outboundCalls.status,
     invariants.status,
     recentCalls.status,
-    latency.status,
+    resolveEffectiveLatencyStatus(latency),
   ]);
 
   return {


### PR DESCRIPTION
## Summary

Two independent fixes shipped together:

### DeepSeek V4 Flash switch
- Replaces Gemini 2.0 Flash Lite with DeepSeek V4 Flash (via DeepInfra) for the in-app chat and inbound SMS agents
- Smarter model at the same price point (~$0.14/$0.28 per M in/out)
- `logicModel` in `ai-models.ts` updated from V3 → V4 Flash so email drafting also benefits

### Latency monitor false-alarm fix
- When there are no recent `inbound_demo` calls in the lookback window, the latency monitor was marking the surface `degraded`, rolling up to a combined degraded status and causing CI to exit non-zero + fire alert emails
- Adds `resolveEffectiveLatencyStatus()` — treats a proof-only gap (all degraded scopes have `sampleCount=0` and `syntheticProbeSampleCount=0`) as healthy for rollup purposes
- Detailed latency object still shows `degraded` so the problem remains visible in health dashboards; it just stops poisoning the top-level status when there's no call data

## Test plan
- [ ] Run `npm test` — suite should stay green
- [ ] Verify health dashboard no longer shows degraded when call lookback window is empty
- [ ] Verify chatbot responses are using DeepSeek V4 Flash in logs

https://claude.ai/code/session_01T5Uz96WvGaQnHG2Q2qmDtw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5Uz96WvGaQnHG2Q2qmDtw)_