### PR TITLE
Redesign marketing site: bespoke editorial "field-ledger" system

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -76,24 +76,25 @@ export default function ContactPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-paper">
       <Navbar />
 
       <main className="pt-28 pb-20 px-6">
         <div className="container mx-auto max-w-xl">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
+            className="inline-flex items-center gap-2 text-sm text-ink2 hover:text-ink transition-colors mb-8"
           >
             <ArrowLeft className="h-4 w-4" />
             Back to home
           </Link>
 
           <div className="mb-8">
-            <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight" style={{ color: "var(--color-ink)" }}>
+            <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-forest mb-3">We&apos;re here to help</p>
+            <h1 className="font-display text-3xl md:text-5xl font-semibold tracking-[-0.01em] text-ink">
               Contact us
             </h1>
-            <p className="text-slate-body mt-2">
+            <p className="text-ink2 mt-3">
               Get in touch with the right team at Earlymark.
             </p>
           </div>
@@ -109,7 +110,7 @@ export default function ContactPage() {
                     <h2 className="font-semibold" style={{ color: "var(--color-ink)" }}>
                       {callPlaced ? "Tracey is calling you now" : "Message sent"}
                     </h2>
-                    <p className="text-sm text-slate-body mt-1">
+                    <p className="text-sm text-ink2 mt-1">
                       {callPlaced
                         ? "Pick up — Tracey will be on the line in a few seconds."
                         : "Thanks for reaching out. We’ll get back to you within 24 hours."}
@@ -125,7 +126,7 @@ export default function ContactPage() {
             <Card className="ott-card-elevated">
               <CardHeader>
                 <CardTitle style={{ color: "var(--color-ink)" }}>Contact form</CardTitle>
-                <CardDescription className="text-slate-body">
+                <CardDescription className="text-ink2">
                   Choose the department that best fits your enquiry, then fill in your details.
                 </CardDescription>
               </CardHeader>
@@ -163,7 +164,7 @@ export default function ContactPage() {
                   <div className="space-y-2">
                     <Label htmlFor="phone">Phone (optional)</Label>
                     <Input id="phone" name="phone" type="tel" placeholder="+61 400 000 000" />
-                    <p className="text-xs text-slate-body">
+                    <p className="text-xs text-ink2">
                       Add your phone if you want Tracey to call you back right away.
                     </p>
                   </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -79,23 +79,21 @@ export default function ContactPage() {
     <div className="min-h-screen bg-paper">
       <Navbar />
 
-      <main className="pt-28 pb-20 px-6">
-        <div className="container mx-auto max-w-xl">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-sm text-ink2 hover:text-ink transition-colors mb-8"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to home
-          </Link>
+      <main className="pt-24 pb-20 px-5 sm:px-8">
+        <div className="mx-auto max-w-xl">
+          <div className="flex items-center justify-between gap-4 border-t border-hair pt-3.5">
+            <span className="em-kicker text-forest">§ Contact</span>
+            <Link href="/" className="em-kicker inline-flex items-center gap-1.5 text-ink2/60 transition-colors hover:text-ink">
+              <ArrowLeft className="h-3 w-3" /> Home
+            </Link>
+          </div>
 
-          <div className="mb-8">
-            <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-forest mb-3">We&apos;re here to help</p>
-            <h1 className="font-display text-3xl md:text-5xl font-semibold tracking-[-0.01em] text-ink">
+          <div className="mb-10 mt-10">
+            <h1 className="em-display text-[2.5rem] leading-[1.0] text-ink sm:text-6xl">
               Contact us
             </h1>
-            <p className="text-ink2 mt-3">
-              Get in touch with the right team at Earlymark.
+            <p className="text-ink2 mt-5 max-w-md leading-relaxed">
+              Get in touch with the right team at Earlymark — or have Tracey call you back.
             </p>
           </div>
 

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -12,6 +12,7 @@ import { Navbar } from "@/components/layout/navbar"
 import { Button } from "@/components/ui/button"
 import { HeroDashboardReel } from "@/components/home/hero-dashboard-reel"
 import { PlatformDiagram } from "@/components/home/platform-diagram"
+import { SectionHead } from "@/components/marketing/section-head"
 
 // ─── Animation ────────────────────────────────────────────────────────────────
 
@@ -543,46 +544,48 @@ export default function FeaturesPage() {
       <main>
 
         {/* ── 1. Hero ── */}
-        <section className="pt-32 sm:pt-40 pb-16 sm:pb-20 px-6 bg-forest relative overflow-hidden isolate">
-          <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
-          <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
-          <div aria-hidden className="absolute inset-x-0 bottom-0 z-0 h-[120px] sm:h-[180px] bg-paper" />
-          <div className="relative z-10 mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
-            <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">The platform</motion.p>
-            <motion.h1 {...fadeUp(0.04)} className="font-display text-4xl sm:text-5xl md:text-7xl font-semibold tracking-[-0.015em] leading-[1.05] text-balance text-paper">
-              An AI assistant.<br />A CRM that runs itself.
-            </motion.h1>
-            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-paper/65 max-w-xl text-balance">
-              One platform with two halves: an AI voice assistant that picks up every call and text, and a full CRM that fills itself in as she works.
-            </motion.p>
-            <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
-              <Link href="/auth">
-                <Button size="lg" variant="mint">
-                  Get started <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
-              </Link>
-              <Link href="/contact#contact-form">
-                <Button size="lg" variant="outline" className="border-white/25 bg-transparent text-paper hover:bg-white/10 hover:border-white/40 hover:text-white">Get a demo</Button>
-              </Link>
+        <section className="em-grain relative overflow-hidden bg-cream px-5 sm:px-8 pt-24 sm:pt-28 pb-20 sm:pb-28">
+          <div className="relative z-10 mx-auto max-w-[1320px]">
+            <motion.div {...fadeUp()} className="flex items-center justify-between gap-4 border-t border-hair pt-3.5">
+              <span className="em-kicker text-forest">§ The platform</span>
+              <span className="em-kicker hidden text-ink2/55 sm:inline">Assistant + CRM</span>
+              <span className="em-kicker text-ink2/55">Australia</span>
             </motion.div>
-          </div>
+            <div className="mt-12 grid gap-x-8 gap-y-10 sm:mt-16 md:grid-cols-12 md:items-end">
+              <motion.h1 {...fadeUp(0.06)} className="em-display col-span-12 text-[clamp(2.5rem,7vw,6rem)] text-ink md:col-span-8">
+                An AI assistant.<br />A CRM that <span className="italic text-forest">runs itself</span>.
+              </motion.h1>
+              <motion.div {...fadeUp(0.12)} className="col-span-12 flex flex-col gap-6 md:col-span-4 md:pb-2">
+                <p className="max-w-sm text-[15px] leading-relaxed text-ink2">
+                  One platform with two halves: an AI voice assistant that picks up every call and text, and a full CRM that fills itself in as she works.
+                </p>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Link href="/auth"><Button size="lg" variant="mint">Get started <ArrowRight className="ml-2 h-4 w-4" /></Button></Link>
+                  <Link href="/contact#contact-form"><Button size="lg" variant="outline">Get a demo</Button></Link>
+                </div>
+              </motion.div>
+            </div>
 
-          {/* Full-width dashboard reel */}
-          <motion.div {...fadeUp(0.16)} className="relative z-10 mx-auto mt-8 md:mt-14 max-w-6xl px-4">
-            <div className="absolute inset-x-[8%] top-8 -z-10 h-32 rounded-full bg-mint-500/20 blur-3xl" />
-            <HeroDashboardReel />
-          </motion.div>
+            {/* Plate 01 — the reel framed as a figure */}
+            <motion.figure {...fadeUp(0.16)} className="relative mt-14 sm:mt-20">
+              <figcaption className="flex items-center justify-between gap-4 border-t border-hair pt-3 pb-5">
+                <span className="em-kicker text-forest">Plate 01</span>
+                <span className="em-figcaption text-right">The operating surface — chat, inbox, map &amp; calendar</span>
+              </figcaption>
+              <HeroDashboardReel />
+            </motion.figure>
+          </div>
         </section>
 
         {/* ── 1.5 Platform diagram ── */}
-        <section className="py-10 md:py-20 px-6 bg-cream">
-          <div className="mx-auto max-w-7xl">
-            <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-              <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>One comprehensive platform.</h2>
-              <p className="mt-4 text-lg text-muted-foreground">
-                An AI assistant and a CRM that runs itself, so you don&apos;t have to.
-              </p>
-            </motion.div>
+        <section className="py-16 md:py-24 px-5 sm:px-8 bg-cream">
+          <div className="mx-auto max-w-[1320px]">
+            <SectionHead
+              index="§01 — Platform"
+              kicker="Two halves, one system"
+              title="One comprehensive platform."
+              lead="An AI assistant and a CRM that runs itself, so you don't have to."
+            />
             <motion.div {...fadeUp(0.08)}>
               <PlatformDiagram />
             </motion.div>
@@ -590,16 +593,14 @@ export default function FeaturesPage() {
         </section>
 
         {/* ── 2. Core jobs ── */}
-        <section className="py-16 md:py-20 px-6 bg-paper">
-          <div className="mx-auto max-w-6xl">
-            <motion.div {...fadeUp()} className="mb-10 max-w-3xl">
-              <h2 className="mt-3 text-3xl md:text-5xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>
-                More than a call bot. A working system for the whole job lifecycle.
-              </h2>
-              <p className="mt-4 text-base leading-7 text-muted-foreground">
-                The homepage explains the promise. This page shows the operating surface: what Tracey touches, where the CRM fills in, and how you keep control.
-              </p>
-            </motion.div>
+        <section className="py-16 md:py-24 px-5 sm:px-8 bg-paper">
+          <div className="mx-auto max-w-[1320px]">
+            <SectionHead
+              index="§02 — The system"
+              kicker="The whole job lifecycle"
+              title={<>More than a call bot.</>}
+              lead="The operating surface: what Tracey touches, where the CRM fills in, and how you keep control."
+            />
 
             <div className="grid gap-4 md:grid-cols-3">
               {PRODUCT_AREAS.map(({ icon: Icon, label, detail }, i) => (

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -538,20 +538,21 @@ const FEATURE_MOCKUPS = [MockupComms, MockupCRM, MockupCalendar, MockupInbox, Mo
 
 export default function FeaturesPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-paper text-ink">
       <Navbar />
       <main>
 
         {/* ── 1. Hero ── */}
-        <section className="pt-32 pb-20 px-6 bg-[linear-gradient(180deg,#F8FAFC_0%,#F1F5F9_60%,#F8FAFC_100%)] relative overflow-hidden isolate">
-          <div className="absolute inset-0 z-0 pointer-events-none" style={{
-            background: "radial-gradient(110% 60% at 50% 0%,rgba(16,185,129,0.18) 0%,rgba(16,185,129,0.00) 72%)",
-          }} />
+        <section className="pt-32 sm:pt-40 pb-16 sm:pb-20 px-6 bg-forest relative overflow-hidden isolate">
+          <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+          <div aria-hidden className="absolute inset-x-0 bottom-0 z-0 h-[120px] sm:h-[180px] bg-paper" />
           <div className="relative z-10 mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
-            <motion.h1 {...fadeUp(0.04)} className="text-4xl sm:text-5xl md:text-7xl font-extrabold tracking-[-0.04em] leading-[1.07] text-balance" style={{ color: "var(--color-ink)" }}>
+            <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">The platform</motion.p>
+            <motion.h1 {...fadeUp(0.04)} className="font-display text-4xl sm:text-5xl md:text-7xl font-semibold tracking-[-0.015em] leading-[1.05] text-balance text-paper">
               An AI assistant.<br />A CRM that runs itself.
             </motion.h1>
-            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-muted-foreground max-w-xl text-balance">
+            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-paper/65 max-w-xl text-balance">
               One platform with two halves: an AI voice assistant that picks up every call and text, and a full CRM that fills itself in as she works.
             </motion.p>
             <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
@@ -561,23 +562,23 @@ export default function FeaturesPage() {
                 </Button>
               </Link>
               <Link href="/contact#contact-form">
-                <Button size="lg" variant="outline">Get a demo</Button>
+                <Button size="lg" variant="outline" className="border-white/25 bg-transparent text-paper hover:bg-white/10 hover:border-white/40 hover:text-white">Get a demo</Button>
               </Link>
             </motion.div>
           </div>
 
           {/* Full-width dashboard reel */}
           <motion.div {...fadeUp(0.16)} className="relative z-10 mx-auto mt-8 md:mt-14 max-w-6xl px-4">
-            <div className="absolute inset-x-[8%] top-8 -z-10 h-32 rounded-full bg-emerald-300/20 blur-3xl" />
+            <div className="absolute inset-x-[8%] top-8 -z-10 h-32 rounded-full bg-mint-500/20 blur-3xl" />
             <HeroDashboardReel />
           </motion.div>
         </section>
 
         {/* ── 1.5 Platform diagram ── */}
-        <section className="py-10 md:py-20 px-6 bg-card border-y border-border/70">
+        <section className="py-10 md:py-20 px-6 bg-cream">
           <div className="mx-auto max-w-7xl">
             <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-              <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>One comprehensive platform.</h2>
+              <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>One comprehensive platform.</h2>
               <p className="mt-4 text-lg text-muted-foreground">
                 An AI assistant and a CRM that runs itself, so you don&apos;t have to.
               </p>
@@ -589,10 +590,10 @@ export default function FeaturesPage() {
         </section>
 
         {/* ── 2. Core jobs ── */}
-        <section className="py-16 md:py-20 px-6 bg-card border-b border-border/70">
+        <section className="py-16 md:py-20 px-6 bg-paper">
           <div className="mx-auto max-w-6xl">
             <motion.div {...fadeUp()} className="mb-10 max-w-3xl">
-              <h2 className="mt-3 text-3xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>
+              <h2 className="mt-3 text-3xl md:text-5xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>
                 More than a call bot. A working system for the whole job lifecycle.
               </h2>
               <p className="mt-4 text-base leading-7 text-muted-foreground">
@@ -605,9 +606,9 @@ export default function FeaturesPage() {
                 <motion.div
                   key={label}
                   {...fadeUp(i * 0.04)}
-                  className="rounded border border-border bg-card p-5 shadow-sm"
+                  className="rounded border border-hair bg-card p-5 shadow-sm"
                 >
-                  <div className="mb-4 flex h-10 w-10 items-center justify-center rounded bg-emerald-50">
+                  <div className="mb-4 flex h-10 w-10 items-center justify-center rounded bg-primary-subtle">
                     <Icon className="h-5 w-5 text-primary" />
                   </div>
                   <h3 className="text-base font-bold" style={{ color: "var(--color-ink)" }}>{label}</h3>
@@ -616,12 +617,12 @@ export default function FeaturesPage() {
               ))}
             </div>
 
-            <motion.div {...fadeUp(0.1)} className="mt-10 overflow-hidden rounded border border-border bg-card shadow-sm">
+            <motion.div {...fadeUp(0.1)} className="mt-10 overflow-hidden rounded border border-hair bg-card shadow-sm">
               <div className="grid md:grid-cols-3">
                 {OPERATING_MODES.map((mode) => (
                   <div key={mode.mode} className="border-b border-border p-6 last:border-b-0 md:border-b-0 md:border-r md:last:border-r-0">
                     <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-primary">{mode.mode}</p>
-                    <h3 className="mt-3 text-lg font-extrabold" style={{ color: "var(--color-ink)" }}>{mode.owner}</h3>
+                    <h3 className="mt-3 text-lg font-display font-semibold" style={{ color: "var(--color-ink)" }}>{mode.owner}</h3>
                     <p className="mt-2 text-sm leading-6 text-muted-foreground">{mode.outcome}</p>
                   </div>
                 ))}
@@ -631,26 +632,26 @@ export default function FeaturesPage() {
         </section>
 
         {/* Comparison table */}
-        <section className="py-20 px-6 bg-card border-b border-border/60">
+        <section className="py-20 px-6 bg-cream">
           <div className="mx-auto max-w-4xl">
             <motion.div {...fadeUp()} className="text-center mb-12">
-              <h2 className="mt-3 text-4xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>Earlymark vs. the traditional setup</h2>
+              <h2 className="mt-3 text-4xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>Earlymark vs. the traditional setup</h2>
               <p className="mt-3 text-base text-muted-foreground">Phone + paper + spreadsheet + late-night follow-ups, vs. one AI that handles it all.</p>
             </motion.div>
 
             <motion.div {...fadeUp(0.06)} className="grid gap-4 md:hidden">
               {COMPARISON_ROWS.map((row) => (
-                <div key={row.task} className="rounded border border-border bg-card p-5 shadow-sm">
+                <div key={row.task} className="rounded border border-hair bg-card p-5 shadow-sm">
                   <h3 className="text-base font-bold" style={{ color: "var(--color-ink)" }}>{row.task}</h3>
                   <div className="mt-4 grid gap-3">
-                    <div className="rounded border border-emerald-100 bg-emerald-50/60 p-3">
+                    <div className="rounded border border-hair bg-primary-subtle/50 p-3">
                       <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-primary">Earlymark</p>
                       <div className="mt-2 flex items-start gap-2">
-                        <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                        <Check className="mt-0.5 h-4 w-4 shrink-0 text-forest" />
                         <span className="text-sm leading-6 text-foreground">{row.earlymark}</span>
                       </div>
                     </div>
-                    <div className="rounded border border-border bg-muted/30 p-3">
+                    <div className="rounded border border-hair bg-muted/30 p-3">
                       <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-muted-foreground">Traditional</p>
                       <div className="mt-2 flex items-start gap-2">
                         <X className="mt-0.5 h-4 w-4 shrink-0 text-rose-400" />
@@ -662,21 +663,21 @@ export default function FeaturesPage() {
               ))}
             </motion.div>
 
-            <motion.div {...fadeUp(0.06)} className="hidden overflow-x-auto rounded border border-border shadow-sm md:block">
+            <motion.div {...fadeUp(0.06)} className="hidden overflow-x-auto rounded border border-hair shadow-sm md:block">
               <div className="min-w-[760px]">
                 <div className="grid grid-cols-3 bg-midnight text-white">
                   <div className="px-5 py-4 text-sm font-semibold text-white/60">Task</div>
-                  <div className="px-5 py-4 text-sm font-semibold text-emerald-400 border-l border-white/10">Earlymark</div>
+                  <div className="px-5 py-4 text-sm font-semibold text-mint-500 border-l border-white/10">Earlymark</div>
                   <div className="px-5 py-4 text-sm font-semibold text-white/60 border-l border-white/10">Traditional</div>
                 </div>
                 {COMPARISON_ROWS.map((row, i) => (
-                  <div key={row.task} className={`grid grid-cols-3 ${i % 2 === 0 ? "bg-card" : "bg-muted/30"} border-t border-border`}>
+                  <div key={row.task} className={`grid grid-cols-3 ${i % 2 === 0 ? "bg-card" : "bg-muted/30"} border-t border-hair`}>
                     <div className="px-5 py-4 text-sm font-semibold" style={{ color: "var(--color-ink)" }}>{row.task}</div>
-                    <div className="px-5 py-4 border-l border-border flex items-start gap-2">
-                      <Check className="w-4 h-4 text-emerald-500 mt-0.5 shrink-0" />
+                    <div className="px-5 py-4 border-l border-hair flex items-start gap-2">
+                      <Check className="w-4 h-4 text-forest mt-0.5 shrink-0" />
                       <span className="text-sm text-foreground">{row.earlymark}</span>
                     </div>
-                    <div className="px-5 py-4 border-l border-border flex items-start gap-2">
+                    <div className="px-5 py-4 border-l border-hair flex items-start gap-2">
                       <X className="w-4 h-4 text-rose-400 mt-0.5 shrink-0" />
                       <span className="text-sm text-muted-foreground">{row.traditional}</span>
                     </div>
@@ -687,17 +688,17 @@ export default function FeaturesPage() {
           </div>
         </section>
 
-        <section className="py-10 md:py-20 px-6 bg-background border-y border-border/70">
+        <section className="py-10 md:py-20 px-6 bg-paper">
           <div className="mx-auto max-w-5xl">
             <div className="grid md:grid-cols-3 gap-6">
               {CORE_JOBS.map((job, i) => {
                 const Icon = job.icon
                 return (
                   <motion.div key={job.num} {...fadeUp(i * 0.07)}
-                    className="rounded border border-border bg-card p-6 flex flex-col gap-4 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
+                    className="rounded border border-hair bg-card p-6 flex flex-col gap-4 hover:shadow-md hover:-translate-y-0.5 transition-all duration-300">
                     <div className="flex items-center gap-3">
                       <span className="text-[11px] font-bold text-primary/60 tracking-wider">{job.num}</span>
-                      <div className="w-10 h-10 rounded bg-emerald-50 flex items-center justify-center">
+                      <div className="w-10 h-10 rounded bg-primary-subtle flex items-center justify-center">
                         <Icon className="w-5 h-5 text-primary" />
                       </div>
                     </div>
@@ -728,9 +729,9 @@ export default function FeaturesPage() {
           },
         ] as const).map((group, groupIdx) => (
           <div key={group.key}>
-            <section className={`px-6 pt-20 pb-6 ${groupIdx === 0 ? "bg-background" : "bg-card"} border-b border-border/60`}>
+            <section className={`px-6 pt-20 pb-6 ${groupIdx === 0 ? "bg-paper" : "bg-cream"}`}>
               <div className="mx-auto max-w-6xl text-center">
-                <motion.h2 {...fadeUp(0.04)} className="text-3xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>
+                <motion.h2 {...fadeUp(0.04)} className="text-3xl md:text-5xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>
                   {group.heading}
                 </motion.h2>
                 <motion.p {...fadeUp(0.08)} className="mx-auto mt-3 max-w-2xl text-base leading-7 text-muted-foreground">
@@ -743,13 +744,13 @@ export default function FeaturesPage() {
               const Mockup = FEATURE_MOCKUPS[i]
               const isEven = localIdx % 2 === 0
               const bg = groupIdx === 0
-                ? (isEven ? "bg-background" : "bg-card")
-                : (isEven ? "bg-card" : "bg-background")
+                ? (isEven ? "bg-paper" : "bg-cream")
+                : (isEven ? "bg-cream" : "bg-paper")
               return (
-                <section key={feat.eyebrow} className={`py-16 px-6 ${bg} border-b border-border/60`}>
+                <section key={feat.eyebrow} className={`py-16 px-6 ${bg}`}>
                   <div className="mx-auto max-w-6xl grid md:grid-cols-2 gap-10 lg:gap-16 items-center">
                     <motion.div {...fadeUp()} className={!isEven ? "md:order-2" : ""}>
-                      <h3 className="mt-3 text-3xl md:text-4xl font-extrabold tracking-[-0.03em] leading-tight" style={{ color: "var(--color-ink)" }}>{feat.title}</h3>
+                      <h3 className="mt-3 text-3xl md:text-4xl font-display font-semibold tracking-[-0.01em] leading-tight" style={{ color: "var(--color-ink)" }}>{feat.title}</h3>
                       <p className="mt-4 text-base leading-7 text-muted-foreground">{feat.body}</p>
                       <ul className="mt-6 space-y-3">
                         {feat.bullets.map(b => (
@@ -760,8 +761,8 @@ export default function FeaturesPage() {
                         ))}
                       </ul>
                       {i === 3 && (
-                        <div className="mt-6 flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3.5">
-                          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                        <div className="mt-6 flex items-start gap-3 rounded-xl border border-hair bg-primary-subtle/60 px-4 py-3.5">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-forest" />
                           <p className="text-sm leading-6 text-foreground">
                             <span className="font-semibold">Works with services marketplaces too.</span>{" "}
                             Tracey monitors your inbox for lead notifications from hipages, ServiceSeeking, Oneflare and more — so no enquiry slips through, even when it arrives as an email.
@@ -780,20 +781,20 @@ export default function FeaturesPage() {
         ))}
 
         {/* ── 4. How it works ── */}
-        <section className="py-20 px-6 bg-background border-b border-border/60">
+        <section className="py-20 px-6 bg-paper">
           <div className="mx-auto max-w-5xl">
             <motion.div {...fadeUp()} className="text-center mb-14">
-              <h2 className="mt-3 text-4xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>Up and running in under a day</h2>
+              <h2 className="mt-3 text-4xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>Up and running in under a day</h2>
             </motion.div>
             <div className="grid md:grid-cols-3 gap-6 relative">
               {/* connecting line — desktop only */}
-              <div className="hidden md:block absolute top-10 left-[calc(16.7%+20px)] right-[calc(16.7%+20px)] h-px bg-gradient-to-r from-emerald-200 via-emerald-300 to-emerald-200" />
+              <div className="hidden md:block absolute top-10 left-[calc(16.7%+20px)] right-[calc(16.7%+20px)] h-px bg-gradient-to-r from-hair via-mint-500/40 to-hair" />
               {HOW_IT_WORKS.map((step, i) => {
                 const Icon = step.icon
                 return (
                   <motion.div key={step.num} {...fadeUp(i * 0.1)}
-                    className="relative flex flex-col items-center text-center p-7 rounded bg-card border border-border">
-                    <div className="w-14 h-14 rounded bg-card border border-emerald-200 shadow-sm flex items-center justify-center mb-5 relative z-10">
+                    className="relative flex flex-col items-center text-center p-7 rounded bg-card border border-hair">
+                    <div className="w-14 h-14 rounded bg-card border border-hair shadow-sm flex items-center justify-center mb-5 relative z-10">
                       <Icon className="w-6 h-6 text-primary" />
                     </div>
                     <span className="text-[11px] font-bold text-primary/60 tracking-widest mb-2">{step.num}</span>
@@ -807,15 +808,15 @@ export default function FeaturesPage() {
         </section>
 
         {/* ── 6. Testimonials ── */}
-        <section className="py-20 px-6 bg-card border-b border-border/60">
+        <section className="py-20 px-6 bg-cream">
           <div className="mx-auto max-w-4xl">
             <motion.div {...fadeUp()} className="text-center mb-12">
-              <h2 className="mt-3 text-4xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>Loved by tradies across Australia</h2>
+              <h2 className="mt-3 text-4xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>Loved by tradies across Australia</h2>
             </motion.div>
             <div className="grid md:grid-cols-2 gap-6">
               {TESTIMONIALS.map((t, i) => (
                 <motion.div key={i} {...fadeUp(i * 0.08)}
-                  className="rounded border border-border bg-card p-8 flex flex-col gap-6">
+                  className="rounded border border-hair bg-card p-8 flex flex-col gap-6">
                   <div className="flex gap-1">
                     {[1,2,3,4,5].map(s => (
                       <svg key={s} className="w-4 h-4 text-amber-400 fill-current" viewBox="0 0 20 20">
@@ -835,12 +836,14 @@ export default function FeaturesPage() {
         </section>
 
         {/* ── 7. Final CTA ── */}
-        <section className="py-24 px-6" style={{ background: "var(--color-forest)" }}>
-          <div className="mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
-            <motion.h2 {...fadeUp(0.04)} className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-white leading-tight text-balance">
-              Give yourself an early mark today
+        <section className="relative overflow-hidden py-16 md:py-28 px-6 bg-forest">
+          <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(70% 60% at 50% 120%, rgba(0,210,139,0.18) 0%, transparent 70%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+          <div className="relative mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
+            <motion.h2 {...fadeUp(0.04)} className="font-display text-4xl md:text-5xl font-semibold tracking-[-0.01em] text-paper leading-[1.05] text-balance">
+              Give yourself an <span className="italic text-mint-500">early mark</span> today
             </motion.h2>
-            <motion.p {...fadeUp(0.08)} className="text-lg text-white/65 leading-7 max-w-xl">
+            <motion.p {...fadeUp(0.08)} className="text-lg text-paper/65 leading-7 max-w-xl">
               Start with your own workflow, your own rules, and a setup that actually reflects how your business runs.
             </motion.p>
             <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
@@ -850,7 +853,7 @@ export default function FeaturesPage() {
                 </Button>
               </Link>
               <Link href="/contact#contact-form">
-                <Button size="lg" variant="ghost" className="text-white border-white/30 hover:bg-card/10">
+                <Button size="lg" variant="ghost" className="text-paper border border-white/25 hover:bg-white/10 hover:text-white">
                   Get a demo
                 </Button>
               </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -171,6 +171,56 @@
   backdrop-filter: blur(20px);
 }
 
+/* ───────────────────────────────────────────────────────────────────────────
+ * EARLYMARK — editorial "field-ledger" marketing primitives
+ * Bespoke layout language for the public site: hairline rules, running index
+ * labels, numbered plates, paper grain. Marketing surfaces only.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/* Subtle paper grain — lifts flat cream into a tactile printed surface */
+.em-grain {
+  position: relative;
+}
+.em-grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+}
+
+/* Tracked index/kicker label — the recurring "spec sheet" voice */
+.em-kicker {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+/* Hairline rule in the warm border tone */
+.em-rule {
+  border-color: var(--color-hair);
+}
+
+/* Display serif helper with editorial leading */
+.em-display {
+  font-family: var(--font-display), "Fraunces", Georgia, serif;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 0.98;
+}
+
+/* Figure/plate caption — annotation voice under product visuals */
+.em-figcaption {
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  color: var(--color-ink2);
+}
+
+
 :root {
   /* Typography - Plus Jakarta Sans */
   --font-sans: 'Plus Jakarta Sans', system-ui, sans-serif;

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,7 @@
 
 @theme {
   --font-sans: var(--font-sans);
+  --font-display: var(--font-display), 'Fraunces', Georgia, serif;
 
   --radius-sm: 18px;
   --radius-md: 18px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,21 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ClientThemeProvider } from "@/components/providers/client-theme-provider";
 
-import { Plus_Jakarta_Sans } from "next/font/google";
+import { Plus_Jakarta_Sans, Fraunces } from "next/font/google";
 
 const fontSans = Plus_Jakarta_Sans({
   subsets: ["latin"],
   variable: "--font-sans",
   weight: ["400", "500", "600", "700", "800"],
+});
+
+// Editorial display serif for marketing headings (warm, optical-sized).
+const fontDisplay = Fraunces({
+  subsets: ["latin"],
+  variable: "--font-display",
+  weight: ["400", "500", "600", "700"],
+  style: ["normal", "italic"],
+  axes: ["opsz", "SOFT"],
 });
 
 export const metadata: Metadata = {
@@ -36,7 +45,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${fontSans.variable} font-sans antialiased`}
+        className={`${fontSans.variable} ${fontDisplay.variable} font-sans antialiased`}
         suppressHydrationWarning
       >
         <ClientThemeProvider>{children}</ClientThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -315,7 +315,7 @@ function FaqSection() {
         <section className="py-12 md:py-20 px-6 bg-cream">
             <div className="max-w-3xl mx-auto">
                 <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest text-center mb-4">Good to know</p>
-                <h2 className="text-3xl md:text-4xl font-extrabold tracking-[-0.03em] text-center mb-10 text-ink">Frequently asked.</h2>
+                <h2 className="text-3xl md:text-4xl font-display font-semibold tracking-[-0.01em] text-center mb-10 text-ink">Frequently asked.</h2>
                 <div className="border-t border-hair">
                     {FAQ_ITEMS.map((item, idx) => {
                         const isOpen = openIndices.includes(idx);
@@ -357,9 +357,9 @@ export default function Home() {
                     <motion.p {...fadeUp(0.02)} className="text-[11px] sm:text-xs font-bold uppercase tracking-[0.28em] text-mint-500">
                         AI receptionist &amp; CRM for trades
                     </motion.p>
-                    <motion.h1 {...fadeUp(0.06)} className="text-4xl sm:text-5xl md:text-7xl font-extrabold tracking-[-0.04em] leading-[1.06] text-balance text-center text-paper">
+                    <motion.h1 {...fadeUp(0.06)} className="font-display text-4xl sm:text-5xl md:text-7xl font-semibold tracking-[-0.02em] leading-[1.04] text-balance text-center text-paper">
                         Your AI assistant &amp; CRM.
-                        <span className="block">Here to give you an <span className="text-mint-500">early mark</span></span>
+                        <span className="block">Here to give you an <span className="italic text-mint-500">early mark</span></span>
                     </motion.h1>
                     <motion.p {...fadeUp(0.08)} className="max-w-xl text-center text-base sm:text-lg leading-relaxed text-paper/65">
                         Tracey answers every call, books the job and runs your CRM — while you stay on the tools.
@@ -384,7 +384,7 @@ export default function Home() {
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="text-center mb-8 md:mb-12">
                         <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">From the tools</p>
-                        <h2 className="text-2xl sm:text-3xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">Built for businesses with non-stop calls.</h2>
+                        <h2 className="text-2xl sm:text-3xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">Built for businesses with non-stop calls.</h2>
                     </motion.div>
                     <motion.div {...fadeUp(0.08)} className="-mx-6 px-6"><TestimonialsCarousel /></motion.div>
                 </div>
@@ -398,7 +398,7 @@ export default function Home() {
                         <div className="relative grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
                             <div className="flex flex-col gap-5">
                                 <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-mint-500">Hear her first</p>
-                                <h2 className="text-3xl md:text-5xl font-extrabold text-paper tracking-[-0.03em] leading-tight">
+                                <h2 className="text-3xl md:text-5xl font-display font-semibold text-paper tracking-[-0.01em] leading-tight">
                                     Interview your assistant now.
                                 </h2>
                                 <p className="text-base md:text-lg leading-relaxed text-paper/65 max-w-md">
@@ -420,7 +420,7 @@ export default function Home() {
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
                         <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The platform</p>
-                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">One comprehensive platform.</h2>
+                        <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">One comprehensive platform.</h2>
                         <p className="mt-4 text-lg text-ink2">
                             An AI assistant and a CRM that runs itself, so you don&apos;t have to.
                         </p>
@@ -436,7 +436,7 @@ export default function Home() {
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
                         <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">Your AI offsider</p>
-                        <h2 className="text-4xl font-extrabold tracking-[-0.03em] md:text-5xl text-ink">Meet Tracey.</h2>
+                        <h2 className="text-4xl font-display font-semibold tracking-[-0.01em] md:text-5xl text-ink">Meet Tracey.</h2>
                         <p className="mt-3 text-lg max-w-xl mx-auto text-ink2">
                             Your AI receptionist, CRM manager, and follow-up specialist — all in one.
                         </p>
@@ -477,7 +477,7 @@ export default function Home() {
                 <div className="container mx-auto max-w-7xl flex flex-col gap-16">
                     <motion.div {...fadeUp()} className="text-center max-w-2xl mx-auto">
                         <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The CRM</p>
-                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">A CRM that fills itself in.</h2>
+                        <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">A CRM that fills itself in.</h2>
                         <p className="mt-3 text-lg leading-relaxed text-ink2">
                             Run it from the dashboard, the in-app chat, or just message Tracey on WhatsApp.
                         </p>
@@ -505,7 +505,7 @@ export default function Home() {
 
                     <motion.div {...fadeUp(0.10)} className="flex flex-col gap-6">
                         <div className="text-center">
-                            <h3 className="text-2xl font-extrabold tracking-[-0.02em] md:text-3xl text-ink">A full-featured CRM, built for the way trades actually work.</h3>
+                            <h3 className="text-2xl font-display font-semibold tracking-[-0.01em] md:text-3xl text-ink">A full-featured CRM, built for the way trades actually work.</h3>
                         </div>
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                             {FEATURE_CARDS.map(({ icon: Icon, title, desc }) => (
@@ -532,7 +532,7 @@ export default function Home() {
                 <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
                 <div className="mx-auto max-w-3xl text-center flex flex-col items-center gap-6 relative z-10">
                     <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">Knock off early</motion.p>
-                    <motion.h2 {...fadeUp(0.02)} className="text-4xl md:text-6xl font-extrabold tracking-[-0.04em] text-paper leading-[1.05] text-balance">Focus on the job.<br/><span className="text-mint-500">Not the admin.</span></motion.h2>
+                    <motion.h2 {...fadeUp(0.02)} className="text-4xl md:text-6xl font-display font-semibold tracking-[-0.015em] text-paper leading-[1.05] text-balance">Focus on the job.<br/><span className="text-mint-500">Not the admin.</span></motion.h2>
                     <motion.p {...fadeUp(0.04)} className="text-lg text-paper/65 leading-7 max-w-xl">Start free. No card required. Live in under a day.</motion.p>
                     <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
                         <Link href="/auth"><Button size="lg" variant="mint">Get started <ArrowRight className="ml-2 h-4 w-4" /></Button></Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import { useState } from "react";
 import { motion } from "framer-motion";
 import {
-    ArrowRight, ChevronDown,
+    ArrowRight,
     Phone, Calendar, MapPin, Users, UsersRound,
     BarChart3, CheckCircle2, MessageSquare, Layers,
     Inbox, ShieldCheck, Globe, Sparkles, Receipt,
@@ -66,6 +66,36 @@ const fadeUp = (delay = 0) => ({
 });
 
 const EASE_STANDARD: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+// ─── Editorial section header (running index — the page's signature device) ─────
+
+function SectionHead({
+    index, kicker, title, lead, dark = false,
+}: { index: string; kicker: string; title: React.ReactNode; lead?: React.ReactNode; dark?: boolean }) {
+    const ruleTone = dark ? "border-white/15" : "border-hair";
+    const idxTone = dark ? "text-mint-500" : "text-forest";
+    const kickerTone = dark ? "text-paper/45" : "text-ink2/55";
+    const titleTone = dark ? "text-paper" : "text-ink";
+    const leadTone = dark ? "text-paper/60" : "text-ink2";
+    return (
+        <motion.div {...fadeUp()} className="mb-10 md:mb-16">
+            <div className={`flex items-center gap-4 border-t ${ruleTone} pt-3.5`}>
+                <span className={`em-kicker ${idxTone}`}>{index}</span>
+                <span className={`em-kicker flex-1 ${kickerTone}`}>{kicker}</span>
+            </div>
+            <div className="mt-7 grid gap-x-8 gap-y-4 md:grid-cols-12 md:items-end">
+                <h2 className={`md:col-span-8 em-display text-[2rem] leading-[1.0] sm:text-5xl md:text-[3.5rem] ${titleTone}`}>
+                    {title}
+                </h2>
+                {lead && (
+                    <p className={`md:col-span-4 text-[15px] leading-relaxed md:self-end md:text-right ${leadTone}`}>
+                        {lead}
+                    </p>
+                )}
+            </div>
+        </motion.div>
+    );
+}
 
 // ─── Static data ──────────────────────────────────────────────────────────────
 
@@ -265,14 +295,16 @@ const TESTIMONIALS = [
 function TestimonialsCarousel() {
     const slides = [...TESTIMONIALS, ...TESTIMONIALS];
     const Card = ({ t }: { t: typeof TESTIMONIALS[0] }) => (
-        <div className="bg-card rounded-md p-8 border border-hair flex flex-col justify-between shadow-[0_2px_10px_-6px_rgba(14,31,26,0.08)]">
-            <div>
-                <span aria-hidden className="block text-5xl font-extrabold leading-none text-mint-500 select-none">&ldquo;</span>
-                <p className="text-[15px] leading-relaxed mt-2 mb-7 text-ink/85">{t.quote}</p>
-            </div>
-            <div className="border-t border-hair pt-4">
-                <p className="font-bold text-sm text-ink">{t.author}</p>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] mt-1 text-forest/70">{t.role}</p>
+        <div className="flex h-full flex-col justify-between border-t-2 border-ink bg-card/40 px-7 pt-7 pb-6">
+            <p className="em-display text-2xl leading-[1.25] text-ink">&ldquo;{t.quote}&rdquo;</p>
+            <div className="mt-8 flex items-center gap-3">
+                <span className="h-8 w-8 rounded-full bg-forest text-paper em-kicker flex items-center justify-center">
+                    {t.author.charAt(0)}
+                </span>
+                <span className="flex flex-col">
+                    <span className="text-sm font-semibold text-ink">{t.author}</span>
+                    <span className="em-kicker mt-1 text-ink2/55">{t.role}</span>
+                </span>
             </div>
         </div>
     );
@@ -312,24 +344,32 @@ function FaqSection() {
     const toggle = (idx: number) =>
         setOpenIndices((prev) => prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]);
     return (
-        <section className="py-12 md:py-20 px-6 bg-cream">
-            <div className="max-w-3xl mx-auto">
-                <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest text-center mb-4">Good to know</p>
-                <h2 className="text-3xl md:text-4xl font-display font-semibold tracking-[-0.01em] text-center mb-10 text-ink">Frequently asked.</h2>
-                <div className="border-t border-hair">
+        <section className="bg-cream px-5 sm:px-8 py-16 md:py-24">
+            <div className="mx-auto grid max-w-[1320px] gap-x-12 gap-y-10 md:grid-cols-12">
+                <div className="md:col-span-4">
+                    <div className="border-t border-hair pt-3.5 md:sticky md:top-24">
+                        <span className="em-kicker text-forest">§ Good to know</span>
+                        <h2 className="em-display mt-6 text-[2rem] leading-[1.0] text-ink sm:text-5xl">
+                            Frequently<br className="hidden md:block" /> asked.
+                        </h2>
+                        <p className="mt-5 max-w-xs text-[15px] leading-relaxed text-ink2">
+                            Still wondering something? Interview Tracey yourself — she&apos;ll answer live.
+                        </p>
+                    </div>
+                </div>
+                <div className="border-t border-ink md:col-span-8">
                     {FAQ_ITEMS.map((item, idx) => {
                         const isOpen = openIndices.includes(idx);
                         return (
                             <div key={idx} className="border-b border-hair">
                                 <button onClick={() => toggle(idx)}
-                                    className="w-full flex items-center justify-between gap-4 py-5 text-left transition-colors group">
-                                    <span className="font-semibold text-[15px] pr-4 text-ink group-hover:text-forest transition-colors">{item.q}</span>
-                                    <span className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-hair bg-card transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}>
-                                        <ChevronDown className="w-4 h-4 text-forest" />
-                                    </span>
+                                    className="group flex w-full items-baseline gap-4 py-5 text-left">
+                                    <span className="em-kicker w-6 shrink-0 text-ink2/45">{String(idx + 1).padStart(2, "0")}</span>
+                                    <span className="flex-1 pr-4 text-[15px] font-semibold text-ink transition-colors group-hover:text-forest">{item.q}</span>
+                                    <span className={`em-display shrink-0 text-2xl leading-none text-forest transition-transform duration-200 ${isOpen ? "rotate-45" : ""}`}>+</span>
                                 </button>
-                                <div className={`transition-all duration-200 overflow-hidden ${isOpen ? "max-h-60" : "max-h-0"}`}>
-                                    <p className="pb-5 pr-10 text-sm text-ink2 leading-relaxed">{item.a}</p>
+                                <div className={`overflow-hidden transition-all duration-200 ${isOpen ? "max-h-60" : "max-h-0"}`}>
+                                    <p className="pb-5 pl-10 pr-10 text-sm leading-relaxed text-ink2">{item.a}</p>
                                 </div>
                             </div>
                         );
@@ -347,84 +387,101 @@ export default function Home() {
         <div className="min-h-screen bg-paper">
             <Navbar />
 
-            {/* Hero — forest bookend */}
-            <section className="relative isolate overflow-hidden bg-forest px-6 pt-32 sm:pt-40 pb-16 sm:pb-20">
-                <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%), radial-gradient(70% 50% at 12% 105%, rgba(14,47,40,0.9) 0%, transparent 70%), radial-gradient(70% 50% at 88% 105%, rgba(14,47,40,0.9) 0%, transparent 70%)" }} />
-                <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
-                {/* paper seam — lower half of the reel sits on the next section's surface */}
-                <div aria-hidden className="absolute inset-x-0 bottom-0 z-0 h-[150px] sm:h-[220px] bg-paper" />
-                <div className="container mx-auto max-w-6xl relative z-10 flex flex-col items-center gap-8">
-                    <motion.p {...fadeUp(0.02)} className="text-[11px] sm:text-xs font-bold uppercase tracking-[0.28em] text-mint-500">
-                        AI receptionist &amp; CRM for trades
-                    </motion.p>
-                    <motion.h1 {...fadeUp(0.06)} className="font-display text-4xl sm:text-5xl md:text-7xl font-semibold tracking-[-0.02em] leading-[1.04] text-balance text-center text-paper">
-                        Your AI assistant &amp; CRM.
-                        <span className="block">Here to give you an <span className="italic text-mint-500">early mark</span></span>
-                    </motion.h1>
-                    <motion.p {...fadeUp(0.08)} className="max-w-xl text-center text-base sm:text-lg leading-relaxed text-paper/65">
-                        Tracey answers every call, books the job and runs your CRM — while you stay on the tools.
-                    </motion.p>
-                    <motion.div {...fadeUp(0.10)} className="flex flex-col sm:flex-row gap-3">
-                        <Link href="/auth"><Button size="lg" variant="mint">Get started</Button></Link>
-                        <a href="#interview-assistant"><Button size="lg" variant="outline" className="border-white/25 bg-transparent text-paper hover:bg-white/10 hover:border-white/40 hover:text-white">Interview your assistant</Button></a>
+            {/* Hero — editorial masthead */}
+            <section className="em-grain relative overflow-hidden bg-cream px-5 sm:px-8 pt-24 sm:pt-28 pb-20 sm:pb-28">
+                <div className="relative z-10 mx-auto max-w-[1320px]">
+                    {/* masthead rule */}
+                    <motion.div {...fadeUp(0.02)} className="flex items-center justify-between gap-4 border-t border-hair pt-3.5">
+                        <span className="em-kicker text-forest">§00 — Index</span>
+                        <span className="em-kicker hidden text-ink2/55 sm:inline">AI receptionist &amp; CRM</span>
+                        <span className="em-kicker text-ink2/55">Australia</span>
                     </motion.div>
-                    <motion.div {...fadeUp(0.14)} className="relative w-full max-w-5xl mx-auto mt-8 sm:mt-12">
-                        <HeroDashboardReel />
-                        <motion.div {...fadeUp(0.18)} className="hidden md:block absolute right-[-0.75rem] lg:right-[-1.5rem] bottom-[-3.25rem] z-20">
-                            <PulsingLogo />
+
+                    {/* headline + spec column */}
+                    <div className="mt-12 grid gap-x-8 gap-y-10 sm:mt-16 md:grid-cols-12 md:items-end">
+                        <motion.h1 {...fadeUp(0.06)} className="em-display col-span-12 text-[clamp(2.75rem,8vw,6.75rem)] text-ink md:col-span-8">
+                            Your AI assistant <span className="text-ink2/50">&amp;</span> CRM.<br />
+                            Here to give you an <span className="italic text-forest">early mark</span>.
+                        </motion.h1>
+                        <motion.div {...fadeUp(0.12)} className="col-span-12 flex flex-col gap-6 md:col-span-4 md:pb-2">
+                            <p className="max-w-sm text-[15px] leading-relaxed text-ink2">
+                                Tracey answers every call, books the job and runs your CRM — while you stay on the tools.
+                            </p>
+                            <div className="flex flex-col gap-3 sm:flex-row">
+                                <Link href="/auth"><Button size="lg" variant="mint">Get started</Button></Link>
+                                <a href="#interview-assistant"><Button size="lg" variant="outline">Interview Tracey</Button></a>
+                            </div>
                         </motion.div>
-                    </motion.div>
+                    </div>
+
+                    {/* Plate 01 — the reel framed as a figure */}
+                    <motion.figure {...fadeUp(0.16)} className="relative mt-14 sm:mt-20">
+                        <figcaption className="flex items-center justify-between gap-4 border-t border-hair pt-3 pb-5">
+                            <span className="em-kicker text-forest">Plate 01</span>
+                            <span className="em-figcaption text-right">Tracey at work — chat, inbox, map &amp; calendar</span>
+                        </figcaption>
+                        <div className="relative">
+                            <HeroDashboardReel />
+                            <div className="absolute bottom-[-3.25rem] right-[-0.75rem] z-20 hidden md:block lg:right-[-1.5rem]">
+                                <PulsingLogo />
+                            </div>
+                        </div>
+                    </motion.figure>
                 </div>
             </section>
 
             <TrustStrip />
 
             {/* Testimonials */}
-            <section className="bg-cream px-6 py-12 md:py-20 overflow-hidden">
-                <div className="container mx-auto max-w-7xl">
-                    <motion.div {...fadeUp()} className="text-center mb-8 md:mb-12">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">From the tools</p>
-                        <h2 className="text-2xl sm:text-3xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">Built for businesses with non-stop calls.</h2>
-                    </motion.div>
-                    <motion.div {...fadeUp(0.08)} className="-mx-6 px-6"><TestimonialsCarousel /></motion.div>
+            <section className="overflow-hidden bg-cream px-5 sm:px-8 py-16 md:py-24">
+                <div className="mx-auto max-w-[1320px]">
+                    <SectionHead
+                        index="§ Field notes"
+                        kicker="From the tools"
+                        title={<>Built for businesses<br className="hidden sm:block" /> with non-stop calls.</>}
+                        lead="Real operators, real days on site — the admin handled in the background."
+                    />
+                    <motion.div {...fadeUp(0.08)} className="-mx-5 px-5 sm:-mx-8 sm:px-8"><TestimonialsCarousel /></motion.div>
                 </div>
             </section>
 
             {/* Interview form — invitation to try Tracey */}
-            <section id="interview-assistant" className="scroll-mt-28 py-12 md:py-20 px-6 bg-paper">
-                <div className="container mx-auto max-w-7xl">
-                    <motion.div {...fadeUp()} className="relative overflow-hidden rounded-md p-7 sm:p-10 md:p-14" style={{ background: "var(--color-forest-dk)" }}>
-                        <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(80% 90% at 85% 0%, rgba(0,210,139,0.14) 0%, transparent 60%)" }} />
-                        <div className="relative grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
-                            <div className="flex flex-col gap-5">
-                                <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-mint-500">Hear her first</p>
-                                <h2 className="text-3xl md:text-5xl font-display font-semibold text-paper tracking-[-0.01em] leading-tight">
-                                    Interview your assistant now.
+            <section id="interview-assistant" className="scroll-mt-20 bg-forest-dk px-5 sm:px-8 py-16 md:py-24">
+                <div className="relative mx-auto max-w-[1320px]">
+                    <div aria-hidden className="pointer-events-none absolute inset-0" style={{ background: "radial-gradient(70% 90% at 90% 0%, rgba(0,210,139,0.12) 0%, transparent 60%)" }} />
+                    <div className="relative">
+                        <div className="flex items-center gap-4 border-t border-white/15 pt-3.5">
+                            <span className="em-kicker text-mint-500">§ Hear her first</span>
+                            <span className="em-kicker flex-1 text-paper/40">No card required</span>
+                        </div>
+                        <div className="mt-10 grid items-end gap-x-8 gap-y-10 lg:grid-cols-12">
+                            <motion.div {...fadeUp()} className="flex flex-col gap-6 lg:col-span-7">
+                                <h2 className="em-display text-[2rem] leading-[1.0] text-paper sm:text-5xl md:text-[3.5rem]">
+                                    Interview your assistant<br className="hidden sm:block" /> before she starts.
                                 </h2>
-                                <p className="text-base md:text-lg leading-relaxed text-paper/65 max-w-md">
+                                <p className="max-w-md text-base leading-relaxed text-paper/60">
                                     She will contact customers and run your CRM so you don&apos;t have to. Put her on the phone before you put her on the payroll.
                                 </p>
-                            </div>
-                            <motion.div {...fadeUp(0.1)} className="bg-card rounded-md p-7 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]">
-                                <h3 className="font-bold text-lg mb-1 text-ink">Interview Tracey for free</h3>
-                                <p className="text-sm mb-6 leading-relaxed text-ink2">Tracey will call you and answer questions, explain her capabilities, or roleplay as your very own AI receptionist.</p>
+                            </motion.div>
+                            <motion.div {...fadeUp(0.1)} className="bg-card rounded-md p-7 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.5)] lg:col-span-5">
+                                <h3 className="mb-1 text-lg font-bold text-ink">Interview Tracey for free</h3>
+                                <p className="mb-6 text-sm leading-relaxed text-ink2">Tracey will call you and answer questions, explain her capabilities, or roleplay as your very own AI receptionist.</p>
                                 <InterviewForm />
                             </motion.div>
                         </div>
-                    </motion.div>
+                    </div>
                 </div>
             </section>
 
             {/* Platform diagram — voice agent + CRM */}
-            <section id="platform" className="bg-paper px-6 py-12 md:py-20">
-                <div className="container mx-auto max-w-7xl">
-                    <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The platform</p>
-                        <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">One comprehensive platform.</h2>
-                        <p className="mt-4 text-lg text-ink2">
-                            An AI assistant and a CRM that runs itself, so you don&apos;t have to.
-                        </p>
-                    </motion.div>
+            <section id="platform" className="bg-paper px-5 sm:px-8 py-16 md:py-24">
+                <div className="mx-auto max-w-[1320px]">
+                    <SectionHead
+                        index="§01 — Platform"
+                        kicker="Two halves, one system"
+                        title="One comprehensive platform."
+                        lead="An AI assistant and a CRM that runs itself, so you don't have to."
+                    />
                     <motion.div {...fadeUp(0.08)}>
                         <PlatformDiagram />
                     </motion.div>
@@ -432,37 +489,31 @@ export default function Home() {
             </section>
 
             {/* Section 1 — Meet Tracey (the voice agent) */}
-            <section id="meet-tracey" className="bg-cream px-6 py-12 md:py-20">
-                <div className="container mx-auto max-w-7xl">
-                    <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">Your AI offsider</p>
-                        <h2 className="text-4xl font-display font-semibold tracking-[-0.01em] md:text-5xl text-ink">Meet Tracey.</h2>
-                        <p className="mt-3 text-lg max-w-xl mx-auto text-ink2">
-                            Your AI receptionist, CRM manager, and follow-up specialist — all in one.
-                        </p>
-                    </motion.div>
+            <section id="meet-tracey" className="bg-cream px-5 sm:px-8 py-16 md:py-24">
+                <div className="mx-auto max-w-[1320px]">
+                    <SectionHead
+                        index="§02 — The assistant"
+                        kicker="Your AI offsider"
+                        title="Meet Tracey."
+                        lead="Your AI receptionist, CRM manager, and follow-up specialist — all in one."
+                    />
 
-                    <motion.div {...fadeUp(0.06)} className="grid sm:grid-cols-3 gap-4 relative">
-                        {/* dashed vertical guide on mobile */}
-                        <div className="absolute left-[22px] top-6 bottom-6 w-0.5 sm:hidden" style={{ background: "repeating-linear-gradient(to bottom, var(--color-hair) 0 4px, transparent 4px 8px)" }} aria-hidden />
+                    <motion.div {...fadeUp(0.06)} className="grid gap-x-8 gap-y-10 sm:grid-cols-3">
                         {TRACEY_WORKFLOW.map(({ label, points }, i) => (
-                            <div key={label} className="bg-card border border-hair rounded-md p-6 flex gap-4 sm:flex-col sm:gap-5 shadow-[0_2px_10px_-6px_rgba(14,31,26,0.08)]">
-                                <div className="flex-shrink-0 relative z-10">
-                                    <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-paper bg-forest ring-4 ring-cream">
-                                        0{i + 1}
-                                    </div>
+                            <div key={label} className="flex flex-col border-t-2 border-ink pt-5">
+                                <div className="flex items-baseline justify-between">
+                                    <span className="em-display text-5xl text-forest">0{i + 1}</span>
+                                    <span className="em-kicker text-ink2/45">Step</span>
                                 </div>
-                                <div className="flex-1 min-w-0">
-                                    <h4 className="text-base font-bold mb-3 text-ink">{label}</h4>
-                                    <ul className="space-y-2.5">
-                                        {points.map((point) => (
-                                            <li key={point} className="flex items-start gap-2.5">
-                                                <span className="mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 bg-mint-500" />
-                                                <span className="text-sm leading-relaxed text-ink2">{point}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
+                                <h4 className="mt-4 mb-4 text-lg font-semibold text-ink">{label}</h4>
+                                <ul className="space-y-3">
+                                    {points.map((point) => (
+                                        <li key={point} className="flex items-start gap-2.5 border-t border-hair pt-3">
+                                            <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-mint-500" />
+                                            <span className="text-sm leading-relaxed text-ink2">{point}</span>
+                                        </li>
+                                    ))}
+                                </ul>
                             </div>
                         ))}
                     </motion.div>
@@ -473,50 +524,46 @@ export default function Home() {
                 </div>
             </section>
             {/* Section 2 — A CRM that fills itself in */}
-            <section id="product" className="py-12 md:py-20 px-6 bg-paper">
-                <div className="container mx-auto max-w-7xl flex flex-col gap-16">
-                    <motion.div {...fadeUp()} className="text-center max-w-2xl mx-auto">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The CRM</p>
-                        <h2 className="text-4xl md:text-5xl font-display font-semibold tracking-[-0.01em] text-ink">A CRM that fills itself in.</h2>
-                        <p className="mt-3 text-lg leading-relaxed text-ink2">
-                            Run it from the dashboard, the in-app chat, or just message Tracey on WhatsApp.
-                        </p>
-                    </motion.div>
+            <section id="product" className="bg-paper px-5 sm:px-8 py-16 md:py-24">
+                <div className="mx-auto flex max-w-[1320px] flex-col gap-16">
+                    <SectionHead
+                        index="§03 — The CRM"
+                        kicker="Runs on plain English"
+                        title={<>A CRM that<br className="hidden sm:block" /> fills itself in.</>}
+                        lead="Run it from the dashboard, the in-app chat, or just message Tracey on WhatsApp."
+                    />
 
-                    <motion.div {...fadeUp(0.06)} className="grid items-center gap-8 md:grid-cols-2">
-                        <div className="flex flex-col gap-6">
-                            <ul className="flex flex-col gap-3">
-                                {[
-                                    "One message moves a job, sends a quote, or closes a lead",
-                                    "Chat drives the CRM — Tracey handles the form-filling",
-                                    "Your whole pipeline, accessible by message",
-                                ].map((b) => (
-                                    <li key={b} className="flex items-start gap-2.5 text-sm text-ink2">
-                                        <CheckCircle2 className="mt-0.5 w-4 h-4 text-mint-500 shrink-0" />
-                                        <span>{b}</span>
-                                    </li>
-                                ))}
-                            </ul>
+                    <motion.div {...fadeUp(0.06)} className="grid items-stretch gap-8 md:grid-cols-2">
+                        <div className="flex flex-col justify-center gap-5">
+                            {[
+                                "One message moves a job, sends a quote, or closes a lead",
+                                "Chat drives the CRM — Tracey handles the form-filling",
+                                "Your whole pipeline, accessible by message",
+                            ].map((b, i) => (
+                                <div key={b} className="flex items-start gap-4 border-t border-hair pt-4">
+                                    <span className="em-kicker text-forest">0{i + 1}</span>
+                                    <span className="text-[15px] leading-relaxed text-ink">{b}</span>
+                                </div>
+                            ))}
                         </div>
-                        <div className="relative min-h-[380px] overflow-hidden rounded-md border border-hair shadow-[0_18px_50px_-22px_rgba(14,31,26,0.25)]">
+                        <div className="relative min-h-[380px] overflow-hidden rounded-md border border-hair shadow-[0_24px_60px_-30px_rgba(14,31,26,0.4)]">
                             <HireMockup1 />
                         </div>
                     </motion.div>
 
-                    <motion.div {...fadeUp(0.10)} className="flex flex-col gap-6">
-                        <div className="text-center">
-                            <h3 className="text-2xl font-display font-semibold tracking-[-0.01em] md:text-3xl text-ink">A full-featured CRM, built for the way trades actually work.</h3>
+                    {/* Feature ledger — bill of materials, not icon cards */}
+                    <motion.div {...fadeUp(0.10)} className="flex flex-col gap-8">
+                        <div className="flex items-center gap-4 border-t border-hair pt-3.5">
+                            <span className="em-kicker text-forest">§ Index of features</span>
+                            <span className="em-kicker flex-1 text-ink2/55">Twelve, included from day one</span>
                         </div>
-                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                            {FEATURE_CARDS.map(({ icon: Icon, title, desc }) => (
-                                <div key={title} className="group flex items-start gap-3 rounded-md border border-hair bg-card p-4 transition-all hover:-translate-y-0.5 hover:border-mint-500/40 hover:shadow-[0_10px_24px_-12px_rgba(14,31,26,0.22)]">
-                                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-subtle">
-                                        <Icon className="h-4 w-4 text-forest" />
-                                    </div>
-                                    <div className="flex flex-col gap-0.5 min-w-0">
-                                        <span className="text-sm font-semibold text-ink">{title}</span>
-                                        <span className="text-xs leading-relaxed text-ink2/85">{desc}</span>
-                                    </div>
+                        <div className="grid gap-x-12 md:grid-cols-2">
+                            {FEATURE_CARDS.map(({ icon: Icon, title, desc }, i) => (
+                                <div key={title} className="group flex items-baseline gap-4 border-b border-hair py-4 transition-colors hover:bg-cream/50">
+                                    <span className="em-kicker w-6 shrink-0 text-ink2/45">{String(i + 1).padStart(2, "0")}</span>
+                                    <Icon className="h-4 w-4 shrink-0 translate-y-0.5 text-forest" />
+                                    <span className="w-40 shrink-0 text-[15px] font-semibold text-ink">{title}</span>
+                                    <span className="hidden flex-1 text-sm leading-relaxed text-ink2/80 sm:block">{desc}</span>
                                 </div>
                             ))}
                         </div>
@@ -527,16 +574,20 @@ export default function Home() {
             <FaqSection />
 
             {/* Final CTA — forest bookend, flows into the footer */}
-            <section className="py-16 md:py-28 px-6 relative overflow-hidden bg-forest">
-                <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(80% 70% at 50% 120%, rgba(0,210,139,0.18) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
-                <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-                <div className="mx-auto max-w-3xl text-center flex flex-col items-center gap-6 relative z-10">
-                    <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">Knock off early</motion.p>
-                    <motion.h2 {...fadeUp(0.02)} className="text-4xl md:text-6xl font-display font-semibold tracking-[-0.015em] text-paper leading-[1.05] text-balance">Focus on the job.<br/><span className="text-mint-500">Not the admin.</span></motion.h2>
-                    <motion.p {...fadeUp(0.04)} className="text-lg text-paper/65 leading-7 max-w-xl">Start free. No card required. Live in under a day.</motion.p>
-                    <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
+            <section className="em-grain relative overflow-hidden bg-forest px-5 sm:px-8 py-20 md:py-32">
+                <div aria-hidden className="pointer-events-none absolute inset-0" style={{ background: "radial-gradient(80% 70% at 50% 120%, rgba(0,210,139,0.18) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
+                <div className="relative z-10 mx-auto max-w-[1320px]">
+                    <motion.div {...fadeUp()} className="flex items-center gap-4 border-t border-white/15 pt-3.5">
+                        <span className="em-kicker text-mint-500">§ Knock off early</span>
+                        <span className="em-kicker flex-1 text-paper/40">Live in under a day</span>
+                    </motion.div>
+                    <motion.h2 {...fadeUp(0.04)} className="em-display mt-10 text-[clamp(3rem,10vw,8rem)] text-paper">
+                        Focus on the job.<br /><span className="italic text-mint-500">Not the admin.</span>
+                    </motion.h2>
+                    <motion.div {...fadeUp(0.12)} className="mt-12 flex flex-col items-start gap-6 sm:flex-row sm:items-center">
                         <Link href="/auth"><Button size="lg" variant="mint">Get started <ArrowRight className="ml-2 h-4 w-4" /></Button></Link>
-                        <Link href="/contact#contact-form"><Button size="lg" variant="ghost" className="text-paper border border-white/25 hover:bg-white/10 hover:text-white">Get a demo</Button></Link>
+                        <Link href="/contact#contact-form"><Button size="lg" variant="ghost" className="border border-white/25 text-paper hover:bg-white/10 hover:text-white">Get a demo</Button></Link>
+                        <span className="text-sm text-paper/55 sm:ml-2">Start free. No card required.</span>
                     </motion.div>
                 </div>
             </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { requestDemoCall } from "@/actions/demo-call-action";
 import { TrustStrip } from "@/components/home/trust-strip";
 import { MobileStickyCTA } from "@/components/home/mobile-sticky-cta";
+import { SectionHead } from "@/components/marketing/section-head";
 
 const HeroDashboardReel = dynamic(
     () => import("@/components/home/hero-dashboard-reel").then((mod) => mod.HeroDashboardReel),
@@ -66,36 +67,6 @@ const fadeUp = (delay = 0) => ({
 });
 
 const EASE_STANDARD: [number, number, number, number] = [0.16, 1, 0.3, 1];
-
-// ─── Editorial section header (running index — the page's signature device) ─────
-
-function SectionHead({
-    index, kicker, title, lead, dark = false,
-}: { index: string; kicker: string; title: React.ReactNode; lead?: React.ReactNode; dark?: boolean }) {
-    const ruleTone = dark ? "border-white/15" : "border-hair";
-    const idxTone = dark ? "text-mint-500" : "text-forest";
-    const kickerTone = dark ? "text-paper/45" : "text-ink2/55";
-    const titleTone = dark ? "text-paper" : "text-ink";
-    const leadTone = dark ? "text-paper/60" : "text-ink2";
-    return (
-        <motion.div {...fadeUp()} className="mb-10 md:mb-16">
-            <div className={`flex items-center gap-4 border-t ${ruleTone} pt-3.5`}>
-                <span className={`em-kicker ${idxTone}`}>{index}</span>
-                <span className={`em-kicker flex-1 ${kickerTone}`}>{kicker}</span>
-            </div>
-            <div className="mt-7 grid gap-x-8 gap-y-4 md:grid-cols-12 md:items-end">
-                <h2 className={`md:col-span-8 em-display text-[2rem] leading-[1.0] sm:text-5xl md:text-[3.5rem] ${titleTone}`}>
-                    {title}
-                </h2>
-                {lead && (
-                    <p className={`md:col-span-4 text-[15px] leading-relaxed md:self-end md:text-right ${leadTone}`}>
-                        {lead}
-                    </p>
-                )}
-            </div>
-        </motion.div>
-    );
-}
 
 // ─── Static data ──────────────────────────────────────────────────────────────
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,8 +22,8 @@ const HeroDashboardReel = dynamic(
     () => import("@/components/home/hero-dashboard-reel").then((mod) => mod.HeroDashboardReel),
     {
         loading: () => (
-            <div className="relative mx-auto w-full max-w-[1120px] overflow-hidden rounded border border-white/55 bg-card/55 shadow-[0_28px_90px_rgba(15,23,42,0.16)] backdrop-blur-xl">
-                <div className="aspect-[16/10] bg-[linear-gradient(180deg,#e2e8f0_0%,#cbd5e1_100%)] sm:aspect-[16/9]" />
+            <div className="relative mx-auto w-full max-w-[1120px] overflow-hidden rounded-md border border-white/15 bg-card/10 shadow-[0_28px_90px_rgba(0,0,0,0.35)] backdrop-blur-xl">
+                <div className="aspect-[16/10] bg-[linear-gradient(180deg,#F6F4EE_0%,#F1ECDD_100%)] sm:aspect-[16/9]" />
             </div>
         ),
     },
@@ -125,25 +125,25 @@ function HireMockup1() {
     ];
     return (
         <div className="h-full flex flex-col bg-card">
-            <div className="flex items-center gap-2 px-4 py-3 border-b border-neutral-200">
-                <div className="w-6 h-6 rounded-full bg-card border border-neutral-200 flex items-center justify-center shadow-sm">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-hair">
+                <div className="w-6 h-6 rounded-full bg-card border border-hair flex items-center justify-center shadow-sm">
                     <Image src="/latest-logo.png" alt="" width={14} height={14} className="w-3.5 h-3.5 object-contain" unoptimized />
                 </div>
-                <span className="text-xs font-semibold text-neutral-900">Tracey Chat</span>
-                <span className="ml-auto text-[10px] text-emerald-500">● Online</span>
+                <span className="text-xs font-semibold text-ink">Tracey Chat</span>
+                <span className="ml-auto text-[10px] text-mint-500">● Online</span>
             </div>
-            <div className="flex-1 flex flex-col justify-end gap-2.5 px-4 py-4 bg-[#F8FAFC]">
+            <div className="flex-1 flex flex-col justify-end gap-2.5 px-4 py-4 bg-paper">
                 {messages.map((m, i) => (
                     <div key={i} className={`flex gap-2 items-end ${m.from === "user" ? "flex-row-reverse" : ""}`}>
                         {m.from === "tracey" && (
-                            <div className="w-5 h-5 rounded-full bg-card border border-neutral-200 flex items-center justify-center shrink-0 shadow-sm">
+                            <div className="w-5 h-5 rounded-full bg-card border border-hair flex items-center justify-center shrink-0 shadow-sm">
                                 <Image src="/latest-logo.png" alt="" width={12} height={12} className="w-3 h-3 object-contain" unoptimized />
                             </div>
                         )}
-                        <div className={`rounded px-3 py-2 text-xs leading-relaxed max-w-[80%] ${
+                        <div className={`rounded-md px-3 py-2 text-xs leading-relaxed max-w-[80%] ${
                             m.from === "user"
-                                ? "bg-primary text-white rounded-tr-sm"
-                                : "bg-card border border-neutral-200 text-neutral-800 rounded-bl-sm shadow-sm"
+                                ? "bg-forest text-paper rounded-tr-sm"
+                                : "bg-card border border-hair text-ink rounded-bl-sm shadow-sm"
                         }`}>
                             {m.text}
                         </div>
@@ -157,7 +157,7 @@ function HireMockup1() {
 // ─── Interview Form ───────────────────────────────────────────────────────────
 
 const INPUT_CLASS =
-    "w-full px-4 py-2.5 rounded-md border border-border text-sm placeholder:text-muted-foreground bg-card transition";
+    "w-full px-4 py-2.5 rounded-md border border-hair text-sm text-ink placeholder:text-ink2/55 bg-paper/60 transition";
 
 const DEMO_CALL_TIMEOUT_MS = 30_000;
 
@@ -213,10 +213,10 @@ function InterviewForm() {
     if (status === "success") {
         return (
             <div className="flex flex-col items-center justify-center text-center gap-4 py-10">
-                <div className="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
-                    <Phone className="w-8 h-8 text-primary" />
+                <div className="w-16 h-16 rounded-full bg-primary-subtle flex items-center justify-center">
+                    <Phone className="w-8 h-8 text-forest" />
                 </div>
-                <h3 className="text-xl font-bold" style={{ color: "var(--color-ink)" }}>
+                <h3 className="text-xl font-bold text-ink">
                     {message || "Tracey is calling you now!"}
                 </h3>
             </div>
@@ -247,7 +247,7 @@ function InterviewForm() {
                 {status === "loading" ? "Calling you now..." : "Interview Tracey for free"}
                 {status !== "loading" && <Phone className="ml-2 h-4 w-4" />}
             </Button>
-            <p className="text-xs text-slate-body text-center">
+            <p className="text-xs text-ink2/75 text-center">
                 Tracey will call you within seconds. No credit card required.
             </p>
         </form>
@@ -265,20 +265,14 @@ const TESTIMONIALS = [
 function TestimonialsCarousel() {
     const slides = [...TESTIMONIALS, ...TESTIMONIALS];
     const Card = ({ t }: { t: typeof TESTIMONIALS[0] }) => (
-        <div className="bg-card rounded p-8 shadow-sm border border-border flex flex-col justify-between">
+        <div className="bg-card rounded-md p-8 border border-hair flex flex-col justify-between shadow-[0_2px_10px_-6px_rgba(14,31,26,0.08)]">
             <div>
-                <div className="flex gap-1 mb-4">
-                    {[1,2,3,4,5].map(s => (
-                        <svg key={s} className="w-4 h-4 text-amber-400 fill-current" viewBox="0 0 20 20">
-                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                        </svg>
-                    ))}
-                </div>
-                <p className="italic text-[15px] leading-relaxed mb-6" style={{ color: "var(--color-ink)", opacity: 0.8 }}>&quot;{t.quote}&quot;</p>
+                <span aria-hidden className="block text-5xl font-extrabold leading-none text-mint-500 select-none">&ldquo;</span>
+                <p className="text-[15px] leading-relaxed mt-2 mb-7 text-ink/85">{t.quote}</p>
             </div>
-            <div>
-                <p className="font-bold text-sm" style={{ color: "var(--color-ink)" }}>{t.author}</p>
-                <p className="text-xs text-muted-foreground font-medium mt-0.5">{t.role}</p>
+            <div className="border-t border-hair pt-4">
+                <p className="font-bold text-sm text-ink">{t.author}</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] mt-1 text-forest/70">{t.role}</p>
             </div>
         </div>
     );
@@ -293,8 +287,8 @@ function TestimonialsCarousel() {
                     transition={{ duration: 26, ease: "linear", repeat: Infinity }}>
                     {slides.map((t, i) => <div key={`${t.author}-${i}`} className="w-[350px]"><Card t={t} /></div>)}
                 </motion.div>
-                <div className="pointer-events-none absolute inset-y-0 left-0 w-20 bg-[linear-gradient(90deg,#F8FAFC_0%,rgba(248,250,252,0)_100%)]" />
-                <div className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-[linear-gradient(270deg,#F8FAFC_0%,rgba(248,250,252,0)_100%)]" />
+                <div className="pointer-events-none absolute inset-y-0 left-0 w-24 bg-[linear-gradient(90deg,#F1ECDD_0%,rgba(241,236,221,0)_100%)]" />
+                <div className="pointer-events-none absolute inset-y-0 right-0 w-24 bg-[linear-gradient(270deg,#F1ECDD_0%,rgba(241,236,221,0)_100%)]" />
             </div>
         </div>
     );
@@ -318,21 +312,24 @@ function FaqSection() {
     const toggle = (idx: number) =>
         setOpenIndices((prev) => prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]);
     return (
-        <section className="py-10 md:py-20 px-4 bg-background">
+        <section className="py-12 md:py-20 px-6 bg-cream">
             <div className="max-w-3xl mx-auto">
-                <h2 className="text-3xl font-bold text-center mb-10" style={{ color: "var(--color-ink)" }}>Frequently asked.</h2>
-                <div className="space-y-3">
+                <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest text-center mb-4">Good to know</p>
+                <h2 className="text-3xl md:text-4xl font-extrabold tracking-[-0.03em] text-center mb-10 text-ink">Frequently asked.</h2>
+                <div className="border-t border-hair">
                     {FAQ_ITEMS.map((item, idx) => {
                         const isOpen = openIndices.includes(idx);
                         return (
-                            <div key={idx} className="border border-border rounded overflow-hidden">
+                            <div key={idx} className="border-b border-hair">
                                 <button onClick={() => toggle(idx)}
-                                    className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-muted/30 transition-colors">
-                                    <span className="font-semibold text-sm pr-4" style={{ color: "var(--color-ink)" }}>{item.q}</span>
-                                    <ChevronDown className={`w-5 h-5 text-muted-foreground shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} />
+                                    className="w-full flex items-center justify-between gap-4 py-5 text-left transition-colors group">
+                                    <span className="font-semibold text-[15px] pr-4 text-ink group-hover:text-forest transition-colors">{item.q}</span>
+                                    <span className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-hair bg-card transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}>
+                                        <ChevronDown className="w-4 h-4 text-forest" />
+                                    </span>
                                 </button>
                                 <div className={`transition-all duration-200 overflow-hidden ${isOpen ? "max-h-60" : "max-h-0"}`}>
-                                    <p className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">{item.a}</p>
+                                    <p className="pb-5 pr-10 text-sm text-ink2 leading-relaxed">{item.a}</p>
                                 </div>
                             </div>
                         );
@@ -347,24 +344,31 @@ function FaqSection() {
 
 export default function Home() {
     return (
-        <div className="min-h-screen bg-background">
+        <div className="min-h-screen bg-paper">
             <Navbar />
 
-            {/* Hero */}
-            <section className="pt-24 sm:pt-32 pb-16 sm:pb-24 px-6 relative overflow-hidden isolate bg-[linear-gradient(180deg,#F8FAFC_0%,#F1F5F9_55%,#F8FAFC_100%)]">
-                <div className="absolute inset-0 z-0 pointer-events-none" style={{ background: `radial-gradient(110% 70% at 50% 10%, rgba(16,185,129,0.20) 0%, rgba(16,185,129,0.10) 42%, rgba(16,185,129,0.00) 74%),radial-gradient(90% 50% at 50% 86%, rgba(34,197,94,0.30) 0%, rgba(34,197,94,0.14) 32%, rgba(34,197,94,0.00) 72%),radial-gradient(70% 34% at 50% 86%, rgba(163,230,53,0.22) 0%, rgba(163,230,53,0.00) 75%)` }} />
-                <div className="absolute inset-y-[2%] left-0 w-[32%] z-0 pointer-events-none opacity-60" style={{ background: "linear-gradient(180deg, rgba(16,185,129,0.12) 0%, rgba(16,185,129,0.05) 48%, rgba(16,185,129,0.00) 100%)", clipPath: "polygon(0 0, 100% 6%, 76% 100%, 0 100%)" }} />
-                <div className="absolute inset-y-[2%] right-0 w-[32%] z-0 pointer-events-none opacity-60" style={{ background: "linear-gradient(180deg, rgba(16,185,129,0.12) 0%, rgba(16,185,129,0.05) 48%, rgba(16,185,129,0.00) 100%)", clipPath: "polygon(24% 0, 100% 0, 100% 100%, 0 100%)" }} />
+            {/* Hero — forest bookend */}
+            <section className="relative isolate overflow-hidden bg-forest px-6 pt-32 sm:pt-40 pb-16 sm:pb-20">
+                <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%), radial-gradient(70% 50% at 12% 105%, rgba(14,47,40,0.9) 0%, transparent 70%), radial-gradient(70% 50% at 88% 105%, rgba(14,47,40,0.9) 0%, transparent 70%)" }} />
+                <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+                {/* paper seam — lower half of the reel sits on the next section's surface */}
+                <div aria-hidden className="absolute inset-x-0 bottom-0 z-0 h-[150px] sm:h-[220px] bg-paper" />
                 <div className="container mx-auto max-w-6xl relative z-10 flex flex-col items-center gap-8">
-                    <motion.h1 {...fadeUp(0.06)} className="text-4xl sm:text-5xl md:text-7xl font-extrabold tracking-[-0.04em] leading-[1.08] text-balance text-center" style={{ color: "var(--color-ink)" }}>
+                    <motion.p {...fadeUp(0.02)} className="text-[11px] sm:text-xs font-bold uppercase tracking-[0.28em] text-mint-500">
+                        AI receptionist &amp; CRM for trades
+                    </motion.p>
+                    <motion.h1 {...fadeUp(0.06)} className="text-4xl sm:text-5xl md:text-7xl font-extrabold tracking-[-0.04em] leading-[1.06] text-balance text-center text-paper">
                         Your AI assistant &amp; CRM.
-                        <span className="block">Here to give you an <span className="text-primary">early mark</span></span>
+                        <span className="block">Here to give you an <span className="text-mint-500">early mark</span></span>
                     </motion.h1>
+                    <motion.p {...fadeUp(0.08)} className="max-w-xl text-center text-base sm:text-lg leading-relaxed text-paper/65">
+                        Tracey answers every call, books the job and runs your CRM — while you stay on the tools.
+                    </motion.p>
                     <motion.div {...fadeUp(0.10)} className="flex flex-col sm:flex-row gap-3">
                         <Link href="/auth"><Button size="lg" variant="mint">Get started</Button></Link>
-                        <a href="#interview-assistant"><Button size="lg" variant="outline">Interview your assistant</Button></a>
+                        <a href="#interview-assistant"><Button size="lg" variant="outline" className="border-white/25 bg-transparent text-paper hover:bg-white/10 hover:border-white/40 hover:text-white">Interview your assistant</Button></a>
                     </motion.div>
-                    <motion.div {...fadeUp(0.14)} className="relative w-full max-w-5xl mx-auto mt-8">
+                    <motion.div {...fadeUp(0.14)} className="relative w-full max-w-5xl mx-auto mt-8 sm:mt-12">
                         <HeroDashboardReel />
                         <motion.div {...fadeUp(0.18)} className="hidden md:block absolute right-[-0.75rem] lg:right-[-1.5rem] bottom-[-3.25rem] z-20">
                             <PulsingLogo />
@@ -376,39 +380,48 @@ export default function Home() {
             <TrustStrip />
 
             {/* Testimonials */}
-            <section className="bg-card px-6 py-12 md:py-24 overflow-hidden">
+            <section className="bg-cream px-6 py-12 md:py-20 overflow-hidden">
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="text-center mb-8 md:mb-12">
-                        <h2 className="text-2xl sm:text-3xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>Built for businesses with non-stop calls.</h2>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">From the tools</p>
+                        <h2 className="text-2xl sm:text-3xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">Built for businesses with non-stop calls.</h2>
                     </motion.div>
                     <motion.div {...fadeUp(0.08)} className="-mx-6 px-6"><TestimonialsCarousel /></motion.div>
                 </div>
             </section>
 
             {/* Interview form — invitation to try Tracey */}
-            <section id="interview-assistant" className="scroll-mt-28 py-12 md:py-24 px-6 relative overflow-hidden bg-[#1E232B]">
+            <section id="interview-assistant" className="scroll-mt-28 py-12 md:py-20 px-6 bg-paper">
                 <div className="container mx-auto max-w-7xl">
-                    <div className="grid lg:grid-cols-2 gap-12 lg:gap-8 items-center">
-                        <div className="flex flex-col gap-8">
-                            <motion.h2 {...fadeUp()} className="text-3xl md:text-5xl font-extrabold text-white tracking-[-0.03em] leading-tight">
-                                Interview your assistant now. She will contact customers and run your CRM so you don&apos;t have to.
-                            </motion.h2>
+                    <motion.div {...fadeUp()} className="relative overflow-hidden rounded-md p-7 sm:p-10 md:p-14" style={{ background: "var(--color-forest-dk)" }}>
+                        <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(80% 90% at 85% 0%, rgba(0,210,139,0.14) 0%, transparent 60%)" }} />
+                        <div className="relative grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+                            <div className="flex flex-col gap-5">
+                                <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-mint-500">Hear her first</p>
+                                <h2 className="text-3xl md:text-5xl font-extrabold text-paper tracking-[-0.03em] leading-tight">
+                                    Interview your assistant now.
+                                </h2>
+                                <p className="text-base md:text-lg leading-relaxed text-paper/65 max-w-md">
+                                    She will contact customers and run your CRM so you don&apos;t have to. Put her on the phone before you put her on the payroll.
+                                </p>
+                            </div>
+                            <motion.div {...fadeUp(0.1)} className="bg-card rounded-md p-7 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]">
+                                <h3 className="font-bold text-lg mb-1 text-ink">Interview Tracey for free</h3>
+                                <p className="text-sm mb-6 leading-relaxed text-ink2">Tracey will call you and answer questions, explain her capabilities, or roleplay as your very own AI receptionist.</p>
+                                <InterviewForm />
+                            </motion.div>
                         </div>
-                        <motion.div {...fadeUp(0.1)} className="bg-card/95 backdrop-blur-md rounded border border-white/40 p-7 shadow-xl">
-                            <h3 className="font-bold text-lg mb-1" style={{ color: "var(--color-ink)" }}>Interview Tracey for free</h3>
-                            <p className="text-slate-body text-sm mb-6 leading-relaxed">Tracey will call you and answer questions, explain her capabilities, or roleplay as your very own AI receptionist.</p>
-                            <InterviewForm />
-                        </motion.div>
-                    </div>
+                    </motion.div>
                 </div>
             </section>
 
             {/* Platform diagram — voice agent + CRM */}
-            <section id="platform" className="bg-background px-6 py-12 md:py-24">
+            <section id="platform" className="bg-paper px-6 py-12 md:py-20">
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>One comprehensive platform.</h2>
-                        <p className="mt-4 text-lg" style={{ color: "var(--color-ink2)" }}>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The platform</p>
+                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">One comprehensive platform.</h2>
+                        <p className="mt-4 text-lg text-ink2">
                             An AI assistant and a CRM that runs itself, so you don&apos;t have to.
                         </p>
                     </motion.div>
@@ -419,11 +432,12 @@ export default function Home() {
             </section>
 
             {/* Section 1 — Meet Tracey (the voice agent) */}
-            <section id="meet-tracey" className="bg-background px-6 py-12 md:py-24">
+            <section id="meet-tracey" className="bg-cream px-6 py-12 md:py-20">
                 <div className="container mx-auto max-w-7xl">
                     <motion.div {...fadeUp()} className="mx-auto mb-12 max-w-3xl text-center">
-                        <h2 className="text-4xl font-extrabold tracking-[-0.03em] md:text-5xl" style={{ color: "var(--color-ink)" }}>Meet Tracey.</h2>
-                        <p className="mt-3 text-lg max-w-xl mx-auto" style={{ color: "var(--color-ink2)" }}>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">Your AI offsider</p>
+                        <h2 className="text-4xl font-extrabold tracking-[-0.03em] md:text-5xl text-ink">Meet Tracey.</h2>
+                        <p className="mt-3 text-lg max-w-xl mx-auto text-ink2">
                             Your AI receptionist, CRM manager, and follow-up specialist — all in one.
                         </p>
                     </motion.div>
@@ -431,29 +445,26 @@ export default function Home() {
                     <motion.div {...fadeUp(0.06)} className="grid sm:grid-cols-3 gap-4 relative">
                         {/* dashed vertical guide on mobile */}
                         <div className="absolute left-[22px] top-6 bottom-6 w-0.5 sm:hidden" style={{ background: "repeating-linear-gradient(to bottom, var(--color-hair) 0 4px, transparent 4px 8px)" }} aria-hidden />
-                        {TRACEY_WORKFLOW.map(({ label, points }, i) => {
-                            const accent = [["#00D28B", "rgba(0,210,139,0.12)"], ["#4A7CE6", "rgba(74,124,230,0.12)"], ["#8B6FE0", "rgba(139,111,224,0.12)"]][i];
-                            return (
-                                <div key={label} className="bg-card border border-[var(--color-hair)] rounded-md p-5 flex gap-4 sm:flex-col sm:gap-4">
-                                    <div className="flex-shrink-0 relative z-10">
-                                        <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-white" style={{ background: accent[0], boxShadow: `0 0 0 4px #F8FAFC, 0 4px 12px -4px ${accent[0]}80` }}>
-                                            0{i + 1}
-                                        </div>
-                                    </div>
-                                    <div className="flex-1 min-w-0">
-                                        <h4 className="text-base font-bold mb-3" style={{ color: "var(--color-ink)" }}>{label}</h4>
-                                        <ul className="space-y-2.5">
-                                            {points.map((point) => (
-                                                <li key={point} className="flex items-start gap-2.5">
-                                                    <span className="mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: accent[0] }} />
-                                                    <span className="text-sm leading-relaxed" style={{ color: "var(--color-ink2)" }}>{point}</span>
-                                                </li>
-                                            ))}
-                                        </ul>
+                        {TRACEY_WORKFLOW.map(({ label, points }, i) => (
+                            <div key={label} className="bg-card border border-hair rounded-md p-6 flex gap-4 sm:flex-col sm:gap-5 shadow-[0_2px_10px_-6px_rgba(14,31,26,0.08)]">
+                                <div className="flex-shrink-0 relative z-10">
+                                    <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-paper bg-forest ring-4 ring-cream">
+                                        0{i + 1}
                                     </div>
                                 </div>
-                            );
-                        })}
+                                <div className="flex-1 min-w-0">
+                                    <h4 className="text-base font-bold mb-3 text-ink">{label}</h4>
+                                    <ul className="space-y-2.5">
+                                        {points.map((point) => (
+                                            <li key={point} className="flex items-start gap-2.5">
+                                                <span className="mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 bg-mint-500" />
+                                                <span className="text-sm leading-relaxed text-ink2">{point}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </div>
+                        ))}
                     </motion.div>
 
                     <motion.div {...fadeUp(0.10)} className="mt-12 flex flex-col items-center gap-5">
@@ -462,11 +473,12 @@ export default function Home() {
                 </div>
             </section>
             {/* Section 2 — A CRM that fills itself in */}
-            <section id="product" className="py-12 md:py-24 px-6 bg-card">
+            <section id="product" className="py-12 md:py-20 px-6 bg-paper">
                 <div className="container mx-auto max-w-7xl flex flex-col gap-16">
                     <motion.div {...fadeUp()} className="text-center max-w-2xl mx-auto">
-                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>A CRM that fills itself in.</h2>
-                        <p className="mt-3 text-lg leading-relaxed" style={{ color: "var(--color-ink2)" }}>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-forest mb-4">The CRM</p>
+                        <h2 className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-ink">A CRM that fills itself in.</h2>
+                        <p className="mt-3 text-lg leading-relaxed text-ink2">
                             Run it from the dashboard, the in-app chat, or just message Tracey on WhatsApp.
                         </p>
                     </motion.div>
@@ -479,31 +491,31 @@ export default function Home() {
                                     "Chat drives the CRM — Tracey handles the form-filling",
                                     "Your whole pipeline, accessible by message",
                                 ].map((b) => (
-                                    <li key={b} className="flex items-start gap-2.5 text-sm text-slate-body">
-                                        <CheckCircle2 className="mt-0.5 w-4 h-4 text-primary shrink-0" />
+                                    <li key={b} className="flex items-start gap-2.5 text-sm text-ink2">
+                                        <CheckCircle2 className="mt-0.5 w-4 h-4 text-mint-500 shrink-0" />
                                         <span>{b}</span>
                                     </li>
                                 ))}
                             </ul>
                         </div>
-                        <div className="relative min-h-[380px] overflow-hidden rounded border border-border shadow-[0_8px_40px_rgba(15,23,42,0.10)]">
+                        <div className="relative min-h-[380px] overflow-hidden rounded-md border border-hair shadow-[0_18px_50px_-22px_rgba(14,31,26,0.25)]">
                             <HireMockup1 />
                         </div>
                     </motion.div>
 
                     <motion.div {...fadeUp(0.10)} className="flex flex-col gap-6">
                         <div className="text-center">
-                            <h3 className="text-2xl font-extrabold tracking-[-0.02em] md:text-3xl" style={{ color: "var(--color-ink)" }}>A full-featured CRM, built for the way trades actually work.</h3>
+                            <h3 className="text-2xl font-extrabold tracking-[-0.02em] md:text-3xl text-ink">A full-featured CRM, built for the way trades actually work.</h3>
                         </div>
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                             {FEATURE_CARDS.map(({ icon: Icon, title, desc }) => (
-                                <div key={title} className="group flex items-start gap-3 rounded-md border border-[var(--color-hair)] bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-[0_6px_18px_-10px_rgba(14,31,26,0.18)]">
-                                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary/10">
-                                        <Icon className="h-4 w-4 text-primary" />
+                                <div key={title} className="group flex items-start gap-3 rounded-md border border-hair bg-card p-4 transition-all hover:-translate-y-0.5 hover:border-mint-500/40 hover:shadow-[0_10px_24px_-12px_rgba(14,31,26,0.22)]">
+                                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-subtle">
+                                        <Icon className="h-4 w-4 text-forest" />
                                     </div>
                                     <div className="flex flex-col gap-0.5 min-w-0">
-                                        <span className="text-sm font-semibold" style={{ color: "var(--color-ink)" }}>{title}</span>
-                                        <span className="text-xs leading-relaxed text-muted-foreground">{desc}</span>
+                                        <span className="text-sm font-semibold text-ink">{title}</span>
+                                        <span className="text-xs leading-relaxed text-ink2/85">{desc}</span>
                                     </div>
                                 </div>
                             ))}
@@ -514,16 +526,17 @@ export default function Home() {
 
             <FaqSection />
 
-            {/* Final CTA */}
-            <section className="py-14 md:py-24 px-6 relative overflow-hidden" style={{ background: "var(--color-forest)" }}>
-                <div aria-hidden className="absolute top-[-60px] left-[-40px] w-56 h-56 rounded-full pointer-events-none" style={{ background: "radial-gradient(circle, rgba(0,210,139,0.3), rgba(22,67,58,0) 70%)" }} />
-                <div aria-hidden className="absolute bottom-[-40px] right-[-60px] w-72 h-72 rounded-full pointer-events-none" style={{ background: "radial-gradient(circle, rgba(0,210,139,0.15), rgba(22,67,58,0) 70%)" }} />
+            {/* Final CTA — forest bookend, flows into the footer */}
+            <section className="py-16 md:py-28 px-6 relative overflow-hidden bg-forest">
+                <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(80% 70% at 50% 120%, rgba(0,210,139,0.18) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
+                <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
                 <div className="mx-auto max-w-3xl text-center flex flex-col items-center gap-6 relative z-10">
-                    <motion.h2 {...fadeUp()} className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-white leading-tight text-balance">Focus on the job.<br/><span style={{ color: "#00D28B" }}>Not the admin.</span></motion.h2>
-                    <motion.p {...fadeUp(0.04)} className="text-lg text-white/65 leading-7 max-w-xl">Start free. No card required. Live in under a day.</motion.p>
+                    <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">Knock off early</motion.p>
+                    <motion.h2 {...fadeUp(0.02)} className="text-4xl md:text-6xl font-extrabold tracking-[-0.04em] text-paper leading-[1.05] text-balance">Focus on the job.<br/><span className="text-mint-500">Not the admin.</span></motion.h2>
+                    <motion.p {...fadeUp(0.04)} className="text-lg text-paper/65 leading-7 max-w-xl">Start free. No card required. Live in under a day.</motion.p>
                     <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
                         <Link href="/auth"><Button size="lg" variant="mint">Get started <ArrowRight className="ml-2 h-4 w-4" /></Button></Link>
-                        <Link href="/contact#contact-form"><Button size="lg" variant="ghost" className="text-white border-white/30 hover:bg-card/10">Get a demo</Button></Link>
+                        <Link href="/contact#contact-form"><Button size="lg" variant="ghost" className="text-paper border border-white/25 hover:bg-white/10 hover:text-white">Get a demo</Button></Link>
                     </motion.div>
                 </div>
             </section>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -103,24 +103,22 @@ function FaqSection() {
   }
 
   return (
-    <div className="space-y-3 max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto border-t border-hair">
       {FAQ_ITEMS.map((item, idx) => {
         const isOpen = openIndices.includes(idx)
         return (
-          <div key={idx} className="border border-border rounded-md overflow-hidden bg-card">
+          <div key={idx} className="border-b border-hair">
             <button
               onClick={() => toggle(idx)}
-              className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-muted/30 transition-colors"
+              className="w-full flex items-center justify-between gap-4 py-5 text-left group"
             >
-              <span className="font-semibold text-sm pr-4" style={{ color: "var(--color-ink)" }}>{item.q}</span>
-              <ChevronDown
-                className={`w-5 h-5 text-muted-foreground shrink-0 transition-transform duration-200 ${
-                  isOpen ? "rotate-180" : ""
-                }`}
-              />
+              <span className="font-semibold text-[15px] pr-4 text-ink group-hover:text-forest transition-colors">{item.q}</span>
+              <span className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-hair bg-card transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}>
+                <ChevronDown className="w-4 h-4 text-forest" />
+              </span>
             </button>
             <div className={`transition-all duration-200 overflow-hidden ${isOpen ? "max-h-60" : "max-h-0"}`}>
-              <p className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">{item.a}</p>
+              <p className="pb-5 pr-10 text-sm text-ink2 leading-relaxed">{item.a}</p>
             </div>
           </div>
         )
@@ -181,31 +179,25 @@ export default function PricingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-paper text-ink">
       <Navbar />
 
       <main>
         {/* ── 1. Hero / Pricing Header ── */}
-        <section className="pt-24 sm:pt-32 pb-10 md:pb-16 px-6 relative overflow-hidden isolate bg-[linear-gradient(180deg,#F8FAFC_0%,#F1F5F9_60%,#F8FAFC_100%)]">
-          <div
-            className="absolute inset-0 z-0 pointer-events-none"
-            style={{
-              background:
-                "radial-gradient(110% 60% at 50% 0%,rgba(16,185,129,0.18) 0%,rgba(16,185,129,0.00) 72%)",
-            }}
-          />
+        <section className="pt-32 sm:pt-40 pb-16 md:pb-24 px-6 relative overflow-hidden isolate bg-forest">
+          <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
           <div className="relative z-10 mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
-            <motion.p {...fadeUp()} className="text-[11px] font-semibold uppercase tracking-[0.28em] text-primary">
+            <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">
               Pricing
             </motion.p>
             <motion.h1
               {...fadeUp(0.04)}
-              className="text-4xl md:text-6xl font-extrabold tracking-[-0.04em] leading-[1.07] text-balance"
-              style={{ color: "var(--color-ink)" }}
+              className="font-display text-4xl md:text-6xl font-semibold tracking-[-0.015em] leading-[1.05] text-balance text-paper"
             >
               One plan. Everything included.
             </motion.h1>
-            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-muted-foreground max-w-xl text-balance">
+            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-paper/65 max-w-xl text-balance">
               A$30/month platform. 10¢ per call minute or text. That&apos;s it.
             </motion.p>
           </div>
@@ -240,7 +232,7 @@ export default function PricingPage() {
                   >
                     Yearly
                   </button>
-                  <span className="absolute -top-3 -right-3 bg-emerald-500 text-white text-[10px] font-bold px-2 py-0.5 rounded-full shadow-sm">
+                  <span className="absolute -top-3 -right-3 bg-forest text-paper text-[10px] font-bold px-2 py-0.5 rounded-full shadow-sm">
                     Save 20%
                   </span>
                 </div>
@@ -366,10 +358,10 @@ export default function PricingPage() {
         </section>
 
         {/* ── 3. ROI Justification ── */}
-        <section className="py-10 md:py-20 px-6 bg-card border-t border-border/60">
+        <section className="py-12 md:py-20 px-6 bg-cream">
           <div className="max-w-4xl mx-auto">
             <motion.div {...fadeUp()} className="text-center mb-14">
-              <h2 className="text-3xl font-extrabold" style={{ color: "var(--color-ink)" }}>Pays for itself by saving 1 missed job</h2>
+              <h2 className="font-display text-3xl md:text-4xl font-semibold tracking-[-0.01em] text-ink">Pays for itself by saving 1 missed job</h2>
               <p className="mt-3 text-muted-foreground max-w-2xl mx-auto">
                 Stop losing money on missed calls, forgotten follow-ups, and wasted admin hours.
               </p>
@@ -380,9 +372,9 @@ export default function PricingPage() {
                 <motion.div
                   key={i}
                   {...fadeUp(0.1 + i * 0.1)}
-                  className="bg-card rounded-md p-8 border border-border shadow-sm text-center flex flex-col items-center justify-center"
+                  className="bg-card rounded-md p-8 border border-hair shadow-[0_2px_10px_-6px_rgba(14,31,26,0.08)] text-center flex flex-col items-center justify-center"
                 >
-                  <div className="text-4xl font-extrabold text-primary mb-3">{stat.value}</div>
+                  <div className="font-display text-4xl font-semibold text-forest mb-3">{stat.value}</div>
                   <div className="text-sm font-semibold text-muted-foreground">{stat.label}</div>
                 </motion.div>
               ))}
@@ -391,10 +383,10 @@ export default function PricingPage() {
         </section>
 
         {/* ── 4. Feature Grid ── */}
-        <section className="py-10 md:py-20 px-6 bg-background border-t border-border/60">
+        <section className="py-12 md:py-20 px-6 bg-paper">
           <div className="max-w-5xl mx-auto">
             <motion.div {...fadeUp()} className="text-center mb-14">
-              <h2 className="text-3xl font-extrabold" style={{ color: "var(--color-ink)" }}>Everything you need is included</h2>
+              <h2 className="font-display text-3xl md:text-4xl font-semibold tracking-[-0.01em] text-ink">Everything you need is included</h2>
               <p className="mt-3 text-muted-foreground">No add-ons, no hidden modules. You get the full platform from day one.</p>
             </motion.div>
 
@@ -405,9 +397,9 @@ export default function PricingPage() {
                   <motion.div
                     key={f.title}
                     {...fadeUp(0.1 + i * 0.05)}
-                    className="bg-card border border-border/50 p-5 rounded-md flex flex-col items-start gap-4 hover:shadow-md transition-shadow"
+                    className="bg-card border border-hair p-5 rounded-md flex flex-col items-start gap-4 hover:shadow-md transition-shadow"
                   >
-                    <div className="w-10 h-10 rounded-md bg-emerald-100 flex items-center justify-center">
+                    <div className="w-10 h-10 rounded-md bg-primary-subtle flex items-center justify-center">
                       <Icon className="w-5 h-5 text-primary" />
                     </div>
                     <div>
@@ -422,10 +414,10 @@ export default function PricingPage() {
         </section>
 
         {/* ── 5. FAQ ── */}
-        <section className="py-10 md:py-20 px-6 bg-card border-t border-border/60">
+        <section className="py-12 md:py-20 px-6 bg-cream">
           <div className="max-w-3xl mx-auto">
             <motion.div {...fadeUp()} className="text-center mb-10">
-              <h2 className="text-3xl font-extrabold" style={{ color: "var(--color-ink)" }}>Pricing questions</h2>
+              <h2 className="font-display text-3xl md:text-4xl font-semibold tracking-[-0.01em] text-ink">Pricing questions</h2>
             </motion.div>
 
             <motion.div {...fadeUp(0.1)}>
@@ -435,10 +427,10 @@ export default function PricingPage() {
         </section>
 
         {/* ── 6. Contact Form ── */}
-        <section id="contact-form" className="py-10 md:py-20 px-6 bg-background border-t border-border/60 scroll-mt-20">
+        <section id="contact-form" className="py-12 md:py-20 px-6 bg-paper scroll-mt-20">
           <div className="container mx-auto max-w-xl">
             <motion.div {...fadeUp()} className="text-center mb-10">
-              <h2 className="text-3xl font-extrabold" style={{ color: "var(--color-ink)" }}>Still have questions?</h2>
+              <h2 className="font-display text-3xl md:text-4xl font-semibold tracking-[-0.01em] text-ink">Still have questions?</h2>
               <p className="text-muted-foreground mt-2">Get in touch with the team.</p>
             </motion.div>
 
@@ -477,7 +469,7 @@ export default function PricingPage() {
                   </CardContent>
                 </Card>
               ) : (
-                <Card className="rounded-md border border-border shadow-sm bg-card">
+                <Card className="rounded-md border border-hair shadow-sm bg-card">
                   <CardHeader className="px-8 pt-8 pb-0">
                     <CardTitle style={{ color: "var(--color-ink)" }}>Get in touch</CardTitle>
                     <CardDescription>Choose the team that best fits your question.</CardDescription>
@@ -584,15 +576,17 @@ export default function PricingPage() {
         </section>
 
         {/* ── 7. Final CTA ── */}
-        <section className="py-14 md:py-24 px-6" style={{ background: "var(--color-forest)" }}>
-          <div className="mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
+        <section className="relative overflow-hidden py-16 md:py-28 px-6 bg-forest">
+          <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(70% 60% at 50% 120%, rgba(0,210,139,0.18) 0%, transparent 70%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+          <div className="relative mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
             <motion.h2
               {...fadeUp()}
-              className="text-4xl md:text-5xl font-extrabold tracking-[-0.03em] text-white leading-tight text-balance"
+              className="font-display text-4xl md:text-5xl font-semibold tracking-[-0.01em] text-paper leading-[1.05] text-balance"
             >
-              Give yourself an early mark
+              Give yourself an <span className="italic text-mint-500">early mark</span>
             </motion.h2>
-            <motion.p {...fadeUp(0.04)} className="text-lg text-white/65 leading-7 max-w-xl">
+            <motion.p {...fadeUp(0.04)} className="text-lg text-paper/65 leading-7 max-w-xl">
               No contracts. No complexity. Try Earlymark free.
             </motion.p>
             <motion.div {...fadeUp(0.12)} className="flex flex-col sm:flex-row gap-3">
@@ -602,7 +596,7 @@ export default function PricingPage() {
                 </Button>
               </Link>
               <Link href="/#interview-assistant">
-                <Button size="lg" variant="ghost" className="text-white border border-white/30 hover:bg-card/10">
+                <Button size="lg" variant="ghost" className="text-paper border border-white/25 hover:bg-white/10 hover:text-white">
                   Interview Tracey for free
                 </Button>
               </Link>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { MastheadHero } from "@/components/marketing/masthead-hero"
 import {
   ArrowRight,
   Send,
@@ -184,24 +185,12 @@ export default function PricingPage() {
 
       <main>
         {/* ── 1. Hero / Pricing Header ── */}
-        <section className="pt-32 sm:pt-40 pb-16 md:pb-24 px-6 relative overflow-hidden isolate bg-forest">
-          <div aria-hidden className="absolute inset-0 z-0 pointer-events-none" style={{ background: "radial-gradient(90% 60% at 50% -10%, rgba(0,210,139,0.16) 0%, rgba(0,210,139,0.05) 45%, transparent 75%)" }} />
-          <div aria-hidden className="absolute inset-x-0 top-0 z-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
-          <div className="relative z-10 mx-auto max-w-3xl text-center flex flex-col items-center gap-6">
-            <motion.p {...fadeUp()} className="text-[11px] font-bold uppercase tracking-[0.28em] text-mint-500">
-              Pricing
-            </motion.p>
-            <motion.h1
-              {...fadeUp(0.04)}
-              className="font-display text-4xl md:text-6xl font-semibold tracking-[-0.015em] leading-[1.05] text-balance text-paper"
-            >
-              One plan. Everything included.
-            </motion.h1>
-            <motion.p {...fadeUp(0.08)} className="text-lg leading-8 text-paper/65 max-w-xl text-balance">
-              A$30/month platform. 10¢ per call minute or text. That&apos;s it.
-            </motion.p>
-          </div>
-        </section>
+        <MastheadHero
+          index="§ Pricing"
+          kicker="One plan, everything in"
+          title={<>One plan.<br />Everything included.</>}
+          lead="A$30/month platform. 10¢ per call minute or text. That's it."
+        />
 
         {/* ── 2. Pricing Section ── */}
         <section className="py-12 px-6">

--- a/app/solutions/[slug]/page.tsx
+++ b/app/solutions/[slug]/page.tsx
@@ -69,20 +69,21 @@ export default async function SolutionDetailPage({
   const ctaIndustry = CTA_INDUSTRIES[solution.slug] ?? `${solution.summaryTitle.toLowerCase()} business`;
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-paper text-ink">
       <Navbar />
       <main className="flex flex-col">
 
         {/* ── Hero ── */}
-        <section className="relative overflow-hidden bg-[linear-gradient(160deg,#0f172a_0%,#0d3b2a_55%,#065f46_100%)] px-6 pt-36 pb-20 text-white">
-          <div className="pointer-events-none absolute inset-0 opacity-50" style={{ background: "radial-gradient(50% 40% at 80% 0%, rgba(16,185,129,0.30) 0%, rgba(16,185,129,0) 70%)" }} />
+        <section className="relative overflow-hidden bg-[linear-gradient(160deg,#0E2F28_0%,#16433A_55%,#1E5447_100%)] px-6 pt-36 pb-20 text-paper">
+          <div aria-hidden className="pointer-events-none absolute inset-0 opacity-60" style={{ background: "radial-gradient(50% 40% at 80% 0%, rgba(0,210,139,0.22) 0%, rgba(0,210,139,0) 70%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
           <div className="relative mx-auto max-w-4xl flex flex-col gap-6">
             <div className="flex items-center gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/30">
+              <span className="flex h-10 w-10 items-center justify-center rounded-md bg-white/10 text-mint-500 ring-1 ring-white/15">
                 <TradeIcon className="h-5 w-5" />
               </span>
             </div>
-            <h1 className="text-4xl font-extrabold tracking-[-0.03em] leading-tight text-white md:text-6xl text-balance">
+            <h1 className="font-display text-4xl font-semibold tracking-[-0.01em] leading-tight text-paper md:text-6xl text-balance">
               {solution.title}
             </h1>
             <p className="text-lg leading-8 text-white/85 max-w-2xl">
@@ -130,7 +131,7 @@ export default async function SolutionDetailPage({
         </section>
 
         {/* ── 3 outcomes ── */}
-        <section className="border-b border-border bg-card px-6 py-10">
+        <section className="bg-cream px-6 py-10">
           <div className="mx-auto max-w-4xl grid grid-cols-1 sm:grid-cols-3 gap-6">
             {[
               { icon: Phone, label: "Every call answered", desc: "Tracey picks up 24/7 so no lead goes to voicemail." },
@@ -157,7 +158,7 @@ export default async function SolutionDetailPage({
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
                 How it works
               </p>
-              <h2 className="mt-3 text-3xl font-extrabold tracking-[-0.03em] md:text-4xl" style={{ color: "var(--color-ink)" }}>
+              <h2 className="mt-3 text-3xl font-display font-semibold tracking-[-0.01em] md:text-4xl" style={{ color: "var(--color-ink)" }}>
                 What Tracey handles for {solution.navLabel.toLowerCase()}
               </h2>
             </div>
@@ -166,10 +167,10 @@ export default async function SolutionDetailPage({
               {solution.workflows.map((workflow, index) => (
                 <article
                   key={workflow.title}
-                  className="group relative flex flex-col gap-4 rounded-2xl border border-border bg-card p-7 transition-all hover:-translate-y-0.5 hover:border-emerald-200 hover:shadow-[0_12px_36px_rgba(15,23,42,0.08)]"
+                  className="group relative flex flex-col gap-4 rounded-md border border-hair bg-card p-7 transition-all hover:-translate-y-0.5 hover:border-mint-500/40 hover:shadow-[0_12px_36px_rgba(15,23,42,0.08)]"
                 >
                   <div className="flex items-center gap-3">
-                    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-50 text-sm font-bold ring-1 ring-emerald-100" style={{ color: "var(--color-forest)" }}>
+                    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary-subtle text-sm font-bold ring-1 ring-mint-100" style={{ color: "var(--color-forest)" }}>
                       {String(index + 1).padStart(2, "0")}
                     </span>
                     <h3 className="text-lg font-bold tracking-[-0.02em]" style={{ color: "var(--color-ink)" }}>
@@ -186,13 +187,13 @@ export default async function SolutionDetailPage({
         </section>
 
         {/* ── FAQ ── */}
-        <section className="border-t border-border bg-card px-6 py-20">
+        <section className="bg-cream px-6 py-20">
           <div className="mx-auto max-w-3xl flex flex-col gap-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
                 FAQ
               </p>
-              <h2 className="mt-3 text-3xl font-extrabold tracking-[-0.03em]" style={{ color: "var(--color-ink)" }}>
+              <h2 className="mt-3 text-3xl font-display font-semibold tracking-[-0.01em]" style={{ color: "var(--color-ink)" }}>
                 Common questions from {solution.navLabel.toLowerCase()}
               </h2>
             </div>
@@ -201,15 +202,15 @@ export default async function SolutionDetailPage({
               {solution.faqs.map((faq) => (
                 <details
                   key={faq.question}
-                  className="group overflow-hidden rounded-2xl border border-border bg-card shadow-[0_2px_8px_rgba(15,23,42,0.04)] transition-all open:border-emerald-200 open:bg-emerald-50/40 open:shadow-[0_8px_24px_rgba(15,23,42,0.06)]"
+                  className="group overflow-hidden rounded-md border border-hair bg-card shadow-[0_2px_8px_rgba(15,23,42,0.04)] transition-all open:border-hair open:bg-primary-subtle/40 open:shadow-[0_8px_24px_rgba(15,23,42,0.06)]"
                 >
                   <summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-6 py-5 [&::-webkit-details-marker]:hidden">
                     <span className="text-base font-semibold" style={{ color: "var(--color-ink)" }}>{faq.question}</span>
-                    <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition-all group-open:rotate-45 group-open:bg-emerald-600 group-open:text-white">
+                    <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition-all group-open:rotate-45 group-open:bg-forest group-open:text-paper">
                       <Plus className="h-4 w-4" />
                     </span>
                   </summary>
-                  <div className="border-t border-emerald-100/60 px-6 pb-6 pt-4 text-sm leading-7 text-muted-foreground">
+                  <div className="border-t border-hair px-6 pb-6 pt-4 text-sm leading-7 text-muted-foreground">
                     {faq.answer}
                   </div>
                 </details>
@@ -219,19 +220,21 @@ export default async function SolutionDetailPage({
         </section>
 
         {/* ── CTA ── */}
-        <section className="px-6 py-20 text-white" style={{ background: "var(--color-forest)" }}>
-          <div className="mx-auto max-w-4xl flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <section className="relative overflow-hidden px-6 py-20 text-paper bg-forest">
+          <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(60% 70% at 90% 120%, rgba(0,210,139,0.16) 0%, transparent 70%)" }} />
+          <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+          <div className="relative mx-auto max-w-4xl flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <div className="max-w-xl">
-              <h2 className="text-3xl font-extrabold tracking-[-0.03em] text-white md:text-4xl">
+              <h2 className="font-display text-3xl font-semibold tracking-[-0.01em] text-paper md:text-4xl">
                 Ready to see what Tracey can do for your {ctaIndustry}?
               </h2>
-              <p className="mt-3 text-sm leading-7 text-white/80">
+              <p className="mt-3 text-sm leading-7 text-paper/70">
                 No contracts. No complexity. Tracey can be answering your calls today.
               </p>
             </div>
             <div className="flex flex-wrap gap-3 shrink-0">
               <Link href="/solutions">
-                <Button variant="ghost" className="border-white/30 text-white hover:bg-card/10 hover:text-white">
+                <Button variant="ghost" className="border border-white/25 text-paper hover:bg-white/10 hover:text-white">
                   Back to Trade services
                 </Button>
               </Link>

--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -33,20 +33,20 @@ const INCLUDED = [
 
 export default function SolutionsPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-paper text-ink">
       <Navbar />
       <main className="mx-auto flex max-w-7xl flex-col gap-20 px-6 pb-24 pt-36">
 
         {/* Hero */}
         <section className="flex flex-col items-center gap-8 text-center">
           <div className="max-w-3xl">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primary">
+            <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-forest">
               {TRADE_SERVICES_SUMMARY.eyebrow}
             </p>
-            <h1 className="mt-4 text-4xl font-extrabold tracking-[-0.03em] md:text-6xl" style={{ color: "var(--color-ink)" }}>
+            <h1 className="mt-4 font-display text-4xl font-semibold tracking-[-0.01em] md:text-6xl text-ink">
               {TRADE_SERVICES_SUMMARY.title}
             </h1>
-            <p className="mt-4 text-lg leading-8 text-muted-foreground">
+            <p className="mt-4 text-lg leading-8 text-ink2">
               {TRADE_SERVICES_SUMMARY.description}
             </p>
           </div>
@@ -68,8 +68,8 @@ export default function SolutionsPage() {
           {/* What's included in every solution */}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-8 pt-2">
             {INCLUDED.map(({ icon: Icon, label }) => (
-              <div key={label} className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Icon className="h-4 w-4 text-primary shrink-0" />
+              <div key={label} className="flex items-center gap-2 text-sm text-ink2">
+                <Icon className="h-4 w-4 text-forest shrink-0" />
                 <span>{label}</span>
               </div>
             ))}
@@ -84,19 +84,19 @@ export default function SolutionsPage() {
             return (
               <article
                 key={service.slug}
-                className="grid gap-0 overflow-hidden rounded-2xl border border-border bg-card shadow-[0_8px_30px_rgba(15,23,42,0.06)] transition-shadow hover:shadow-[0_12px_40px_rgba(15,23,42,0.10)] md:grid-cols-[1.1fr_1fr]"
+                className="grid gap-0 overflow-hidden rounded-md border border-hair bg-card shadow-[0_8px_30px_-18px_rgba(14,31,26,0.18)] transition-shadow hover:shadow-[0_14px_44px_-18px_rgba(14,31,26,0.28)] md:grid-cols-[1.1fr_1fr]"
               >
                 {/* Text side */}
                 <div className={`flex flex-col justify-center gap-5 p-8 md:p-10 ${reverse ? "md:order-2" : ""}`}>
                   <div className="flex items-center gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50" style={{ color: "var(--color-forest)" }}>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-subtle text-forest">
                       <Icon className="h-5 w-5" />
                     </span>
                   </div>
-                  <h2 className="text-2xl font-extrabold tracking-[-0.02em] md:text-3xl" style={{ color: "var(--color-ink)" }}>
+                  <h2 className="font-display text-2xl font-semibold tracking-[-0.01em] md:text-3xl text-ink">
                     {service.summaryTeaser}
                   </h2>
-                  <p className="text-base leading-7 text-muted-foreground">
+                  <p className="text-base leading-7 text-ink2">
                     {service.summaryAngle}
                   </p>
                   <div>
@@ -110,17 +110,17 @@ export default function SolutionsPage() {
                 </div>
 
                 {/* Visual side — dark green panel with workflow list */}
-                <div className={`relative flex flex-col justify-center gap-5 bg-[linear-gradient(155deg,#0f172a_0%,#0d3b2a_55%,#065f46_100%)] p-8 md:p-10 ${reverse ? "md:order-1" : ""}`}>
-                  <div className="pointer-events-none absolute inset-0 opacity-40" style={{ background: "radial-gradient(60% 50% at 80% 0%, rgba(16,185,129,0.25) 0%, rgba(16,185,129,0) 70%)" }} />
+                <div className={`relative flex flex-col justify-center gap-5 bg-[linear-gradient(155deg,#0E2F28_0%,#16433A_55%,#1E5447_100%)] p-8 md:p-10 ${reverse ? "md:order-1" : ""}`}>
+                  <div className="pointer-events-none absolute inset-0 opacity-50" style={{ background: "radial-gradient(60% 50% at 80% 0%, rgba(0,210,139,0.22) 0%, rgba(0,210,139,0) 70%)" }} />
                   <ul className="relative flex flex-col gap-3">
                     {service.workflows.slice(0, 3).map((workflow) => (
                       <li
                         key={workflow.title}
-                        className="flex items-start gap-3 rounded-xl border border-white/10 bg-card/5 p-3.5 backdrop-blur-sm"
+                        className="flex items-start gap-3 rounded-md border border-white/10 bg-white/5 p-3.5 backdrop-blur-sm"
                       >
-                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" />
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-mint-500" />
                         <div className="flex flex-col gap-0.5">
-                          <span className="text-sm font-semibold text-white">{workflow.title}</span>
+                          <span className="text-sm font-semibold text-paper">{workflow.title}</span>
                           <span className="text-xs leading-5 text-white/65 line-clamp-2">{workflow.body}</span>
                         </div>
                       </li>
@@ -133,21 +133,22 @@ export default function SolutionsPage() {
         </section>
 
         {/* Bottom CTA */}
-        <section className="rounded-md p-10 text-white text-center flex flex-col items-center gap-6" style={{ background: "var(--color-forest)" }}>
-          <h2 className="text-3xl font-extrabold tracking-[-0.03em] md:text-4xl">
-            Give yourself an early mark today
+        <section className="relative overflow-hidden rounded-md bg-forest p-10 md:p-14 text-paper text-center flex flex-col items-center gap-6">
+          <div aria-hidden className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(70% 60% at 50% 120%, rgba(0,210,139,0.18) 0%, transparent 70%)" }} />
+          <h2 className="relative font-display text-3xl font-semibold tracking-[-0.01em] md:text-4xl">
+            Give yourself an <span className="italic text-mint-500">early mark</span> today
           </h2>
-          <p className="text-white/70 max-w-lg leading-7">
+          <p className="relative text-paper/65 max-w-lg leading-7">
             No contracts. No complexity. Try Tracey free.
           </p>
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <div className="relative flex flex-col sm:flex-row gap-3 justify-center">
             <Link href="/auth">
               <Button size="lg" variant="mint">
                 Get started <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             </Link>
             <Link href="/contact#contact-form">
-              <Button size="lg" variant="ghost" className="text-white border-white/30 hover:bg-card/10">
+              <Button size="lg" variant="ghost" className="text-paper border border-white/25 hover:bg-white/10 hover:text-white">
                 Get a demo
               </Button>
             </Link>

--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -6,6 +6,7 @@ import {
 import { Footer } from "@/components/layout/footer";
 import { Navbar } from "@/components/layout/navbar";
 import { Button } from "@/components/ui/button";
+import { MastheadHero } from "@/components/marketing/masthead-hero";
 import { TRADE_SERVICES, TRADE_SERVICES_SUMMARY } from "@/lib/trade-services";
 
 const TRADE_ICONS: Record<string, typeof Zap> = {
@@ -35,38 +36,26 @@ export default function SolutionsPage() {
   return (
     <div className="min-h-screen bg-paper text-ink">
       <Navbar />
-      <main className="mx-auto flex max-w-7xl flex-col gap-20 px-6 pb-24 pt-36">
+      <main>
 
         {/* Hero */}
-        <section className="flex flex-col items-center gap-8 text-center">
-          <div className="max-w-3xl">
-            <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-forest">
-              {TRADE_SERVICES_SUMMARY.eyebrow}
-            </p>
-            <h1 className="mt-4 font-display text-4xl font-semibold tracking-[-0.01em] md:text-6xl text-ink">
-              {TRADE_SERVICES_SUMMARY.title}
-            </h1>
-            <p className="mt-4 text-lg leading-8 text-ink2">
-              {TRADE_SERVICES_SUMMARY.description}
-            </p>
-          </div>
+        <MastheadHero
+          index="§ Solutions"
+          kicker={TRADE_SERVICES_SUMMARY.eyebrow}
+          title={TRADE_SERVICES_SUMMARY.title}
+          lead={TRADE_SERVICES_SUMMARY.description}
+          actions={<>
+            <Link href="/auth"><Button size="lg" variant="mint">Get started <ArrowRight className="ml-2 h-4 w-4" /></Button></Link>
+            <Link href="/contact#contact-form"><Button size="lg" variant="outline">Get a demo</Button></Link>
+          </>}
+        />
 
-          <div className="flex flex-col justify-center gap-3 sm:flex-row">
-            <Link href="/auth">
-              <Button size="lg" variant="mint">
-                Get started
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
-            </Link>
-            <Link href="/contact#contact-form">
-              <Button size="lg" variant="outline">
-                Get a demo
-              </Button>
-            </Link>
-          </div>
+        <div className="mx-auto flex max-w-[1320px] flex-col gap-20 px-5 sm:px-8 pb-24 pt-16 md:pt-24">
 
-          {/* What's included in every solution */}
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-8 pt-2">
+        {/* What's included in every solution */}
+        <div className="flex flex-col gap-4 border-t border-hair pt-4 sm:flex-row sm:items-center sm:gap-10">
+          <span className="em-kicker text-forest shrink-0">In every solution</span>
+          <div className="flex flex-col gap-3 sm:flex-row sm:gap-10">
             {INCLUDED.map(({ icon: Icon, label }) => (
               <div key={label} className="flex items-center gap-2 text-sm text-ink2">
                 <Icon className="h-4 w-4 text-forest shrink-0" />
@@ -74,7 +63,7 @@ export default function SolutionsPage() {
               </div>
             ))}
           </div>
-        </section>
+        </div>
 
         {/* Trade cards */}
         <section className="flex flex-col gap-6">
@@ -88,10 +77,11 @@ export default function SolutionsPage() {
               >
                 {/* Text side */}
                 <div className={`flex flex-col justify-center gap-5 p-8 md:p-10 ${reverse ? "md:order-2" : ""}`}>
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-between gap-3 border-b border-hair pb-4">
                     <span className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-subtle text-forest">
                       <Icon className="h-5 w-5" />
                     </span>
+                    <span className="em-kicker text-ink2/45">{String(index + 1).padStart(2, "0")} / {String(TRADE_SERVICES.length).padStart(2, "0")}</span>
                   </div>
                   <h2 className="font-display text-2xl font-semibold tracking-[-0.01em] md:text-3xl text-ink">
                     {service.summaryTeaser}
@@ -155,6 +145,7 @@ export default function SolutionsPage() {
           </div>
         </section>
 
+        </div>
       </main>
       <Footer />
     </div>

--- a/components/home/autonomy-mode-tabs.tsx
+++ b/components/home/autonomy-mode-tabs.tsx
@@ -59,11 +59,11 @@ export function AutonomyModeTabs() {
                             onClick={() => setActive(mode.id)}
                             className={`relative flex items-center gap-2 rounded-t-xl border border-b-0 px-4 py-3 text-sm font-semibold transition-all ${
                                 isActive
-                                    ? "z-10 -mb-px border-emerald-200 bg-card text-midnight shadow-[0_-4px_12px_rgba(15,23,42,0.05)]"
-                                    : "border-transparent bg-emerald-50/60 text-muted-foreground hover:bg-emerald-50 hover:text-midnight"
+                                    ? "z-10 -mb-px border-hair bg-card text-ink shadow-[0_-4px_12px_rgba(14,31,26,0.05)]"
+                                    : "border-transparent bg-white/40 text-ink2/70 hover:bg-white/70 hover:text-ink"
                             }`}
                         >
-                            <Icon className={`h-4 w-4 ${isActive ? "text-emerald-600" : "text-muted-foreground"}`} />
+                            <Icon className={`h-4 w-4 ${isActive ? "text-forest" : "text-ink2/60"}`} />
                             {mode.label}
                         </button>
                     );
@@ -71,7 +71,7 @@ export function AutonomyModeTabs() {
             </div>
 
             {/* Tab panel */}
-            <div role="tabpanel" className="rounded-b-2xl rounded-tr-2xl border border-emerald-200 bg-card p-7 md:p-8 shadow-[0_18px_50px_rgba(15,23,42,0.08)]">
+            <div role="tabpanel" className="rounded-b-2xl rounded-tr-2xl border border-hair bg-card p-7 md:p-8 shadow-[0_18px_50px_-22px_rgba(14,31,26,0.22)]">
                 <AnimatePresence mode="wait">
                     <motion.div
                         key={current.id}
@@ -81,12 +81,12 @@ export function AutonomyModeTabs() {
                         transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
                         className="flex flex-col gap-5"
                     >
-                        <p className="text-lg font-semibold text-midnight md:text-xl">{current.tagline}</p>
+                        <p className="text-lg font-semibold text-ink md:text-xl">{current.tagline}</p>
                         <ul className="grid gap-3 md:grid-cols-3">
                             {current.permissions.map((perm) => (
-                                <li key={perm} className="flex items-start gap-2.5 rounded-xl bg-emerald-50/40 px-4 py-3 ring-1 ring-emerald-100">
-                                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
-                                    <span className="text-sm leading-relaxed text-foreground">{perm}</span>
+                                <li key={perm} className="flex items-start gap-2.5 rounded-md bg-paper px-4 py-3 ring-1 ring-hair">
+                                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-forest" />
+                                    <span className="text-sm leading-relaxed text-ink">{perm}</span>
                                 </li>
                             ))}
                         </ul>

--- a/components/home/hero-dashboard-reel.tsx
+++ b/components/home/hero-dashboard-reel.tsx
@@ -368,7 +368,7 @@ function ReelChrome({ children }: { children: React.ReactNode }) {
             initial={{ opacity: 0, y: 18 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
-            className="relative overflow-hidden rounded border border-white/55 bg-card/55 shadow-[0_28px_90px_rgba(15,23,42,0.16)] backdrop-blur-xl"
+            className="relative overflow-hidden rounded-md border border-white/55 bg-card/55 shadow-[0_38px_110px_-30px_rgba(0,0,0,0.55)] backdrop-blur-xl"
         >
             <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.52)_0%,rgba(255,255,255,0.18)_18%,rgba(255,255,255,0)_36%)] pointer-events-none" />
             <div className="absolute inset-x-0 top-0 h-px bg-card/80 pointer-events-none" />
@@ -383,8 +383,8 @@ function ReelChrome({ children }: { children: React.ReactNode }) {
                         earlymark.ai/crm
                     </div>
                 </div>
-                <div className="hidden items-center gap-1.5 rounded-full border border-emerald-200/80 bg-emerald-50/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-700 sm:flex">
-                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+                <div className="hidden items-center gap-1.5 rounded-full border border-mint-100 bg-primary-subtle px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-forest sm:flex">
+                    <span className="w-1.5 h-1.5 rounded-full bg-mint-500 animate-pulse" />
                     Live demo
                 </div>
             </div>
@@ -410,8 +410,8 @@ export function HeroDashboardReel({ className = "" }: { className?: string }) {
     return (
         <div className={`relative mx-auto w-full max-w-[1120px] ${className}`}>
             {/* Ambient glows */}
-            <div className="absolute inset-x-[10%] top-6 -z-10 h-28 rounded-full bg-emerald-400/18 blur-3xl" />
-            <div className="absolute inset-x-[18%] bottom-0 -z-10 h-24 rounded-full bg-cyan-300/16 blur-3xl" />
+            <div className="absolute inset-x-[10%] top-6 -z-10 h-28 rounded-full bg-mint-500/20 blur-3xl" />
+            <div className="absolute inset-x-[18%] bottom-0 -z-10 h-24 rounded-full bg-mint-500/10 blur-3xl" />
 
             {/* ── Mobile: static chat preview only ── */}
             <div className="md:hidden">
@@ -429,7 +429,7 @@ export function HeroDashboardReel({ className = "" }: { className?: string }) {
                 <div className="relative overflow-hidden md:h-[500px]">
                     <div className="absolute bottom-4 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full border border-white/80 bg-card/88 px-3.5 py-2 shadow-sm backdrop-blur">
                         <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                            <ActiveStepIcon className="h-3.5 w-3.5 text-emerald-600" />
+                            <ActiveStepIcon className="h-3.5 w-3.5 text-forest" />
                             <span>{activeStep.label}</span>
                         </div>
                         <div className="h-4 w-px bg-muted" />
@@ -443,7 +443,7 @@ export function HeroDashboardReel({ className = "" }: { className?: string }) {
                                         onClick={() => setActive(idx)}
                                         aria-label={`Show ${step.label} view`}
                                         className={`h-2.5 rounded-full transition-all duration-200 ${
-                                            isActive ? "w-6 bg-emerald-500" : "w-2.5 bg-muted-foreground/20 hover:bg-slate-400"
+                                            isActive ? "w-6 bg-mint-500" : "w-2.5 bg-muted-foreground/20 hover:bg-muted-foreground/40"
                                         }`}
                                     />
                                 );

--- a/components/home/hero-dashboard-reel.tsx
+++ b/components/home/hero-dashboard-reel.tsx
@@ -368,7 +368,7 @@ function ReelChrome({ children }: { children: React.ReactNode }) {
             initial={{ opacity: 0, y: 18 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
-            className="relative overflow-hidden rounded-md border border-white/55 bg-card/55 shadow-[0_38px_110px_-30px_rgba(0,0,0,0.55)] backdrop-blur-xl"
+            className="relative overflow-hidden rounded-md border border-hair bg-card shadow-[0_40px_90px_-45px_rgba(14,31,26,0.5)]"
         >
             <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.52)_0%,rgba(255,255,255,0.18)_18%,rgba(255,255,255,0)_36%)] pointer-events-none" />
             <div className="absolute inset-x-0 top-0 h-px bg-card/80 pointer-events-none" />

--- a/components/home/platform-diagram.tsx
+++ b/components/home/platform-diagram.tsx
@@ -43,21 +43,21 @@ export function PlatformDiagram() {
                     whileInView={{ opacity: 1, x: 0 }}
                     viewport={{ once: true, margin: "-60px" }}
                     transition={{ duration: 0.6, ease: EASE }}
-                    className="relative flex flex-col gap-5 rounded-2xl border border-emerald-900/10 bg-[linear-gradient(145deg,#103126_0%,#1B4637_52%,#2B5F4D_100%)] p-7 md:p-8 shadow-[0_18px_60px_rgba(15,23,42,0.14)]"
+                    className="relative flex flex-col gap-5 rounded-md bg-[linear-gradient(145deg,#0E2F28_0%,#16433A_55%,#1E5447_100%)] p-7 md:p-8 shadow-[0_18px_50px_-18px_rgba(14,31,26,0.45)]"
                 >
                     <div className="flex items-center gap-3">
-                        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-card/10">
-                            <Phone className="h-5 w-5 text-emerald-300" />
+                        <div className="flex h-11 w-11 items-center justify-center rounded-md bg-white/10">
+                            <Phone className="h-5 w-5 text-mint-500" />
                         </div>
                         <div>
                             <p className="text-xs font-bold uppercase tracking-[0.18em] text-white/50">Voice Agent</p>
-                            <h3 className="text-xl font-bold text-white">Your AI voice assistant</h3>
+                            <h3 className="text-xl font-bold text-paper">Your AI voice assistant</h3>
                         </div>
                     </div>
                     <ul className="space-y-2.5">
                         {VOICE_POINTS.map((point) => (
                             <li key={point} className="flex items-start gap-2.5">
-                                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-mint-500" />
                                 <span className="text-sm leading-relaxed text-white/80">{point}</span>
                             </li>
                         ))}
@@ -67,7 +67,7 @@ export function PlatformDiagram() {
                         <div className="flex flex-wrap gap-2">
                             {CHANNELS.map(({ label, icon: Icon }) => (
                                 <span key={label} className="inline-flex items-center gap-1.5 rounded-full bg-white/10 border border-white/15 px-3 py-1 text-xs text-white/75">
-                                    <Icon className="h-3 w-3 text-emerald-400" />
+                                    <Icon className="h-3 w-3 text-mint-500" />
                                     {label}
                                 </span>
                             ))}
@@ -84,11 +84,11 @@ export function PlatformDiagram() {
                     className="flex flex-row md:flex-col items-center justify-center gap-4 py-4 md:py-0"
                     aria-hidden="true"
                 >
-                    <div className="flex h-20 w-20 md:h-24 md:w-24 items-center justify-center rounded-full border-2 border-emerald-200 bg-card shadow-[0_10px_28px_rgba(16,185,129,0.30)]">
-                        <ArrowRight className="h-9 w-9 md:h-11 md:w-11 text-emerald-600 rotate-90 md:rotate-0" strokeWidth={2.5} />
+                    <div className="flex h-16 w-16 md:h-20 md:w-20 items-center justify-center rounded-full border border-hair bg-card shadow-[0_10px_28px_-10px_rgba(14,31,26,0.25)]">
+                        <ArrowRight className="h-7 w-7 md:h-9 md:w-9 text-forest rotate-90 md:rotate-0" strokeWidth={2} />
                     </div>
-                    <div className="flex h-20 w-20 md:h-24 md:w-24 items-center justify-center rounded-full border-2 border-emerald-200 bg-card shadow-[0_10px_28px_rgba(16,185,129,0.30)]">
-                        <ArrowLeft className="h-9 w-9 md:h-11 md:w-11 text-emerald-600 rotate-90 md:rotate-0" strokeWidth={2.5} />
+                    <div className="flex h-16 w-16 md:h-20 md:w-20 items-center justify-center rounded-full border border-hair bg-card shadow-[0_10px_28px_-10px_rgba(14,31,26,0.25)]">
+                        <ArrowLeft className="h-7 w-7 md:h-9 md:w-9 text-forest rotate-90 md:rotate-0" strokeWidth={2} />
                     </div>
                 </motion.div>
 
@@ -98,28 +98,28 @@ export function PlatformDiagram() {
                     whileInView={{ opacity: 1, x: 0 }}
                     viewport={{ once: true, margin: "-60px" }}
                     transition={{ duration: 0.6, delay: 0.1, ease: EASE }}
-                    className="relative flex flex-col gap-5 rounded-2xl border border-border bg-card p-7 md:p-8 shadow-[0_18px_60px_rgba(15,23,42,0.10)]"
+                    className="relative flex flex-col gap-5 rounded-md border border-hair bg-card p-7 md:p-8 shadow-[0_18px_50px_-22px_rgba(14,31,26,0.25)]"
                 >
                     <div className="flex items-center gap-3">
-                        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-50">
-                            <Database className="h-5 w-5 text-emerald-600" />
+                        <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary-subtle">
+                            <Database className="h-5 w-5 text-forest" />
                         </div>
                         <div>
-                            <p className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">CRM</p>
-                            <h3 className="text-xl font-bold text-midnight">A CRM that runs itself</h3>
+                            <p className="text-xs font-bold uppercase tracking-[0.18em] text-ink2/70">CRM</p>
+                            <h3 className="text-xl font-bold text-ink">A CRM that runs itself</h3>
                         </div>
                     </div>
-                    <div className="flex items-start gap-2.5 rounded-xl bg-emerald-50/60 px-3.5 py-3 ring-1 ring-emerald-100">
-                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
-                        <span className="text-sm font-semibold leading-relaxed text-midnight">Auto-logs every job and customer interaction</span>
+                    <div className="flex items-start gap-2.5 rounded-md bg-primary-subtle/60 px-3.5 py-3 ring-1 ring-mint-100">
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-forest" />
+                        <span className="text-sm font-semibold leading-relaxed text-ink">Auto-logs every job and customer interaction</span>
                     </div>
                     <div className="flex flex-col gap-2.5">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground">Traditional CRM features</p>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-ink2/70">Traditional CRM features</p>
                         <div className="grid grid-cols-2 gap-x-3 gap-y-2">
                             {CRM_FEATURES.map(({ icon: Icon, label }) => (
                                 <div key={label} className="flex items-center gap-2">
-                                    <Icon className="h-3.5 w-3.5 shrink-0 text-emerald-600" />
-                                    <span className="text-xs leading-snug text-muted-foreground">{label}</span>
+                                    <Icon className="h-3.5 w-3.5 shrink-0 text-forest" />
+                                    <span className="text-xs leading-snug text-ink2">{label}</span>
                                 </div>
                             ))}
                         </div>

--- a/components/home/trust-strip.tsx
+++ b/components/home/trust-strip.tsx
@@ -18,27 +18,18 @@ export function TrustStrip() {
     ];
 
     return (
-        <section className="bg-card border-y border-border px-6 py-10 md:py-14">
+        <section className="bg-paper px-6 pt-14 pb-12 md:pt-20 md:pb-16">
             <div className="container mx-auto max-w-5xl">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-0 sm:divide-x sm:divide-[var(--color-hair)]">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 sm:gap-0 sm:divide-x sm:divide-hair">
                     {metrics.map((m) => (
                         <div key={m.label} className="flex flex-col items-center text-center sm:px-10 gap-1">
-                            <div
-                                className="text-4xl md:text-5xl font-extrabold tracking-[-0.04em] leading-none"
-                                style={{ color: "var(--color-ink)" }}
-                            >
+                            <div className="text-5xl md:text-6xl font-extrabold tracking-[-0.04em] leading-none text-ink">
                                 {m.value}
                             </div>
-                            <div
-                                className="text-sm font-semibold uppercase tracking-wide mt-1"
-                                style={{ color: "var(--color-forest)" }}
-                            >
+                            <div className="text-[11px] font-bold uppercase tracking-[0.22em] mt-2.5 text-forest">
                                 {m.label}
                             </div>
-                            <p
-                                className="text-xs leading-relaxed max-w-[200px] mt-1"
-                                style={{ color: "var(--color-ink2)" }}
-                            >
+                            <p className="text-xs leading-relaxed max-w-[200px] mt-1.5 text-ink2/80">
                                 {m.sub}
                             </p>
                         </div>

--- a/components/home/trust-strip.tsx
+++ b/components/home/trust-strip.tsx
@@ -1,37 +1,44 @@
 export function TrustStrip() {
     const metrics = [
         {
+            no: "01",
             value: "99%",
-            label: "calls answered",
+            label: "Calls answered",
             sub: "Every customer gets a response, even while you're on the tools",
         },
         {
+            no: "02",
             value: "~60%",
-            label: "more jobs booked",
+            label: "More jobs booked",
             sub: "Average increase in booked jobs in the first month",
         },
         {
+            no: "03",
             value: "~3 hrs",
-            label: "admin saved daily",
+            label: "Admin saved daily",
             sub: "Time reclaimed from calls, follow-ups, and manual entry",
         },
     ];
 
     return (
-        <section className="bg-paper px-6 pt-14 pb-12 md:pt-20 md:pb-16">
-            <div className="container mx-auto max-w-5xl">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 sm:gap-0 sm:divide-x sm:divide-hair">
-                    {metrics.map((m) => (
-                        <div key={m.label} className="flex flex-col items-center text-center sm:px-10 gap-1">
-                            <div className="text-5xl md:text-6xl font-extrabold tracking-[-0.04em] leading-none text-ink">
-                                {m.value}
-                            </div>
-                            <div className="text-[11px] font-bold uppercase tracking-[0.22em] mt-2.5 text-forest">
-                                {m.label}
-                            </div>
-                            <p className="text-xs leading-relaxed max-w-[200px] mt-1.5 text-ink2/80">
-                                {m.sub}
-                            </p>
+        <section className="bg-paper px-5 sm:px-8 py-16 md:py-24">
+            <div className="mx-auto max-w-[1320px]">
+                <div className="flex items-center gap-4 border-t border-hair pt-3.5">
+                    <span className="em-kicker text-forest">§ Results</span>
+                    <span className="em-kicker flex-1 text-ink2/55">Measured across live workspaces</span>
+                </div>
+                <div className="mt-10 grid grid-cols-1 md:grid-cols-3">
+                    {metrics.map((m, i) => (
+                        <div
+                            key={m.label}
+                            className={`flex flex-col gap-3 py-8 md:py-2 md:px-10 ${
+                                i > 0 ? "border-t border-hair md:border-t-0 md:border-l" : "md:pl-0"
+                            }`}
+                        >
+                            <span className="em-kicker text-ink2/45">{m.no}</span>
+                            <div className="em-display text-[clamp(3.5rem,7vw,5.5rem)] text-ink">{m.value}</div>
+                            <div className="text-base font-semibold text-forest">{m.label}</div>
+                            <p className="max-w-[240px] text-sm leading-relaxed text-ink2/80">{m.sub}</p>
                         </div>
                     ))}
                 </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,54 +1,57 @@
 import Link from "next/link";
+import Image from "next/image";
+
+const PRODUCT_LINKS = [
+  { href: "/features", label: "Product" },
+  { href: "/solutions", label: "Solutions" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/contact", label: "Contact" },
+];
+
+const LEGAL_LINKS = [
+  { href: "/privacy", label: "Privacy" },
+  { href: "/terms", label: "Terms" },
+  { href: "/cookies", label: "Cookies" },
+];
 
 export function Footer() {
   return (
-    <footer className="w-full border-t border-border/40 bg-background/80 backdrop-blur-sm">
-      <div className="max-w-7xl mx-auto px-6 py-5 flex flex-col gap-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-        <span>&copy; {new Date().getFullYear()} Earlymark</span>
-        <nav className="flex flex-wrap items-center gap-x-4 gap-y-2">
-          <Link
-            href="/features"
-            className="hover:text-foreground transition-colors"
-          >
-            Product
-          </Link>
-          <Link
-            href="/solutions"
-            className="hover:text-foreground transition-colors"
-          >
-            Solutions
-          </Link>
-          <Link
-            href="/pricing"
-            className="hover:text-foreground transition-colors"
-          >
-            Pricing
-          </Link>
-          <Link
-            href="/contact"
-            className="hover:text-foreground transition-colors"
-          >
-            Contact
-          </Link>
-          <Link
-            href="/privacy"
-            className="hover:text-foreground transition-colors"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="/terms"
-            className="hover:text-foreground transition-colors"
-          >
-            Terms
-          </Link>
-          <Link
-            href="/cookies"
-            className="hover:text-foreground transition-colors"
-          >
-            Cookies
-          </Link>
-        </nav>
+    <footer className="w-full bg-forest">
+      <div className="h-px w-full bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+      <div className="max-w-7xl mx-auto px-6 pt-12 pb-8 flex flex-col gap-10">
+        <div className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-3 max-w-xs">
+            <Link href="/" className="flex items-center gap-2.5">
+              <Image src="/latest-logo.png" alt="Earlymark" width={28} height={28} className="rounded-md" unoptimized />
+              <span className="text-base font-bold tracking-tight text-paper">Earlymark</span>
+            </Link>
+            <p className="text-xs leading-relaxed text-white/50">
+              The AI assistant &amp; CRM that answers every call, books the job, and handles the admin — so you can knock off early.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-x-16 gap-y-8">
+            <div className="flex flex-col gap-2.5">
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-mint-500">Explore</p>
+              {PRODUCT_LINKS.map(({ href, label }) => (
+                <Link key={href} href={href} className="text-sm text-white/65 transition-colors hover:text-white">
+                  {label}
+                </Link>
+              ))}
+            </div>
+            <div className="flex flex-col gap-2.5">
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-mint-500">Legal</p>
+              {LEGAL_LINKS.map(({ href, label }) => (
+                <Link key={href} href={href} className="text-sm text-white/65 transition-colors hover:text-white">
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 border-t border-white/10 pt-6 text-xs text-white/40 sm:flex-row sm:items-center sm:justify-between">
+          <span>&copy; {new Date().getFullYear()} Earlymark. All rights reserved.</span>
+          <span>Made for tradies, run by Tracey.</span>
+        </div>
       </div>
     </footer>
   );

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -50,14 +50,14 @@ export function Navbar() {
                 <div className="flex h-9 w-9 items-center justify-center">
                     <Image src="/latest-logo.png" alt="Earlymark Logo" width={32} height={32} className="rounded-lg" unoptimized />
                 </div>
-                <span className="text-lg font-bold tracking-tight text-midnight">Earlymark</span>
+                <span className="text-lg font-bold tracking-tight text-ink">Earlymark</span>
             </Link>
 
             <div className="hidden items-center gap-8 md:flex">
-                <Link href="/" className="text-[15px] font-medium text-slate-body transition-colors hover:text-midnight">
+                <Link href="/" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
                     Home
                 </Link>
-                <Link href="/features" className="text-[15px] font-medium text-slate-body transition-colors hover:text-midnight">
+                <Link href="/features" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
                     Product
                 </Link>
 
@@ -68,7 +68,7 @@ export function Navbar() {
                     onFocus={openSolutions}
                     onBlur={closeSolutionsSoon}
                 >
-                    <Link href="/solutions" className="inline-flex items-center gap-1 text-[15px] font-medium text-slate-body transition-colors hover:text-midnight">
+                    <Link href="/solutions" className="inline-flex items-center gap-1 text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
                         Solutions
                         <ChevronDown className={`h-4 w-4 transition-transform ${isSolutionsOpen ? "rotate-180" : ""}`} />
                     </Link>
@@ -76,9 +76,9 @@ export function Navbar() {
                     <div
                         className={`absolute left-1/2 top-full z-50 pt-3 transition-all duration-200 ${isSolutionsOpen ? "pointer-events-auto visible translate-y-0 opacity-100" : "pointer-events-none invisible -translate-y-1 opacity-0"}`}
                     >
-                        <div className="w-[640px] -translate-x-1/2 overflow-hidden rounded-2xl border border-border bg-card shadow-[0_24px_60px_rgba(15,23,42,0.18)]">
+                        <div className="w-[640px] -translate-x-1/2 overflow-hidden rounded-2xl border border-hair bg-card shadow-[0_24px_60px_-18px_rgba(14,31,26,0.35)]">
                             <div className="px-5 pt-5 pb-2">
-                                <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-600">Trade services</p>
+                                <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-forest">Trade services</p>
                                 <p className="mt-1 text-sm text-muted-foreground">Earlymark workflows tuned for your trade.</p>
                             </div>
                             <div className="grid grid-cols-2 gap-1 p-3">
@@ -88,14 +88,14 @@ export function Navbar() {
                                         <Link
                                             key={service.slug}
                                             href={`/solutions/${service.slug}`}
-                                            className="group flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-emerald-50/60"
+                                            className="group flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-paper"
                                             onClick={() => setIsSolutionsOpen(false)}
                                         >
-                                            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600 group-hover:bg-emerald-100">
+                                            <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary-subtle text-forest group-hover:bg-mint-100">
                                                 <Icon className="h-4 w-4" />
                                             </span>
                                             <span className="flex flex-col gap-0.5">
-                                                <span className="text-[14px] font-semibold text-midnight">{service.navLabel}</span>
+                                                <span className="text-[14px] font-semibold text-ink">{service.navLabel}</span>
                                                 <span className="text-[12px] leading-snug text-muted-foreground line-clamp-2">{service.summaryTeaser}</span>
                                             </span>
                                         </Link>
@@ -105,22 +105,22 @@ export function Navbar() {
                             <Link
                                 href="/solutions"
                                 onClick={() => setIsSolutionsOpen(false)}
-                                className="flex items-center justify-between border-t border-border/50 bg-muted/20 px-5 py-3 text-[13px] font-semibold text-midnight transition-colors hover:bg-emerald-50/60"
+                                className="flex items-center justify-between border-t border-hair bg-paper/60 px-5 py-3 text-[13px] font-semibold text-ink transition-colors hover:bg-paper"
                             >
                                 <span>View all trade services</span>
-                                <ArrowRight className="h-4 w-4 text-emerald-600" />
+                                <ArrowRight className="h-4 w-4 text-forest" />
                             </Link>
                         </div>
                     </div>
                 </div>
 
-                <Link href="/pricing" className="text-[15px] font-medium text-slate-body transition-colors hover:text-midnight">
+                <Link href="/pricing" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
                     Pricing
                 </Link>
             </div>
 
             <div className="flex items-center gap-3">
-                <Button asChild variant="ghost" size="sm" className="hidden text-[15px] font-medium text-midnight sm:inline-flex">
+                <Button asChild variant="ghost" size="sm" className="hidden text-[15px] font-medium text-ink sm:inline-flex">
                     <Link href="/contact">
                         Contact us
                     </Link>
@@ -132,18 +132,18 @@ export function Navbar() {
                 </Button>
                 <button
                     onClick={() => setIsOpen(!isOpen)}
-                    className="-mr-2 p-2 text-midnight md:hidden"
+                    className="-mr-2 p-2 text-ink md:hidden"
                 >
                     {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
                 </button>
             </div>
 
             {isOpen && (
-                <div className="animate-in fade-in slide-in-from-top-2 absolute left-0 right-0 top-16 z-50 mx-4 flex flex-col gap-4 rounded-2xl border border-border bg-card p-5 shadow-xl md:hidden">
-                    <Link href="/" className="text-[15px] font-medium text-slate-body" onClick={() => setIsOpen(false)}>Home</Link>
-                    <Link href="/features" className="text-[15px] font-medium text-slate-body" onClick={() => setIsOpen(false)}>Product</Link>
+                <div className="animate-in fade-in slide-in-from-top-2 absolute left-0 right-0 top-16 z-50 mx-4 flex flex-col gap-4 rounded-2xl border border-hair bg-card p-5 shadow-xl md:hidden">
+                    <Link href="/" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Home</Link>
+                    <Link href="/features" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Product</Link>
                     <div className="flex flex-col gap-2">
-                        <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-600">Solutions</p>
+                        <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-forest">Solutions</p>
                         <div className="grid grid-cols-2 gap-2">
                             {TRADE_SERVICES.map((service) => {
                                 const Icon = TRADE_ICONS[service.slug] ?? Sparkles
@@ -151,29 +151,29 @@ export function Navbar() {
                                     <Link
                                         key={service.slug}
                                         href={`/solutions/${service.slug}`}
-                                        className="flex items-center gap-2 rounded-xl border border-border bg-card px-3 py-2.5"
+                                        className="flex items-center gap-2 rounded-xl border border-hair bg-card px-3 py-2.5"
                                         onClick={() => setIsOpen(false)}
                                     >
-                                        <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
+                                        <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary-subtle text-forest">
                                             <Icon className="h-3.5 w-3.5" />
                                         </span>
-                                        <span className="text-sm font-semibold text-midnight">{service.navLabel}</span>
+                                        <span className="text-sm font-semibold text-ink">{service.navLabel}</span>
                                     </Link>
                                 )
                             })}
                         </div>
                         <Link
                             href="/solutions"
-                            className="mt-1 flex items-center justify-between rounded-xl border border-emerald-200 bg-emerald-50/60 px-3 py-2.5 text-sm font-semibold text-midnight"
+                            className="mt-1 flex items-center justify-between rounded-xl border border-hair bg-paper px-3 py-2.5 text-sm font-semibold text-ink"
                             onClick={() => setIsOpen(false)}
                         >
                             <span>View all trade services</span>
-                            <ArrowRight className="h-4 w-4 text-emerald-600" />
+                            <ArrowRight className="h-4 w-4 text-forest" />
                         </Link>
                     </div>
-                    <Link href="/pricing" className="text-[15px] font-medium text-slate-body" onClick={() => setIsOpen(false)}>Pricing</Link>
-                    <hr className="border-border/50" />
-                    <Link href="/contact" className="text-[15px] font-medium text-slate-body" onClick={() => setIsOpen(false)}>Contact us</Link>
+                    <Link href="/pricing" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Pricing</Link>
+                    <hr className="border-hair" />
+                    <Link href="/contact" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Contact us</Link>
                     <Link href="/auth" className="text-[15px] font-bold text-primary" onClick={() => setIsOpen(false)}>Log in / Get started</Link>
                 </div>
             )}

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import { Button } from "@/components/ui/button"
 import {
     ChevronDown, Menu, X, ArrowRight,
     Zap, Wrench, Trees, Sparkles, Bug, Key, Paintbrush, Thermometer,
@@ -45,19 +44,23 @@ export function Navbar() {
     }, [])
 
     return (
-        <nav className="fixed top-5 left-1/2 z-50 flex h-16 w-[95%] max-w-[1200px] -translate-x-1/2 items-center justify-between rounded-full border border-white/20 bg-card/70 px-6 shadow-lg backdrop-blur-md transition-all lg:px-8">
+        <nav className="fixed top-0 left-0 right-0 z-50 border-b border-hair bg-paper/85 backdrop-blur-md">
+          <div className="mx-auto flex h-16 max-w-[1320px] items-center justify-between px-5 sm:px-8">
             <Link href="/" className="flex items-center gap-2.5">
-                <div className="flex h-9 w-9 items-center justify-center">
-                    <Image src="/latest-logo.png" alt="Earlymark Logo" width={32} height={32} className="rounded-lg" unoptimized />
+                <div className="flex h-8 w-8 items-center justify-center">
+                    <Image src="/latest-logo.png" alt="Earlymark Logo" width={30} height={30} className="rounded-md" unoptimized />
                 </div>
-                <span className="text-lg font-bold tracking-tight text-ink">Earlymark</span>
+                <span className="flex items-baseline gap-2.5">
+                    <span className="font-display text-xl font-semibold tracking-[-0.01em] text-ink">Earlymark</span>
+                    <span className="em-kicker hidden text-ink2/55 lg:inline">Est. for trades</span>
+                </span>
             </Link>
 
-            <div className="hidden items-center gap-8 md:flex">
-                <Link href="/" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
+            <div className="hidden items-center gap-9 md:flex">
+                <Link href="/" className="text-[14px] font-medium text-ink2 transition-colors hover:text-ink">
                     Home
                 </Link>
-                <Link href="/features" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
+                <Link href="/features" className="text-[14px] font-medium text-ink2 transition-colors hover:text-ink">
                     Product
                 </Link>
 
@@ -68,7 +71,7 @@ export function Navbar() {
                     onFocus={openSolutions}
                     onBlur={closeSolutionsSoon}
                 >
-                    <Link href="/solutions" className="inline-flex items-center gap-1 text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
+                    <Link href="/solutions" className="inline-flex items-center gap-1 text-[14px] font-medium text-ink2 transition-colors hover:text-ink">
                         Solutions
                         <ChevronDown className={`h-4 w-4 transition-transform ${isSolutionsOpen ? "rotate-180" : ""}`} />
                     </Link>
@@ -114,22 +117,19 @@ export function Navbar() {
                     </div>
                 </div>
 
-                <Link href="/pricing" className="text-[15px] font-medium text-ink2 transition-colors hover:text-ink">
+                <Link href="/pricing" className="text-[14px] font-medium text-ink2 transition-colors hover:text-ink">
                     Pricing
                 </Link>
             </div>
 
-            <div className="flex items-center gap-3">
-                <Button asChild variant="ghost" size="sm" className="hidden text-[15px] font-medium text-ink sm:inline-flex">
-                    <Link href="/contact">
-                        Contact us
-                    </Link>
-                </Button>
-                <Button asChild size="sm" variant="mint" className="hidden text-[15px] font-medium sm:inline-flex">
-                    <Link href="/auth">
-                        Log in / Get started
-                    </Link>
-                </Button>
+            <div className="flex items-center gap-5">
+                <Link href="/contact" className="hidden text-[14px] font-medium text-ink2 transition-colors hover:text-ink sm:inline-flex">
+                    Contact
+                </Link>
+                <Link href="/auth" className="group hidden items-center gap-2 text-[14px] font-semibold text-ink sm:inline-flex">
+                    <span className="border-b-2 border-mint-500 pb-0.5 transition-colors group-hover:border-forest">Log in / Get started</span>
+                    <ArrowRight className="h-3.5 w-3.5 text-forest transition-transform group-hover:translate-x-0.5" />
+                </Link>
                 <button
                     onClick={() => setIsOpen(!isOpen)}
                     className="-mr-2 p-2 text-ink md:hidden"
@@ -137,9 +137,10 @@ export function Navbar() {
                     {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
                 </button>
             </div>
+          </div>
 
             {isOpen && (
-                <div className="animate-in fade-in slide-in-from-top-2 absolute left-0 right-0 top-16 z-50 mx-4 flex flex-col gap-4 rounded-2xl border border-hair bg-card p-5 shadow-xl md:hidden">
+                <div className="animate-in fade-in slide-in-from-top-2 absolute left-0 right-0 top-16 z-50 mx-4 flex flex-col gap-4 rounded-md border border-hair bg-card p-5 shadow-xl md:hidden">
                     <Link href="/" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Home</Link>
                     <Link href="/features" className="text-[15px] font-medium text-ink2" onClick={() => setIsOpen(false)}>Product</Link>
                     <div className="flex flex-col gap-2">

--- a/components/marketing/masthead-hero.tsx
+++ b/components/marketing/masthead-hero.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+const fadeUp = (delay = 0) => ({
+    initial: { opacity: 0, y: 28 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, margin: "-60px" },
+    transition: { duration: 0.6, delay, ease: EASE },
+});
+
+/**
+ * Editorial masthead hero for inner marketing pages.
+ * Top hairline rule (index · kicker · locale), then an oversized Fraunces
+ * headline with a right-hand spec column for the lead + actions.
+ */
+export function MastheadHero({
+    index, kicker, title, lead, actions,
+}: {
+    index: string;
+    kicker: string;
+    title: React.ReactNode;
+    lead?: React.ReactNode;
+    actions?: React.ReactNode;
+}) {
+    return (
+        <section className="em-grain relative overflow-hidden bg-cream px-5 sm:px-8 pt-24 sm:pt-28 pb-16 md:pb-24">
+            <div className="relative z-10 mx-auto max-w-[1320px]">
+                <motion.div {...fadeUp(0.02)} className="flex items-center justify-between gap-4 border-t border-hair pt-3.5">
+                    <span className="em-kicker text-forest">{index}</span>
+                    <span className="em-kicker hidden text-ink2/55 sm:inline">{kicker}</span>
+                    <span className="em-kicker text-ink2/55">Australia</span>
+                </motion.div>
+                <div className="mt-12 grid gap-x-8 gap-y-8 sm:mt-16 md:grid-cols-12 md:items-end">
+                    <motion.h1 {...fadeUp(0.06)} className="em-display col-span-12 text-[clamp(2.5rem,7vw,6rem)] text-ink md:col-span-8">
+                        {title}
+                    </motion.h1>
+                    {(lead || actions) && (
+                        <motion.div {...fadeUp(0.12)} className="col-span-12 flex flex-col gap-6 md:col-span-4 md:pb-2">
+                            {lead && <p className="max-w-sm text-[15px] leading-relaxed text-ink2">{lead}</p>}
+                            {actions && <div className="flex flex-col gap-3 sm:flex-row">{actions}</div>}
+                        </motion.div>
+                    )}
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/components/marketing/section-head.tsx
+++ b/components/marketing/section-head.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const fadeUp = {
+    initial: { opacity: 0, y: 28 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, margin: "-60px" },
+    transition: { duration: 0.6, ease: EASE },
+};
+
+/**
+ * Running indexed section header — the marketing site's signature device.
+ * A hairline rule with an index + kicker, then an oversized serif title and
+ * an optional right-aligned lead. Works on light and dark (forest) surfaces.
+ */
+export function SectionHead({
+    index, kicker, title, lead, dark = false,
+}: {
+    index: string;
+    kicker: string;
+    title: React.ReactNode;
+    lead?: React.ReactNode;
+    dark?: boolean;
+}) {
+    const ruleTone = dark ? "border-white/15" : "border-hair";
+    const idxTone = dark ? "text-mint-500" : "text-forest";
+    const kickerTone = dark ? "text-paper/45" : "text-ink2/55";
+    const titleTone = dark ? "text-paper" : "text-ink";
+    const leadTone = dark ? "text-paper/60" : "text-ink2";
+    return (
+        <motion.div {...fadeUp} className="mb-10 md:mb-16">
+            <div className={`flex items-center gap-4 border-t ${ruleTone} pt-3.5`}>
+                <span className={`em-kicker ${idxTone}`}>{index}</span>
+                <span className={`em-kicker flex-1 ${kickerTone}`}>{kicker}</span>
+            </div>
+            <div className="mt-7 grid gap-x-8 gap-y-4 md:grid-cols-12 md:items-end">
+                <h2 className={`md:col-span-8 em-display text-[2rem] leading-[1.0] sm:text-5xl md:text-[3.5rem] ${titleTone}`}>
+                    {title}
+                </h2>
+                {lead && (
+                    <p className={`md:col-span-4 text-[15px] leading-relaxed md:self-end md:text-right ${leadTone}`}>
+                        {lead}
+                    </p>
+                )}
+            </div>
+        </motion.div>
+    );
+}


### PR DESCRIPTION
## What & why

The public site read as generic AI-SaaS — the *layout language itself* (floating pill nav, centered hero + screenshot, icon-card grid, carousel, accordion) was the tell, not just the palette. This redesigns the actual design system into something distinctive and editorial, so it looks like a boutique studio made it.

## The concept: an editorial "field-ledger"

A single, cohesive system that runs through every page and ties to the trade/working theme:

- **Running section index** — every section opens with a hairline rule + `§00 — Index`, `§01 — Platform`, etc., like a spec sheet
- **Numbered "Plates"** — product visuals framed as captioned figures (`Plate 01 — Tracey at work…`)
- **Oversized Fraunces display type** with tight editorial leading
- **Hairline rules + tracked micro-labels** throughout; subtle **paper grain** for tactile warmth

## Changes

- **Typography**: added Fraunces serif display font (`font-display`) alongside Plus Jakarta Sans
- **Navbar**: floating pill → flush masthead bar with hairline rule + underlined inline CTA
- **Hero**: asymmetric editorial masthead (oversized serif headline + spec column), reel reframed as a captioned plate
- **Stats**: print-style block with oversized serif numerals
- **Testimonials**: editorial pull-quotes on ruled blocks
- **Features**: 12 icon cards → numbered "index of features" ledger
- **Workflow & FAQ**: ruled, numbered editorial layouts
- **CTA**: full-bleed oversized serif statement
- **Warm palette** applied end to end (paper/cream/forest/mint/ink), replacing cool-gray/emerald/slate
- Extracted `SectionHead` + `MastheadHero` shared components so all pages speak one language
- App-screen mockups left faithful to the real product

## Verification

`tsc` and ESLint pass clean across all touched files. Note: not rendered visually in-sandbox (Google Fonts network-blocked, no browser), so a local `npm run dev` pass is worth it to dial in oversized type proportions if needed.

https://claude.ai/code/session_01K7pRqgH67XvnBC61snczSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7pRqgH67XvnBC61snczSL)_